### PR TITLE
ClassSet now can be created from an array of class descriptions

### DIFF
--- a/src/Analyzer/ClassDescriptionArrayParser.php
+++ b/src/Analyzer/ClassDescriptionArrayParser.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Arkitect\Analyzer;
+
+
+use Arkitect\Analyzer\Events\ClassAnalyzed;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+class ClassDescriptionArrayParser implements Parser
+{
+
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function parse($classDescription): void
+    {
+        $this->eventDispatcher->dispatch(new ClassAnalyzed($classDescription));
+    }
+
+
+}

--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -8,7 +8,7 @@ use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 use Psr\EventDispatcher\EventDispatcherInterface;
 
-class FileParser
+class FileParser implements Parser
 {
     private $parser;
 
@@ -26,8 +26,11 @@ class FileParser
         $this->traverser->addVisitor($this->fileVisitor);
     }
 
-    public function parse(string $filePath, string $fileContent): void
+    public function parse($file): void
     {
+        $filePath = $file->getRelativePath();
+        $fileContent = $file->getContents();
+
         try {
 
             $this->fileVisitor->setCurrentAnalisedFile($filePath);

--- a/src/Analyzer/FullyQualifiedClassName.php
+++ b/src/Analyzer/FullyQualifiedClassName.php
@@ -17,6 +17,13 @@ class FullyQualifiedClassName
      */
     private $class;
 
+    private function __construct(PatternString $fqcnString, PatternString $namespace, PatternString $class)
+    {
+        $this->fqcnString = $fqcnString;
+        $this->namespace = $namespace;
+        $this->class = $class;
+    }
+
     public function toString(): string
     {
         return $this->fqcnString->toString();
@@ -54,11 +61,6 @@ class FullyQualifiedClassName
         $className = array_pop($pieces);
         $namespace = implode('\\', $pieces);
 
-        $f = new self();
-        $f->fqcnString = new PatternString($fqcn);
-        $f->namespace = new PatternString($namespace);
-        $f->class = new PatternString($className);
-
-        return $f;
+        return new self(new PatternString($fqcn), new PatternString($namespace), new PatternString($className));
     }
 }

--- a/src/Analyzer/Parser.php
+++ b/src/Analyzer/Parser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Arkitect\Analyzer;
+
+interface Parser
+{
+    public function parse($file): void;
+}

--- a/tests/unit/ClassSetTest.php
+++ b/tests/unit/ClassSetTest.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace unit;
+
+
+use Arkitect\Analyzer\ClassDescription;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
+use Arkitect\Analyzer\Events\ClassAnalyzed;
+use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\ClassSet;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ClassSetTest extends TestCase
+{
+
+    public function test_can_be_built_from_files() {
+        $set = ClassSet::fromDir(__DIR__.'/../e2e/fixtures/happy_island');
+        $fakeSubscriber = new FakeSubscriber();
+        $set->addSubScriber($fakeSubscriber);
+        $set->run();
+        $this->assertEquals([
+            new ClassDescription('HappyIsland', FullyQualifiedClassName::fromString('App\HappyIsland\HappyClass'), [], []),
+            new ClassDescription('BadCode', FullyQualifiedClassName::fromString('App\BadCode\BadCode'), [], []),
+            new ClassDescription('OtherBadCode', FullyQualifiedClassName::fromString('App\BadCode\OtherBadCode'), [], []),
+        ], $fakeSubscriber->getAllClassAnalyzed());
+    }
+
+    public function test_can_be_built_from_array() {
+        $set = ClassSet::fromArray([
+            ClassDescription::build('Fruit\Banana', 'my/path')->get(),
+            ClassDescription::build('Fruit\Apple', 'my/path')->get(),
+        ]);
+        $fakeSubscriber = new FakeSubscriber();
+        $set->addSubScriber($fakeSubscriber);
+        $set->run();
+        $this->assertEquals([
+            ClassDescription::build('Fruit\Banana', 'my/path')->get(),
+            ClassDescription::build('Fruit\Apple', 'my/path')->get()
+        ], $fakeSubscriber->getAllClassAnalyzed());
+    }
+
+}
+
+class FakeSubscriber implements EventSubscriberInterface {
+
+    private $allClassAnalyzed;
+
+    public function __construct()
+    {
+        $this->allClassAnalyzed = [];
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ClassAnalyzed::class => 'onClassAnalyzed'
+        ];
+    }
+
+    public function onClassAnalyzed(ClassAnalyzed $classAnalyzed): void
+    {
+        $this->allClassAnalyzed []= $classAnalyzed->getClassDescription();
+    }
+
+    public function getAllClassAnalyzed()
+    {
+        return $this->allClassAnalyzed;
+    }
+}

--- a/tests/unit/FileVisitorTest.php
+++ b/tests/unit/FileVisitorTest.php
@@ -6,6 +6,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Analyzer\FileParser;
 use Arkitect\Testing\EventDispatcherSpy;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\SplFileInfo;
 
 class FileVisitorTest extends TestCase
 {
@@ -32,11 +33,34 @@ class Cat implements AnInterface
 }
 EOF;
 
-        $fp->parse('my/file/path', $code);
+        $fp->parse(new FakeFile('my/file/path', $code));
 
         [$firstEvent, $secondEvent] = $ed->getDispatchedEvents();
 
         $this->assertInstanceOf(ClassDescription::class, $firstEvent->getClassDescription());
         $this->assertInstanceOf(ClassDescription::class, $secondEvent->getClassDescription());
     }
+}
+
+class FakeFile {
+
+    private $path;
+    private $content;
+
+    public function __construct($path, $content)
+    {
+        $this->path = $path;
+        $this->content = $content;
+    }
+
+    public function getRelativePath()
+    {
+        return $this->path;
+    }
+
+    public function getContents()
+    {
+        return $this->content;
+    }
+
 }


### PR DESCRIPTION
Per creare i test delle regole reali per #4 il primo passo che ho fatto è poter generare un ClassSet senza dover avere tutti i file sul filesystem, in maniera da poter definire delle sorta di fixture al volo nel codice. 
Questo ci permette di avere le pre-condizioni del test vicino alla parte di assert e di iniziare a scollare un po' la parte di parsing dei file da quella dei check delle regole.