### PR TITLE
test moving responsibilities from classSet to rulechecker

### DIFF
--- a/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
+++ b/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
@@ -10,11 +10,13 @@ use PHPUnit\Framework\Constraint\Constraint;
 
 class ArchRuleCheckerConstraintAdapter extends Constraint
 {
-    private RuleChecker $ruleChecker;
+    private ClassSet $classSet;
 
-    public function __construct(ClassSet $classSet, Violations $violations)
+    private Violations $violations;
+
+    public function __construct(ClassSet $classSet)
     {
-        $this->ruleChecker = new RuleChecker($classSet, $violations);
+        $this->classSet = $classSet;
     }
 
     public function toString(): string
@@ -24,13 +26,15 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
 
     protected function matches(/** ArchRule */ $rule): bool
     {
-        $this->ruleChecker->check($rule);
+        $ruleChecker = RuleChecker::build($this->classSet, $rule);
 
-        return !$this->ruleChecker->hasViolations();
+        $this->violations = $ruleChecker->run();
+
+        return 0 === $this->violations->count();
     }
 
     protected function failureDescription($other): string
     {
-        return "\n".$this->ruleChecker->getViolations()->toString();
+        return "\n".$this->violations->toString();
     }
 }

--- a/src/PHPUnit/ArchRuleTestCase.php
+++ b/src/PHPUnit/ArchRuleTestCase.php
@@ -5,13 +5,12 @@ namespace Arkitect\PHPUnit;
 
 use Arkitect\ClassSet;
 use Arkitect\Rules\DSL\ArchRule;
-use Arkitect\Rules\Violations;
 
 class ArchRuleTestCase extends \PHPUnit\Framework\TestCase
 {
     public static function assertArchRule(ArchRule $rule, ClassSet $set): void
     {
-        $constraint = new ArchRuleCheckerConstraintAdapter($set, new Violations());
+        $constraint = new ArchRuleCheckerConstraintAdapter($set);
 
         static::assertThat($rule, $constraint);
     }

--- a/tests/Unit/ClassSetTest.php
+++ b/tests/Unit/ClassSetTest.php
@@ -4,53 +4,19 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit;
 
-use Arkitect\Analyzer\ClassDescriptionBuilder;
-use Arkitect\Analyzer\Events\ClassAnalyzed;
 use Arkitect\ClassSet;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ClassSetTest extends TestCase
 {
-    public function test_can_be_built_from_files(): void
+    public function test_can_iterate_over_directories_recursively(): void
     {
         $set = ClassSet::fromDir(__DIR__.'/../E2E/fixtures/happy_island');
-        $fakeSubscriber = new FakeSubscriber();
 
-        $set->addSubscriber($fakeSubscriber);
-        $set->run();
+        $files = iterator_to_array($set);
 
-        self::assertEquals([
-            ClassDescriptionBuilder::create('App\BadCode\BadCode')->setFilePath('BadCode')->get(),
-            ClassDescriptionBuilder::create('App\HappyIsland\HappyClass')->setFilePath('HappyIsland')->get(),
-            ClassDescriptionBuilder::create('App\BadCode\OtherBadCode')->setFilePath('OtherBadCode')->get(),
-        ], $fakeSubscriber->getAllClassAnalyzed());
-    }
-}
-
-class FakeSubscriber implements EventSubscriberInterface
-{
-    private $allClassAnalyzed;
-
-    public function __construct()
-    {
-        $this->allClassAnalyzed = [];
-    }
-
-    public static function getSubscribedEvents()
-    {
-        return [
-            ClassAnalyzed::class => 'onClassAnalyzed',
-        ];
-    }
-
-    public function onClassAnalyzed(ClassAnalyzed $classAnalyzed): void
-    {
-        $this->allClassAnalyzed[] = $classAnalyzed->getClassDescription();
-    }
-
-    public function getAllClassAnalyzed()
-    {
-        return $this->allClassAnalyzed;
+        self::assertEquals('BadCode', array_shift($files)->getFilenameWithoutExtension());
+        self::assertEquals('HappyClass', array_shift($files)->getFilenameWithoutExtension());
+        self::assertEquals('OtherBadCode', array_shift($files)->getFilenameWithoutExtension());
     }
 }

--- a/tests/Unit/Rules/RuleCheckerTest.php
+++ b/tests/Unit/Rules/RuleCheckerTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Rules;
+
+use Arkitect\Analyzer\ClassDescription;
+use Arkitect\Analyzer\FilePath;
+use Arkitect\Analyzer\Parser;
+use Arkitect\ClassSet;
+use Arkitect\Rules\DSL\ArchRule;
+use Arkitect\Rules\RuleChecker;
+use Arkitect\Rules\Violations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\SplFileInfo;
+
+class RuleCheckerTest extends TestCase
+{
+    public function test_should_run_parse_on_all_files_in_class_set(): void
+    {
+        $violations = new Violations();
+        $fileParser = new FakeParser();
+        $rule = new FakeRule();
+
+        $fileParser->onClassAnalyzed(static function (ClassDescription $classDescription) use ($rule, $violations): void {
+            $rule->check($classDescription, $violations);
+        });
+
+        $ruleChecker = new RuleChecker(new FakeClassSet(), $rule, $fileParser, new FilePath(), $violations);
+        $violations = $ruleChecker->run();
+
+        self::assertCount(3, $violations);
+    }
+}
+
+class FakeClassSet extends ClassSet
+{
+    public function __construct()
+    {
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator([
+            new FakeSplFileInfo('uno', '.', 'dir'),
+            new FakeSplFileInfo('due', '.', 'dir'),
+            new FakeSplFileInfo('tre', '.', 'dir'),
+        ]);
+    }
+}
+
+class FakeSplFileInfo extends SplFileInfo
+{
+    public function getContents(): string
+    {
+        return '';
+    }
+}
+
+class FakeRule implements ArchRule
+{
+    public function check(ClassDescription $classDescription, Violations $violations): void
+    {
+        $violations->add('nuuuuuu');
+    }
+}
+
+class FakeParser implements Parser
+{
+    private $callback;
+
+    public function parse(string $fileContent): void
+    {
+        \call_user_func($this->callback, ClassDescription::build('uno')->get());
+    }
+
+    public function onClassAnalyzed(callable $callable): void
+    {
+        $this->callback = $callable;
+    }
+}


### PR DESCRIPTION
Ho fatto una prova per spostare le responsabilità dal ClassSet a RuleChecker. Questo è il risultato
- ClassSet è una classe che itera sulla classi php di una directory. Potrebbe essere rinominata in FileSet, considerando che i file potrebbero contenere non solo classi, ma anche interfacce, trait, funzioni, ...
- Parser prende in pasto una stringa contenente codide php e lo parsa, richiamando una callback ogni volta che ha parsato una classe
- RuleChecker fa da colla: prende ClassSet, FileParser e una ArchRule e li collega, facendo in modo che per ogni file venga parsato e per ogni classe venga applicata la regola
Ha senso come organizzazione?

Una cosa che è sparita è l'event dispatcher. Mi sembra possa essere una buona idea nel caso emettessimo eventi differenti, ma per ora non è questo il caso
