### PR TITLE
Allows exclusion of directories and files from ClassSet

### DIFF
--- a/src/ClassSet.php
+++ b/src/ClassSet.php
@@ -17,9 +17,9 @@ class ClassSet implements \IteratorAggregate
         $this->exclude = [];
     }
 
-    public function exclude(string ...$pattern): self
+    public function excludePath(string $pattern): self
     {
-        $this->exclude = array_merge($this->exclude, $pattern);
+        $this->exclude[] = Glob::toRegex($pattern);
 
         return $this;
     }

--- a/src/Glob.php
+++ b/src/Glob.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect;
+
+class Glob
+{
+    public static function toRegex($glob): string
+    {
+        $regexp = strtr(preg_quote($glob, '/'), [
+            '\*' => '.*',
+            '\?' => '.',
+            '\[' => '[',
+            '\]' => ']',
+            '\[\!' => '[ˆ',
+        ]);
+
+        return '/'.$regexp.'/';
+    }
+}

--- a/tests/Unit/ClassSetTest.php
+++ b/tests/Unit/ClassSetTest.php
@@ -23,12 +23,41 @@ class ClassSetTest extends TestCase
     public function test_can_exclude_files_or_directories(): void
     {
         $set = ClassSet::fromDir(__DIR__.'/../E2E/fixtures/mvc')
-            ->exclude('Model', 'ContainerAwareInterface')
-            ->exclude('/.*Catalog.*/');
+            ->excludePath('Model')
+            ->excludePath('ContainerAwareInterface');
 
         $expected = [
+            'Controller/CatalogController.php',
+            'Controller/Foo.php',
             'Controller/ProductsController.php',
             'Controller/UserController.php',
+            'Services/UserService.php',
+            'View/CatalogView.php',
+            'View/ProductView.php',
+            'View/UserView.php',
+        ];
+
+        $actual = array_values(array_map(function ($item) {
+            return $item->getRelativePathname();
+        }, iterator_to_array($set)));
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public function test_can_exclude_glob_patterns(): void
+    {
+        $set = ClassSet::fromDir(__DIR__.'/../E2E/fixtures/mvc')
+            ->excludePath('*Catalog*');
+
+        $expected = [
+            'ContainerAwareInterface.php',
+            'Controller/Foo.php',
+            'Controller/ProductsController.php',
+            'Controller/UserController.php',
+            'Model/Products.php',
+            'Model/Repository/ProductsRepository.php',
+            'Model/Repository/UserRepository.php',
+            'Model/User.php',
             'Services/UserService.php',
             'View/ProductView.php',
             'View/UserView.php',

--- a/tests/Unit/GlobTest.php
+++ b/tests/Unit/GlobTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit;
+
+use Arkitect\Glob;
+use PHPUnit\Framework\TestCase;
+
+class GlobTest extends TestCase
+{
+    public function test_can_exclude_using_glob_pattern(): void
+    {
+        // * - Matches zero or more characters.
+        $this->assertEquals('/.*Catalog.*/', Glob::toRegex('*Catalog*'));
+
+        // * - Matches zero or more characters.
+        $this->assertEquals('/Cata\.log/', Glob::toRegex('Cata.log'));
+
+        // ? - Matches exactly one character (any character).
+        $this->assertEquals('/C.talog/', Glob::toRegex('C?talog'));
+
+        // [...] - Matches one character from a group of characters. If the first character is !, matches any character not in the group.
+        $this->assertEquals('/prova[123]/', Glob::toRegex('prova[123]'));
+
+        // [...] - Matches one character from a group of characters. If the first character is !, matches any character not in the group.
+        $this->assertEquals('/prova[ˆ123]/', Glob::toRegex('prova[!123]'));
+    }
+}


### PR DESCRIPTION
Ho fatto un esperimento provando un approccio alternativo alla #28 
Ho aggiunto un metodo exclude al ClassSet, variadico e fluente, per poter aggiungere nomi di file o directory che vengono esclusi quando si itera la directory specificata

exclude accetta espressioni regolari, veniva comodo col fatto che internamente usiamo Finder di symfony. 
Questo toglie coerenza rispetto alla sintassi glob che ci eravamo detti di mantenere. 
Se vogliamo mantenere la stessa logica glob like anche in questo punto, potremmo alternativamente: 
- tradurre la sintassi glob in regexp in fase di costruzione del finder
- iterare comunque tutta la directory, e scartando a posteriori i path che non fanno match

