### PR TITLE
configFile option optional, not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To use this tool you need to launch a command via bash or with Docker like this:
 phparkitect check
 ```
 
-With this command `phparkitect` will search all rules in the root of you project the default config file called `phparkitect.php`.
+With this command `phparkitect` will search all rules in the root of your project the default config file called `phparkitect.php`.
 You can also specify your configuration file using `--check` option like this:
 
 phparkitect check --config=/project/yourConfigFile.php

--- a/README.md
+++ b/README.md
@@ -48,5 +48,51 @@ docker run --rm -it -v $(PWD):/project phparkitect/phparkitect:latest check --co
 If you have a project with an incompatible version of PHP with Arkitect, using Docker can help you use Arkitect despite the PHP version.
 
 # How to use it
+
+To use this tool you need to launch a command via bash or with Docker like this:
+
+```
+phparkitect check
+```
+
+With this command `phparkitect` will search all rules in the root of you project the default config file called `phparkitect.php`.
+You can also specify your configuration file using `--check` option like this:
+
+phparkitect check --config=/project/yourConfigFile.php
+
+Example of configuration file `phparkitect.php`
+
+```
+<?php
+declare(strict_types=1);
+
+use Arkitect\ClassSet;
+use Arkitect\ClassSetRules;
+use Arkitect\CLI\Config;
+use Arkitect\Expression\ForClasses\HaveNameMatching;
+use Arkitect\Expression\ForClasses\Implement;
+use Arkitect\Expression\ForClasses\NotHaveDependencyOutsideNamespace;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+
+return static function (Config $config): void {
+    $mvc_class_set = ClassSet::fromDir(__DIR__.'/mvc');
+
+    $rule_1 = Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+        ->should(new HaveNameMatching('*Controller'))
+        ->because('we want uniform naming');
+
+    $rule_2 = Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('App\Domain'))
+        ->should(new NotHaveDependencyOutsideNamespace('App\Domain'))
+        ->because('we want protect our domain');
+
+    $config
+        ->add(ClassSetRules::create($mvc_class_set, ...[$rule_1, $rule_2]));
+};
+```
+
+
 ## With PHPUnit
 ## Standalone

--- a/src/CLI/Check.php
+++ b/src/CLI/Check.php
@@ -14,6 +14,8 @@ class Check extends Command
 {
     private const CONFIG_FILENAME_PARAM = 'config';
 
+    private const DEFAULT_FILENAME = 'phparkitect.php';
+
     private const SUCCESS_CODE = 0;
 
     private const ERROR_CODE = 1;
@@ -31,7 +33,7 @@ class Check extends Command
             ->addOption(
                 self::CONFIG_FILENAME_PARAM,
                 'c',
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_OPTIONAL,
                 'File containing configs, such as rules to be matched'
             );
     }
@@ -96,7 +98,10 @@ class Check extends Command
     {
         $filename = $input->getOption(self::CONFIG_FILENAME_PARAM);
 
-        Assert::notNull($filename, 'You must specify the file containing rules');
+        if (null === $filename) {
+            $filename = self::DEFAULT_FILENAME;
+        }
+
         Assert::file($filename, 'Config file not found');
 
         return $filename;

--- a/tests/E2E/CliTest.php
+++ b/tests/E2E/CliTest.php
@@ -15,9 +15,36 @@ class CliTest extends TestCase
 
     private string $phparkitect = __DIR__.'/../../bin-stub/phparkitect';
 
-    public function test_returns_error_wit_mulitple_violations(): void
+    public function test_returns_error_with_mulitple_violations(): void
     {
-        $process = $this->runArkitect(__DIR__.'/fixtures/configMvc.php');
+        $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/fixtures/configMvc.php');
+
+        $expectedErrors = 'ERRORS!
+
+App\Controller\Foo violates rules
+  should implement ContainerAwareInterface
+  should have a name that matches *Controller
+
+App\Controller\ProductsController violates rules
+  should implement ContainerAwareInterface
+
+App\Controller\UserController violates rules
+  should implement ContainerAwareInterface
+
+App\Controller\YieldController violates rules
+  should implement ContainerAwareInterface
+
+App\Domain\Model violates rules
+  should not depend on classes outside in namespace App\Domain (on line 14)
+  should not depend on classes outside in namespace App\Domain (on line 15)';
+
+        $this->assertEquals(self::ERROR_CODE, $process->getExitCode());
+        $this->assertStringContainsString($expectedErrors, $process->getOutput());
+    }
+
+    public function test_returns_error_with_mulitple_violations_without_passing_config_file(): void
+    {
+        $process = $this->runArkitect();
 
         $expectedErrors = 'ERRORS!
 
@@ -44,14 +71,14 @@ App\Domain\Model violates rules
 
     public function test_does_not_explode_if_an_exception_is_thrown(): void
     {
-        $process = $this->runArkitect(__DIR__.'/fixtures/configThrowsException.php');
+        $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/fixtures/configThrowsException.php');
 
         $this->assertEquals(self::ERROR_CODE, $process->getExitCode());
     }
 
     public function test_run_command_with_success(): void
     {
-        $process = $this->runArkitect(__DIR__.'/fixtures/configMvcWithoutErrors.php');
+        $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/fixtures/configMvcWithoutErrors.php');
 
         $this->assertEquals(self::SUCCESS_CODE, $process->getExitCode());
         $this->assertStringNotContainsString('ERRORS!', $process->getOutput());
@@ -59,7 +86,7 @@ App\Domain\Model violates rules
 
     public function test_bug_yield(): void
     {
-        $process = $this->runArkitect(__DIR__.'/fixtures/configMvcForYieldBug.php');
+        $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/fixtures/configMvcForYieldBug.php');
 
         $expectedErrors = 'ERRORS!
 
@@ -70,9 +97,17 @@ App\Controller\Foo violates rules
         $this->assertStringContainsString($expectedErrors, $process->getOutput());
     }
 
-    protected function runArkitect($configFilePath): Process
+    protected function runArkitectPassingConfigFilePath($configFilePath): Process
     {
         $process = new Process([$this->phparkitect, 'check', '--config='.$configFilePath], __DIR__);
+        $process->run();
+
+        return $process;
+    }
+
+    protected function runArkitect(): Process
+    {
+        $process = new Process([$this->phparkitect, 'check'], __DIR__);
         $process->run();
 
         return $process;

--- a/tests/E2E/CliTest.php
+++ b/tests/E2E/CliTest.php
@@ -15,7 +15,7 @@ class CliTest extends TestCase
 
     private string $phparkitect = __DIR__.'/../../bin-stub/phparkitect';
 
-    public function test_returns_error_with_mulitple_violations(): void
+    public function test_returns_error_with_multiple_violations(): void
     {
         $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/fixtures/configMvc.php');
 

--- a/tests/E2E/phparkitect.php
+++ b/tests/E2E/phparkitect.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+use Arkitect\ClassSet;
+use Arkitect\ClassSetRules;
+use Arkitect\CLI\Config;
+use Arkitect\Expression\ForClasses\HaveNameMatching;
+use Arkitect\Expression\ForClasses\Implement;
+use Arkitect\Expression\ForClasses\NotHaveDependencyOutsideNamespace;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+
+return static function (Config $config): void {
+    $mvc_class_set = ClassSet::fromDir(__DIR__.'/fixtures/mvc');
+
+    $rule_1 = Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+        ->should(new Implement('ContainerAwareInterface'))
+        ->because('all controllers should be container aware');
+
+    $rule_2 = Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+        ->should(new HaveNameMatching('*Controller'))
+        ->because('we want uniform naming');
+
+    $rule_3 = Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('App\Domain'))
+        ->should(new NotHaveDependencyOutsideNamespace('App\Domain'))
+        ->because('we want protect our domain');
+
+    $config
+        ->add(ClassSetRules::create($mvc_class_set, ...[$rule_1, $rule_2, $rule_3]));
+};


### PR DESCRIPTION
In this PR I have changed the option `configFile` from `required` to `optional` because the command now is shorter.
If the `configFile` parameter is not sent, `phparkitect` searches automatically in the root of the project the default file configuration called `phparkitect.php`

What do you think?