### PR TITLE
Integrate the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Rule::allClasses()
 You can check all the costraints using our cli tool, or, if you prefer, you can add the rules to your Phpunit tests, like this:
 
 ```php
- public function test_controller_naming_convention(): void
-    {
-        $set = ClassSet::fromDir(__DIR__.'/fixtures/happy_island');
+public function test_controller_naming_convention(): void
+{
+    $set = ClassSet::fromDir(__DIR__.'/fixtures/happy_island');
 
-        Rule::allClasses()
-            ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
-            ->should(new HaveNameMatching('*Controller'))
-            ->because("it's a symfony naming convention");
+    Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+        ->should(new HaveNameMatching('*Controller'))
+        ->because("it's a symfony naming convention");
 
-        ArchRuleTestCase::assertArchRule($rule, $set);
-    }
+    ArchRuleTestCase::assertArchRule($rule, $set);
+}
 ```
 
 ## What kind of rules can I enforce with Arkitect
@@ -37,6 +37,13 @@ Currently you can check if a class:
 # How to install
 
 ## Using composer
+The recommended way to install Arkitect is to use Composer in a dedicated composer.json file in your project, for example in the tools/arkitect directory:
+
+```bash
+$ mkdir --parents tools/arkitect
+$ composer require --working-dir=tools/arkitect phparkitect/phparkitect
+```
+
 ## Using a phar
 ## Using docker
 
@@ -62,7 +69,7 @@ phparkitect check --config=/project/yourConfigFile.php
 
 Example of configuration file `phparkitect.php`
 
-```
+```php
 <?php
 declare(strict_types=1);
 


### PR DESCRIPTION
Vorrei aprire una discussione sul modo di installare consigliato. Ho visto che quella di installare in una cartella a parte il tool non è solo un mia idea perversa ma è una cosa suggerita da lla doc del tool [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer#installation).

A mio avviso installare il tool come dipenzenza, anche "dev" del progetto non è una buona pratica. In generale tendo a non installare tool di qa (psalm, cs-fixer & co.) con composer per non "sporcare" le dipendenze del progetto.

Suggerirei quindi di installarlo in una cartella dedicata e di mettere li dentro il file con le archrules.

NB: risolve anche il problema del''autocomplete!