### PR TITLE
fixed bug about dependencies

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -25,8 +25,7 @@ class FileVisitor extends NodeVisitorAbstract
 
             foreach ($node->implements as $interface) {
                 $this->classDescriptionBuilder
-                     ->addInterface($interface->toString(), $interface->getLine())
-                     ->addDependency(new ClassDependency($interface->toCodeString(), $interface->getLine()));
+                     ->addInterface($interface->toString(), $interface->getLine());
             }
         }
 


### PR DESCRIPTION
The bug was inside `FileVisitor` because we added dependencies after adding interfaces in a wrong way  like this:

`\Foo\Bar\Baz`

The correct way is already inside `addInterfaces`:

`Foo\Bar\Baz`

Issue related: #135 