### PR TITLE
get dependencies when passed as params

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -42,6 +42,16 @@ class FileVisitor extends NodeVisitorAbstract
             $this->classDescriptionBuilder
                 ->addDependency(new ClassDependency($node->class->toString(), $node->getLine()));
         }
+
+        /**
+         * matches parameters dependency in functions and method definitions like
+         * public function __construct(Symfony\Component\HttpFoundation\Request $request).
+         *
+         * @see FileVisitorTest::test_should_returns_all_dependencies
+         */
+        if ($node instanceof Node\Param) {
+            $this->addParamDependency($node);
+        }
     }
 
     public function getClassDescriptions(): array
@@ -61,5 +71,19 @@ class FileVisitor extends NodeVisitorAbstract
 
             $this->classDescriptions[] = $classDescription;
         }
+    }
+
+    private function addParamDependency(Node\Param $node): void
+    {
+        if (null === $node->type || $node->type instanceof Node\NullableType || $node->type instanceof Node\Identifier) {
+            return;
+        }
+
+        if (!method_exists($node->type, 'toString')) {
+            return;
+        }
+
+        $this->classDescriptionBuilder
+            ->addDependency(new ClassDependency($node->type->toString(), $node->getLine()));
     }
 }

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -126,4 +126,37 @@ EOF;
 
         $this->assertCount(0, $violations);
     }
+
+    public function test_should_returns_all_dependencies(): void
+    {
+        $code = <<< 'EOF'
+<?php
+namespace Foo\Bar;
+
+use Doctrine\MongoDB\Collection;
+use Foo\Baz\Baz;
+use Symfony\Component\HttpFoundation\Request;
+
+class MyClass implements Baz
+{
+    public function __construct(Request $request)
+    {
+        $collection = new Collection($request);
+    }
+}
+EOF;
+
+        /** @var FileParser $fp */
+        $fp = FileParserFactory::createFileParser();
+        $fp->parse($code);
+        $cd = $fp->getClassDescriptions();
+
+        $expectedDependencies = [
+            new ClassDependency('Foo\Baz\Baz', 8),
+            new ClassDependency('Symfony\Component\HttpFoundation\Request', 10),
+            new ClassDependency('Doctrine\MongoDB\Collection', 12),
+        ];
+
+        $this->assertEquals($expectedDependencies, $cd[0]->getDependencies());
+    }
 }


### PR DESCRIPTION
In this PR I added the possibility to get dependencies when they are passed as parameters inside functions.

I think that class FileVisitorTest will be too big in the future, but at the moment I don't have other solutions and for the moment could be good enough.

I have escaped scalar values like `int` or `string`