### PR TITLE
fix parsing arrow function using php_version dynamically into parser

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -36,6 +36,7 @@ return (new PhpCsFixer\Config())
     'general_phpdoc_annotation_remove' => ['annotations' => ['author', 'package']],
     'list_syntax' => ['syntax' => 'short'],
     'phpdoc_to_comment' => false,
-    'php_unit_method_casing' => ['case' => 'snake_case']
+    'php_unit_method_casing' => ['case' => 'snake_case'],
+      'function_to_constant' => false
   ])
 ;

--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -10,7 +10,6 @@ use PhpParser\ParserFactory;
 
 class FileParser implements Parser
 {
-    private const PHP_VERSION = '7.1';
     /** @var \PhpParser\Parser */
     private $parser;
 
@@ -26,7 +25,7 @@ class FileParser implements Parser
 
         $lexer = new Emulative([
             'usedAttributes' => ['comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos'],
-             'phpVersion' => self::PHP_VERSION,
+             'phpVersion' => phpversion('tidy'),
         ]);
 
         $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);

--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -25,7 +25,7 @@ class FileParser implements Parser
 
         $lexer = new Emulative([
             'usedAttributes' => ['comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos'],
-             'phpVersion' => phpversion(),
+             'phpVersion' => phpversion('tidy'),
         ]);
 
         $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);

--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -25,7 +25,7 @@ class FileParser implements Parser
 
         $lexer = new Emulative([
             'usedAttributes' => ['comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos'],
-             'phpVersion' => phpversion('tidy'),
+             'phpVersion' => phpversion(),
         ]);
 
         $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -188,4 +188,38 @@ EOF;
 
         $this->assertEquals($expectedDependencies, $cd[0]->getDependencies());
     }
+
+    /**
+     * @requires PHP >= 7.4
+     */
+    public function test_it_should_parse_arrow_function(): void
+    {
+        $code = <<< 'EOF'
+<?php
+
+namespace Root\Animals;
+
+class Animal
+{
+    public function __construct()
+    {
+        $y = 1;
+        $fn1 = fn($x) => $x + $y;
+    }
+}
+EOF;
+
+        /** @var FileParser $fp */
+        $fp = FileParserFactory::createFileParser();
+        $fp->parse($code);
+
+        $cd = $fp->getClassDescriptions();
+
+        $violations = new Violations();
+
+        $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Foo', 'Symfony', 'Doctrine');
+        $dependsOnTheseNamespaces->evaluate($cd[0], $violations);
+
+        $this->assertCount(0, $violations);
+    }
 }


### PR DESCRIPTION
In this PR I removed the PHP version fixed for the emulator, and now we are using the PHP version dynamically.
Removing PHP version specification break all the tests.

Related issue: #160  