### PR TITLE
Fixes makefile comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: ## it launches tests
 test_%: ## it launches a test
 	bin/phpunit --filter $@
 
-%Test: ## lancia un test
+%Test: ## it launches a test
 	bin/phpunit --filter $@
 
 phar: ## it creates phar
@@ -32,7 +32,7 @@ outdated:
 coverage: ## it launches coverage
 	phpdbg -qrr ./bin/phpunit --coverage-html build/coverage
 
-csfix: ## cs fix
+csfix: ## it launches cs fix
 	bin/php-cs-fixer fix -v
 
 psalm: ## it launches psalm


### PR DESCRIPTION
In Makefile you got an italian comment and a minor discrepancy in cs fix description (all others were 'it launches').
Moreover I don't know if `test_%` and `%Test` targets are legit to cohexists, or it them are an old residue (in order to avoid getting rid of one of those without ignoring the reason, I prefer to point this out right here).