### PR TITLE
handling errors when there is a problem on parsing files

### DIFF
--- a/src/Analyzer/Parser.php
+++ b/src/Analyzer/Parser.php
@@ -5,7 +5,9 @@ namespace Arkitect\Analyzer;
 
 interface Parser
 {
-    public function parse(string $fileContent): void;
+    public function parse(string $fileContent, string $filename): void;
 
     public function getClassDescriptions(): array;
+
+    public function getParsingErrors(): array;
 }

--- a/src/CLI/Check.php
+++ b/src/CLI/Check.php
@@ -5,6 +5,7 @@ namespace Arkitect\CLI;
 
 use Arkitect\CLI\Progress\DebugProgress;
 use Arkitect\CLI\Progress\ProgressBarProgress;
+use Arkitect\Rules\ParsingErrors;
 use Arkitect\Rules\Violations;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -71,10 +72,17 @@ class Check extends Command
             $this->readRules($config, $rulesFilename);
 
             $runner = new Runner();
-            $violations = $runner->run($config, $progress, $targetPhpVersion);
-
+            $runner->run($config, $progress, $targetPhpVersion);
+            $violations = $runner->getViolations();
             if ($violations->count() > 0) {
                 $this->printViolations($violations, $output);
+
+                return self::ERROR_CODE;
+            }
+
+            $parsedErrors = $runner->getParsingErrors();
+            if ($parsedErrors->count() > 0) {
+                $this->printParsedErrors($parsedErrors, $output);
 
                 return self::ERROR_CODE;
             }
@@ -135,5 +143,11 @@ class Check extends Command
     {
         $output->writeln('<error>ERRORS!</error>');
         $output->writeln(sprintf('%s', $violations->toString()));
+    }
+
+    private function printParsedErrors(ParsingErrors $parsingErrors, OutputInterface $output): void
+    {
+        $output->writeln('<error>ERROR ON PARSING THESE FILES:</error>');
+        $output->writeln(sprintf('%s', $parsingErrors->toString()));
     }
 }

--- a/src/CLI/Runner.php
+++ b/src/CLI/Runner.php
@@ -9,36 +9,52 @@ use Arkitect\Analyzer\FileParserFactory;
 use Arkitect\Analyzer\Parser;
 use Arkitect\ClassSetRules;
 use Arkitect\CLI\Progress\Progress;
+use Arkitect\Rules\ParsingErrors;
 use Arkitect\Rules\Violations;
 use Symfony\Component\Finder\SplFileInfo;
 
 class Runner
 {
-    public function run(Config $config, Progress $progress, TargetPhpVersion $targetPhpVersion): Violations
+    /** @var Violations */
+    private $violations;
+
+    /** @var ParsingErrors */
+    private $parsingErrors;
+
+    public function run(Config $config, Progress $progress, TargetPhpVersion $targetPhpVersion): void
     {
         /** @var FileParser $fileParser */
         $fileParser = FileParserFactory::createFileParser($targetPhpVersion);
-        $violations = new Violations();
+        $this->violations = new Violations();
+        $this->parsingErrors = new ParsingErrors();
 
         /** @var ClassSetRules $classSetRule */
         foreach ($config->getClassSetRules() as $classSetRule) {
             $progress->startFileSetAnalysis($classSetRule->getClassSet());
 
-            $this->check($classSetRule, $progress, $fileParser, $violations);
+            $this->check($classSetRule, $progress, $fileParser, $this->violations, $this->parsingErrors);
 
             $progress->endFileSetAnalysis($classSetRule->getClassSet());
         }
-
-        return $violations;
     }
 
-    public function check(ClassSetRules $classSetRule, Progress $progress, Parser $fileParser, Violations $violations): void
-    {
+    public function check(
+        ClassSetRules $classSetRule,
+        Progress $progress,
+        Parser $fileParser,
+        Violations $violations,
+        ParsingErrors $parsingErrors
+    ): void {
         /** @var SplFileInfo $file */
         foreach ($classSetRule->getClassSet() as $file) {
             $progress->startParsingFile($file->getRelativePathname());
 
-            $fileParser->parse($file->getContents());
+            $fileParser->parse($file->getContents(), $file->getRelativePathname());
+            $parsedErrors = $fileParser->getParsingErrors();
+
+            foreach ($parsedErrors as $parsedError) {
+                $parsingErrors->add($parsedError);
+            }
 
             foreach ($fileParser->getClassDescriptions() as $classDescription) {
                 foreach ($classSetRule->getRules() as $rule) {
@@ -48,5 +64,15 @@ class Runner
 
             $progress->endParsingFile($file->getRelativePathname());
         }
+    }
+
+    public function getViolations(): Violations
+    {
+        return $this->violations;
+    }
+
+    public function getParsingErrors(): ParsingErrors
+    {
+        return $this->parsingErrors;
     }
 }

--- a/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
+++ b/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
@@ -11,6 +11,7 @@ use Arkitect\CLI\Progress\VoidProgress;
 use Arkitect\CLI\Runner;
 use Arkitect\CLI\TargetPhpVersion;
 use Arkitect\Rules\ArchRule;
+use Arkitect\Rules\ParsingErrors;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\Constraint\Constraint;
 
@@ -28,6 +29,9 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
     /** @var FileParser */
     private $fileparser;
 
+    /** @var ParsingErrors */
+    private $parsingErrors;
+
     public function __construct(ClassSet $classSet)
     {
         $targetPhpVersion = TargetPhpVersion::create(null);
@@ -35,6 +39,7 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
         $this->fileparser = FileParserFactory::createFileParser($targetPhpVersion);
         $this->classSet = $classSet;
         $this->violations = new Violations();
+        $this->parsingErrors = new ParsingErrors();
     }
 
     public function toString(): string
@@ -48,7 +53,8 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
             ClassSetRules::create($this->classSet, $other),
             new VoidProgress(),
             $this->fileparser,
-            $this->violations
+            $this->violations,
+            $this->parsingErrors
         );
 
         return 0 === $this->violations->count();

--- a/src/Rules/ParsingError.php
+++ b/src/Rules/ParsingError.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Rules;
+
+class ParsingError
+{
+    /** @var string */
+    private $relativeFilePath;
+
+    /** @var string */
+    private $error;
+
+    public function __construct(string $relativeFilePath, string $error)
+    {
+        $this->error = $error;
+        $this->relativeFilePath = $relativeFilePath;
+    }
+
+    public static function create(string $relativeFilePath, string $error): self
+    {
+        return new self($relativeFilePath, $error);
+    }
+
+    public function getError(): string
+    {
+        return $this->error;
+    }
+
+    public function getRelativeFilePath(): string
+    {
+        return $this->relativeFilePath;
+    }
+}

--- a/src/Rules/ParsingErrors.php
+++ b/src/Rules/ParsingErrors.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Rules;
+
+use Arkitect\Exceptions\IndexNotFoundException;
+
+class ParsingErrors implements \IteratorAggregate, \Countable
+{
+    /**
+     * @var ParsingError[]
+     */
+    private $parsingErrors;
+
+    public function __construct(array $parsingErrors = [])
+    {
+        $this->parsingErrors = $parsingErrors;
+    }
+
+    public function add(ParsingError $parsingError): void
+    {
+        $this->parsingErrors[] = $parsingError;
+    }
+
+    public function get(int $index): ParsingError
+    {
+        if (!\array_key_exists($index, $this->parsingErrors)) {
+            throw new IndexNotFoundException($index);
+        }
+
+        return $this->parsingErrors[$index];
+    }
+
+    public function getIterator()
+    {
+        foreach ($this->parsingErrors as $parsingError) {
+            yield $parsingError;
+        }
+    }
+
+    public function count(): int
+    {
+        return \count($this->parsingErrors);
+    }
+
+    public function toString(): string
+    {
+        $errors = '';
+
+        /** @var ParsingError $parsingError */
+        foreach ($this->parsingErrors as $parsingError) {
+            $errors .= "\n".$parsingError->getError().' in file: '.$parsingError->getRelativeFilePath();
+            $errors .= "\n";
+        }
+
+        return $errors;
+    }
+
+    public function toArray(): array
+    {
+        return $this->parsingErrors;
+    }
+}

--- a/tests/Unit/Analyzer/FileParserTest.php
+++ b/tests/Unit/Analyzer/FileParserTest.php
@@ -37,7 +37,7 @@ class FileParserTest extends TestCase
         ';
 
         $traverser->traverse(Argument::type('array'))->shouldBeCalled();
-        $fileParser->parse($content);
+        $fileParser->parse($content, 'foo');
     }
 
     /**
@@ -66,6 +66,6 @@ class FileParserTest extends TestCase
         ';
 
         $traverser->traverse(Argument::type('array'))->shouldBeCalled();
-        $fileParser->parse($content);
+        $fileParser->parse($content, 'foo');
     }
 }

--- a/tests/Unit/Rules/ParsingErrorsTest.php
+++ b/tests/Unit/Rules/ParsingErrorsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Rules;
+
+use Arkitect\Exceptions\IndexNotFoundException;
+use Arkitect\Rules\ParsingError;
+use Arkitect\Rules\ParsingErrors;
+use PHPUnit\Framework\TestCase;
+
+class ParsingErrorsTest extends TestCase
+{
+    /** @var ParsingErrors */
+    private $parsingStore;
+
+    /** @var ParsingError */
+    private $parsingError;
+
+    protected function setUp(): void
+    {
+        $this->parsingStore = new ParsingErrors();
+        $this->parsingError = ParsingError::create(
+            'App\Controller\ProductController',
+            'Syntax error, unexpected T_STRING on line 8',
+            1
+        );
+        $this->parsingStore->add($this->parsingError);
+    }
+
+    public function test_add_elements_to_store_and_get_it(): void
+    {
+        $this->assertEquals($this->parsingError, $this->parsingStore->get(0));
+    }
+
+    public function test_add_elements_to_store_and_cant_get_it_if_index_not_valid(): void
+    {
+        $this->expectException(IndexNotFoundException::class);
+        $this->expectExceptionMessage('Index not found 1111');
+        $this->assertEquals('', $this->parsingStore->get(1111));
+    }
+
+    public function test_count(): void
+    {
+        $parsingError = ParsingError::create(
+            'App\Controller\Shop',
+            'Syntax error, unexpected T_STRING on line 8',
+            2
+        );
+        $this->parsingStore->add($parsingError);
+        $this->assertEquals(2, $this->parsingStore->count());
+    }
+
+    public function test_to_string(): void
+    {
+        $parsingError = ParsingError::create(
+            'App\Controller\Foo',
+            'Syntax error, unexpected T_STRING on line 8'
+        );
+
+        $this->parsingStore->add($parsingError);
+        $expected = '
+Syntax error, unexpected T_STRING on line 8 in file: App\Controller\ProductController
+
+Syntax error, unexpected T_STRING on line 8 in file: App\Controller\Foo
+';
+
+        $this->assertEquals($expected, $this->parsingStore->toString());
+    }
+}

--- a/tests/Unit/Rules/RuleCheckerTest.php
+++ b/tests/Unit/Rules/RuleCheckerTest.php
@@ -10,6 +10,7 @@ use Arkitect\ClassSetRules;
 use Arkitect\CLI\Progress\VoidProgress;
 use Arkitect\CLI\Runner;
 use Arkitect\Rules\DSL\ArchRule;
+use Arkitect\Rules\ParsingErrors;
 use Arkitect\Rules\Violation;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -22,6 +23,7 @@ class RuleCheckerTest extends TestCase
         $violations = new Violations();
         $fileParser = new FakeParser();
         $rule = new FakeRule();
+        $parsingErrors = new ParsingErrors();
 
         $runner = new Runner();
 
@@ -29,7 +31,8 @@ class RuleCheckerTest extends TestCase
             ClassSetRules::create(new FakeClassSet(), ...[$rule]),
             new VoidProgress(),
             $fileParser,
-            $violations
+            $violations,
+            $parsingErrors
         );
 
         self::assertCount(3, $violations);
@@ -70,12 +73,17 @@ class FakeRule implements ArchRule
 
 class FakeParser implements Parser
 {
-    public function parse(string $fileContent): void
+    public function parse(string $fileContent, string $filename): void
     {
     }
 
     public function getClassDescriptions(): array
     {
         return [ClassDescription::build('uno')->get()];
+    }
+
+    public function getParsingErrors(): array
+    {
+        return [];
     }
 }


### PR DESCRIPTION
In this PR I am trying to add information about parse errors.
Related issue: #167 

At the moment if there is a parse error we return a NOT SUCCESS code but we finish parsing all files.

The output at the moment is like this using the relative path file: 

```
 0/19 [>---------------------------]   0%
 19/19 [============================] 100%

PARSED ERRORS!

Syntax error, unexpected T_STRING on line 8 in file: Model/ClassWithError.php
```
