### PR TITLE
test: add fail test with self as parameter type

### DIFF
--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -299,6 +299,10 @@ class Tiger extends Animal
     public static function bar()
     {
     }
+    public function equals(self $other): bool
+    {
+        return $this == $other;
+    }
 }
 EOF;
 


### PR DESCRIPTION
PHPArkitect detects the "external dependency" (false positive) with the `self` keyword used as parameter type.

I added a test that fails.