### PR TITLE
Add return typehint to getIterator methods for php 8.1

### DIFF
--- a/src/ClassSet.php
+++ b/src/ClassSet.php
@@ -36,7 +36,7 @@ class ClassSet implements \IteratorAggregate
         return $this->directory;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         $finder = (new Finder())
             ->files()

--- a/src/Rules/ParsingErrors.php
+++ b/src/Rules/ParsingErrors.php
@@ -31,7 +31,7 @@ class ParsingErrors implements \IteratorAggregate, \Countable
         return $this->parsingErrors[$index];
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         foreach ($this->parsingErrors as $parsingError) {
             yield $parsingError;

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -31,7 +31,7 @@ class Violations implements \IteratorAggregate, \Countable
         return $this->violations[$index];
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         foreach ($this->violations as $violation) {
             yield $violation;

--- a/tests/Unit/Rules/RuleCheckerTest.php
+++ b/tests/Unit/Rules/RuleCheckerTest.php
@@ -45,7 +45,7 @@ class FakeClassSet extends ClassSet
     {
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator([
             new FakeSplFileInfo('uno', '.', 'dir'),


### PR DESCRIPTION
Hello, 
Thanks for this useful project :+1: 

Just a little contribution to avoid deprecation notices on php 8.1:

```
PHPArkitect 0.2.6

Config file: tests/phparkitect.php


Deprecated: Return type of Arkitect\ClassSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /srv/vendor/phparkitect/phparkitect/src/ClassSet.php on line 39

Deprecated: Return type of Arkitect\Rules\Violations::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /srv/vendor/phparkitect/phparkitect/src/Rules/Violations.php on line 34

Deprecated: Return type of Arkitect\Rules\ParsingErrors::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /srv/vendor/phparkitect/phparkitect/src/Rules/ParsingErrors.php on line 34
analyze class set /srv/tests/../src

 155/155 [============================] 100%

NO VIOLATIONS DETECTED!

``` 