### PR TITLE
fix: no param dependency for special type

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -113,6 +113,10 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
+        if (method_exists($node->type, 'isSpecialClassName') && ($node->type->isSpecialClassName())) {
+            return;
+        }
+
         if (!method_exists($node->type, 'toString')) {
             return;
         }

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -299,6 +299,10 @@ class Tiger extends Animal
     public static function bar()
     {
     }
+    public function equals(self $other): bool
+    {
+        return $this == $other;
+    }
 }
 EOF;
 

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -299,9 +299,8 @@ class Tiger extends Animal
     public static function bar()
     {
     }
-    public function equals(self $other): bool
+    public function doSomething(self $self, static $static)
     {
-        return $this == $other;
     }
 }
 EOF;


### PR DESCRIPTION
It solve false positives when the 'self' or 'static' keywords are used as method param type.