### PR TITLE
added default namespace into depende only on these namespaces expression

### DIFF
--- a/src/Expression/ForClasses/DependsOnlyOnTheseNamespaces.php
+++ b/src/Expression/ForClasses/DependsOnlyOnTheseNamespaces.php
@@ -34,7 +34,8 @@ class DependsOnlyOnTheseNamespaces implements Expression
 
         /** @var ClassDependency $dependency */
         foreach ($dependencies as $dependency) {
-            if ('' === $dependency->getFQCN()->namespace()) {
+            if ('' === $dependency->getFQCN()->namespace() ||
+                ($theClass->namespaceMatches($dependency->getFQCN()->namespace()))) {
                 continue;
             }
 

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -318,4 +318,37 @@ EOF;
 
         $this->assertCount(0, $violations);
     }
+
+    public function test_it_should_return_errors_for_class_outside_namespace(): void
+    {
+        $code = <<< 'EOF'
+<?php
+
+namespace MyNamespace\MyClasses;
+
+use AnotherNamespace\Baz;
+
+class Foo
+{
+    public function foo()
+    {
+        $bar = new Bar();
+        $baz = new Baz();
+    }
+}
+EOF;
+
+        /** @var FileParser $fp */
+        $fp = FileParserFactory::createFileParser(TargetPhpVersion::create('7.4'));
+        $fp->parse($code, 'relativePathName');
+
+        $cd = $fp->getClassDescriptions();
+
+        $violations = new Violations();
+
+        $dependsOnlyOnTheseNamespaces = new DependsOnlyOnTheseNamespaces();
+        $dependsOnlyOnTheseNamespaces->evaluate($cd[0], $violations);
+
+        $this->assertCount(1, $violations);
+    }
 }

--- a/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
@@ -71,4 +71,19 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
 
         self::assertEquals(0, $violations->count());
     }
+
+    public function test_it_should_return_true_if_depends_on_same_namespace_without_specifing_it(): void
+    {
+        $dependOnClasses = new DependsOnlyOnTheseNamespaces();
+
+        $classDescription = ClassDescription::build('HappyIsland\Myclass')
+            ->addDependency(new ClassDependency('HappyIsland\Banana', 0))
+            ->addDependency(new ClassDependency('myNamespace\Mango', 10))
+            ->get();
+
+        $violations = new Violations();
+        $dependOnClasses->evaluate($classDescription, $violations);
+
+        self::assertEquals(1, $violations->count());
+    }
 }


### PR DESCRIPTION
With this PR we are saying that using `DependsOnlyOnTheseNamespaces` is implicit that the same namespace of the parsed class is allowed without specifying it.

Solving #200 