### PR TITLE
changed php version during phar creation

### DIFF
--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 7.1
 
       - name: Validate composer.json and composer.lock
         run: composer validate
@@ -37,7 +37,7 @@ jobs:
         with:
           args: --prefer-dist --no-dev -o
           composer_version: 2
-          php_version: 7.4
+          php_version: 7.1
 
       - name: "Compile phparkitect phar"
         run: ./bin/box.phar compile -c ./box.json


### PR DESCRIPTION
I changed the PHP version from `7.4` to `7.1` to solve this issue: #242 
In my opinion, this can create future problems, I don't know at the moment if the option `target-php-version` is enough or we have to create a phar version for each PHP version.