### PR TITLE
increase xdebug max nesting level to 10000

### DIFF
--- a/src/CLI/Check.php
+++ b/src/CLI/Check.php
@@ -52,6 +52,7 @@ class Check extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         ini_set('memory_limit', '-1');
+        ini_set('xdebug.max_nesting_level', '10000');
 
         try {
             $verbose = $input->getOption('verbose');


### PR DESCRIPTION
In this PR I added an `ini_set` to solve the problem about xdebug infinite loop because with big classes with many dependencies this could happen.

This PR solves the issue #251 