### PR TITLE
feat: Add `HaveAttribute` class expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Currently, you can check if a class:
  - is not abstract
  - doc block contains a string
  - doc block not contains a string
+ - has an attribute
 
 You can also define components and ensure that a component:
 - should not depend on any component

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Currently, you can check if a class:
  - is not abstract
  - doc block contains a string
  - doc block not contains a string
- - has an attribute
+ - has an attribute (requires PHP >= 8.0)
 
 You can also define components and ensure that a component:
 - should not depend on any component

--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -8,17 +8,16 @@ class ClassDescription
     /** @var FullyQualifiedClassName */
     private $FQCN;
 
-    /** @var array */
+    /** @var list<ClassDependency> */
     private $dependencies;
 
-    /** @var array */
+    /** @var list<FullyQualifiedClassName> */
     private $interfaces;
 
     /** @var string */
     private $fullPath;
-    /**
-     * @var ?FullyQualifiedClassName
-     */
+
+    /** @var ?FullyQualifiedClassName */
     private $extends;
 
     /** @var bool */
@@ -30,6 +29,15 @@ class ClassDescription
     /** @var string */
     private $docBlock;
 
+    /** @var list<FullyQualifiedClassName> */
+    private $attributes;
+
+    /**
+     * @param list<ClassDependency>         $dependencies
+     * @param list<FullyQualifiedClassName> $interfaces
+     * @param ?FullyQualifiedClassName      $extends
+     * @param list<FullyQualifiedClassName> $attributes
+     */
     public function __construct(
         FullyQualifiedClassName $FQCN,
         array $dependencies,
@@ -37,7 +45,8 @@ class ClassDescription
         ?FullyQualifiedClassName $extends,
         bool $final,
         bool $abstract,
-        string $docBlock = ''
+        string $docBlock = '',
+        array $attributes = []
     ) {
         $this->FQCN = $FQCN;
         $this->dependencies = $dependencies;
@@ -47,6 +56,7 @@ class ClassDescription
         $this->abstract = $abstract;
         $this->fullPath = '';
         $this->docBlock = $docBlock;
+        $this->attributes = $attributes;
     }
 
     public function setFullPath(string $fullPath): void
@@ -122,11 +132,17 @@ class ClassDescription
         return $this->fullPath;
     }
 
+    /**
+     * @return list<ClassDependency>
+     */
     public function getDependencies(): array
     {
         return $this->dependencies;
     }
 
+    /**
+     * @return list<FullyQualifiedClassName>
+     */
     public function getInterfaces(): array
     {
         return $this->interfaces;
@@ -159,5 +175,24 @@ class ClassDescription
         }
 
         return false;
+    }
+
+    /**
+     * @return list<FullyQualifiedClassName>
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    public function hasAttribute(string $pattern): bool
+    {
+        return array_reduce(
+            $this->attributes,
+            static function (bool $carry, FullyQualifiedClassName $attribute) use ($pattern): bool {
+                return $carry || $attribute->matches($pattern);
+            },
+            false
+        );
     }
 }

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -5,13 +5,13 @@ namespace Arkitect\Analyzer;
 
 class ClassDescriptionBuilder
 {
-    /** @var array */
+    /** @var list<ClassDependency> */
     private $classDependencies;
 
     /** @var FullyQualifiedClassName */
     private $FQCN;
 
-    /** @var array */
+    /** @var list<FullyQualifiedClassName> */
     private $interfaces;
 
     /** @var ?FullyQualifiedClassName */
@@ -29,6 +29,14 @@ class ClassDescriptionBuilder
     /** @var string */
     private $docBlock;
 
+    /** @var list<FullyQualifiedClassName> */
+    private $attributes;
+
+    /**
+     * @param list<ClassDependency>         $classDependencies
+     * @param list<FullyQualifiedClassName> $interfaces
+     * @param list<FullyQualifiedClassName> $attributes
+     */
     private function __construct(
         FullyQualifiedClassName $FQCN,
         string $filePath,
@@ -36,7 +44,8 @@ class ClassDescriptionBuilder
         array $interfaces,
         bool $final,
         bool $abstract,
-        string $docBlock = ''
+        string $docBlock = '',
+        array $attributes = []
     ) {
         $this->FQCN = $FQCN;
         $this->filePath = $filePath;
@@ -45,6 +54,7 @@ class ClassDescriptionBuilder
         $this->final = $final;
         $this->abstract = $abstract;
         $this->docBlock = $docBlock;
+        $this->attributes = $attributes;
     }
 
     public static function create(string $FQCN): self
@@ -56,7 +66,8 @@ class ClassDescriptionBuilder
             [],
             false,
             false,
-            ''
+            '',
+            []
         );
     }
 
@@ -99,7 +110,8 @@ class ClassDescriptionBuilder
             $this->extend,
             $this->final,
             $this->abstract,
-            $this->docBlock
+            $this->docBlock,
+            $this->attributes
         );
         $cd->setFullPath($this->filePath);
 
@@ -123,6 +135,14 @@ class ClassDescriptionBuilder
     public function setDocBlock(string $docBlock): self
     {
         $this->docBlock = $docBlock;
+
+        return $this;
+    }
+
+    public function addAttribute(string $FQCN, int $line): self
+    {
+        $this->addDependency(new ClassDependency($FQCN, $line));
+        $this->attributes[] = FullyQualifiedClassName::fromString($FQCN);
 
         return $this;
     }

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -52,6 +52,13 @@ class FileVisitor extends NodeVisitorAbstract
                 $docComment = $node->getDocComment();
                 $this->classDescriptionBuilder->setDocBlock($docComment->getText());
             }
+
+            foreach ($node->attrGroups as $attributeGroup) {
+                foreach ($attributeGroup->attrs as $attribute) {
+                    $this->classDescriptionBuilder
+                        ->addAttribute($attribute->name->toString(), $attribute->getLine());
+                }
+            }
         }
 
         /**

--- a/src/Expression/ForClasses/HaveAttribute.php
+++ b/src/Expression/ForClasses/HaveAttribute.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Expression\ForClasses;
+
+use Arkitect\Analyzer\ClassDescription;
+use Arkitect\Expression\Description;
+use Arkitect\Expression\Expression;
+use Arkitect\Rules\Violation;
+use Arkitect\Rules\Violations;
+
+final class HaveAttribute implements Expression
+{
+    /** @var string */
+    private $attribute;
+
+    public function __construct(string $attribute)
+    {
+        $this->attribute = $attribute;
+    }
+
+    public function describe(ClassDescription $theClass, string $because): Description
+    {
+        return new Description("should have the attribute {$this->attribute}", $because);
+    }
+
+    public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
+    {
+        if ($theClass->hasAttribute($this->attribute)) {
+            return;
+        }
+
+        $violations->add(
+            Violation::create(
+                $theClass->getFQCN(),
+                $this->describe($theClass, $because)->toString()
+            )
+        );
+    }
+}

--- a/tests/E2E/PHPUnit/CheckClassHaveAttributeTest.php
+++ b/tests/E2E/PHPUnit/CheckClassHaveAttributeTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Tests\E2E\PHPUnit;
+
+use Arkitect\ClassSet;
+use Arkitect\Expression\ForClasses\HaveAttribute;
+use Arkitect\Expression\ForClasses\HaveNameMatching;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @requires PHP >= 8.0
+ */
+final class CheckClassHaveAttributeTest extends TestCase
+{
+    public function test_entities_should_reside_in_app_model(): void
+    {
+        $set = ClassSet::fromDir(__DIR__.'/../_fixtures/mvc');
+
+        $rule = Rule::allClasses()
+            ->that(new HaveAttribute('Entity'))
+            ->should(new ResideInOneOfTheseNamespaces('App\Model'))
+            ->because('we use an ORM');
+
+        ArchRuleTestCase::assertArchRule($rule, $set);
+    }
+
+    public function test_controllers_should_have_name_ending_in_controller(): void
+    {
+        $set = ClassSet::fromDir(__DIR__.'/../_fixtures/mvc');
+
+        $rule = Rule::allClasses()
+            ->that(new HaveAttribute('AsController'))
+            ->should(new HaveNameMatching('*Controller'))
+            ->because('its a symfony thing');
+
+        $expectedExceptionMessage = '
+App\Controller\Foo violates rules
+  should have a name that matches *Controller because its a symfony thing';
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        ArchRuleTestCase::assertArchRule($rule, $set);
+    }
+
+    public function test_controllers_should_have_controller_attribute(): void
+    {
+        $set = ClassSet::fromDir(__DIR__.'/../_fixtures/mvc');
+
+        $rule = Rule::allClasses()
+            ->that(new HaveNameMatching('*Controller'))
+            ->should(new HaveAttribute('AsController'))
+            ->because('it configures the service container');
+
+        ArchRuleTestCase::assertArchRule($rule, $set);
+    }
+}

--- a/tests/E2E/_fixtures/mvc/Controller/BaseController.php
+++ b/tests/E2E/_fixtures/mvc/Controller/BaseController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+#[\AsController]
 class BaseController
 {
 }

--- a/tests/E2E/_fixtures/mvc/Controller/CatalogController.php
+++ b/tests/E2E/_fixtures/mvc/Controller/CatalogController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+#[\AsController]
 class CatalogController implements \ContainerAwareInterface
 {
     public function viewAction(string $id)

--- a/tests/E2E/_fixtures/mvc/Controller/Foo.php
+++ b/tests/E2E/_fixtures/mvc/Controller/Foo.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+#[\AsController]
 class Foo
 {
 }

--- a/tests/E2E/_fixtures/mvc/Controller/ProductsController.php
+++ b/tests/E2E/_fixtures/mvc/Controller/ProductsController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+#[\AsController]
 class ProductsController
 {
 }

--- a/tests/E2E/_fixtures/mvc/Controller/UserController.php
+++ b/tests/E2E/_fixtures/mvc/Controller/UserController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+#[\AsController]
 class UserController
 {
 }

--- a/tests/E2E/_fixtures/mvc/Controller/YieldController.php
+++ b/tests/E2E/_fixtures/mvc/Controller/YieldController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 
 use App\Model\Products;
 
+#[\AsController]
 class YieldController
 {
     public function testingBug()

--- a/tests/E2E/_fixtures/mvc/Model/Catalog.php
+++ b/tests/E2E/_fixtures/mvc/Model/Catalog.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Model;
 
+#[\Entity]
 class Catalog
 {
 }

--- a/tests/E2E/_fixtures/mvc/Model/Products.php
+++ b/tests/E2E/_fixtures/mvc/Model/Products.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Model;
 
+#[\Entity]
 class Products
 {
 }

--- a/tests/E2E/_fixtures/mvc/Model/User.php
+++ b/tests/E2E/_fixtures/mvc/Model/User.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Model;
 
+#[\Entity]
 class User
 {
 }

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -7,6 +7,7 @@ namespace Arkitect\Tests\Unit\Analyzer;
 use Arkitect\Analyzer\ClassDependency;
 use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Analyzer\ClassDescriptionBuilder;
+use Arkitect\Analyzer\FullyQualifiedClassName;
 use PHPUnit\Framework\TestCase;
 
 class ClassDescriptionBuilderTest extends TestCase
@@ -98,6 +99,20 @@ class ClassDescriptionBuilderTest extends TestCase
  * @psalm-immutable
  */',
             $classDescription->getDocBlock()
+        );
+    }
+
+    public function test_it_should_add_attributes(): void
+    {
+        $FQCN = 'HappyIsland';
+        $classDescriptionBuilder = ClassDescriptionBuilder::create($FQCN);
+        $classDescriptionBuilder->addAttribute('AttrClass', 27);
+
+        $classDescription = $classDescriptionBuilder->get();
+
+        self::assertEquals(
+            [FullyQualifiedClassName::fromString('AttrClass')],
+            $classDescription->getAttributes()
         );
     }
 }

--- a/tests/Unit/Analyzer/ClassDescriptionTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionTest.php
@@ -80,4 +80,23 @@ class ClassDescriptionTest extends TestCase
 
         $this->assertFalse($cd->containsDocBlock('@another-annotation'));
     }
+
+    public function test_should_return_true_if_has_attribute(): void
+    {
+        $cd = $this->builder
+            ->addAttribute('FooAttr', 27)
+            ->get();
+
+        self::assertTrue($cd->hasAttribute('FooAttr'));
+        self::assertTrue($cd->hasAttribute('Foo*'));
+    }
+
+    public function test_should_return_false_if_not_has_attribute(): void
+    {
+        $cd = $this->builder
+            ->addAttribute('FooAttr', 27)
+            ->get();
+
+        self::assertFalse($cd->hasAttribute('Bar'));
+    }
 }


### PR DESCRIPTION
Hi there!

This change will add the ability to check for the existence of an attribute on a class. The addition of this ability won't break existing functionality on PHP < 8.0, but because attributes only exist on PHP >= 8.0, using this new expression does require the latter. Perhaps this limitation should be documented explicitly if you are willing to accept the change.

Thanks!