### PR TITLE
added prophecy as a dependency to avoid warning into our tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "vimeo/psalm": "^4.6",
         "friendsofphp/php-cs-fixer": "^2.16",
         "phpunit/phpunit": "^7.5|^9.0",
-        "mikey179/vfsstream": "^1.6"
+        "mikey179/vfsstream": "^1.6",
+        "phpspec/prophecy-phpunit": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Unit/Analyzer/FileParserTest.php
+++ b/tests/Unit/Analyzer/FileParserTest.php
@@ -11,9 +11,12 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class FileParserTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_parse_file(): void
     {
         $traverser = $this->prophesize(NodeTraverser::class);

--- a/tests/Unit/CLI/Progress/DebugProgressTest.php
+++ b/tests/Unit/CLI/Progress/DebugProgressTest.php
@@ -7,10 +7,13 @@ namespace Arkitect\Tests\Unit\CLI\Progress;
 use Arkitect\ClassSet;
 use Arkitect\CLI\Progress\DebugProgress;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DebugProgressTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function test_it_should_generate_text_on_start_parsing_file(): void
     {
         $output = $this->prophesize(OutputInterface::class);


### PR DESCRIPTION
In this PR I added the dependency phpspec/prophecy-phpunit to use the ProphecyTrait in our tests and avoid warning when we run them.