### PR TITLE
test: add test for const outside namespace

### DIFF
--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -353,6 +353,38 @@ EOF;
         $this->assertCount(1, $violations);
     }
 
+    public function test_it_should_return_errors_for_const_outside_namespace(): void
+    {
+        $code = <<< 'EOF'
+<?php
+
+namespace Root\Cars;
+
+use AnotherNamespace\CarMake;
+
+class KiaSportage extends AbstractCar
+{
+    public function __construct()
+    {
+        parent::__construct(CarMake::KIA, 'Sportage');
+    }
+}
+EOF;
+
+        /** @var FileParser $fp */
+        $fp = FileParserFactory::createFileParser(TargetPhpVersion::create('7.4'));
+        $fp->parse($code, 'relativePathName');
+
+        $cd = $fp->getClassDescriptions();
+
+        $violations = new Violations();
+
+        $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('Root\Cars');
+        $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
+
+        $this->assertCount(1, $violations);
+    }
+
     /**
      * @requires PHP >= 8.0
      */


### PR DESCRIPTION
I have added a FAIL test to detect const outside namespace as dependency.