### PR TITLE
added add-shouldOnlyDependOnComponents

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,11 +286,13 @@ return static function (Config $config): void {
         ->component('Service')->definedBy('App\Service\*')
         ->component('Repository')->definedBy('App\Repository\*')
         ->component('Entity')->definedBy('App\Entity\*')
+        ->component('Domain')->definedBy('App\Domain\*')
 
         ->where('Controller')->mayDependOnComponents('Service', 'Entity')
         ->where('Service')->mayDependOnComponents('Repository', 'Entity')
         ->where('Repository')->mayDependOnComponents('Entity')
         ->where('Entity')->shouldNotDependOnAnyComponent()
+        ->where('Domain')->shouldOnlyDependOnComponents('Domain')
 
         ->rules();
         

--- a/src/RuleBuilders/Architecture/Architecture.php
+++ b/src/RuleBuilders/Architecture/Architecture.php
@@ -17,14 +17,14 @@ class Architecture implements Component, DefinedBy, Where, MayDependOnComponents
     /** @var array<string, string[]> */
     private $allowedDependencies;
     /** @var array<string, string[]> */
-    private $allowedSpecificDependencies;
+    private $componentDependsOnlyOnTheseNamespaces;
 
     private function __construct()
     {
         $this->componentName = '';
         $this->componentSelectors = [];
         $this->allowedDependencies = [];
-        $this->allowedSpecificDependencies = [];
+        $this->componentDependsOnlyOnTheseNamespaces = [];
     }
 
     public static function withComponents(): Component
@@ -62,7 +62,7 @@ class Architecture implements Component, DefinedBy, Where, MayDependOnComponents
 
     public function shouldOnlyDependOnComponents(string ...$componentNames)
     {
-        $this->allowedSpecificDependencies[$this->componentName] = $componentNames;
+        $this->componentDependsOnlyOnTheseNamespaces[$this->componentName] = $componentNames;
 
         return $this;
     }
@@ -101,13 +101,13 @@ class Architecture implements Component, DefinedBy, Where, MayDependOnComponents
                 }
             }
 
-            if (!isset($this->allowedSpecificDependencies[$name])) {
+            if (!isset($this->componentDependsOnlyOnTheseNamespaces[$name])) {
                 continue;
             }
 
             $allowedDependencies = array_map(function (string $componentName): string {
                 return $this->componentSelectors[$componentName];
-            }, $this->allowedSpecificDependencies[$name]);
+            }, $this->componentDependsOnlyOnTheseNamespaces[$name]);
 
             yield Rule::allClasses()
                 ->that(new ResideInOneOfTheseNamespaces($selector))

--- a/src/RuleBuilders/Architecture/Architecture.php
+++ b/src/RuleBuilders/Architecture/Architecture.php
@@ -3,11 +3,12 @@ declare(strict_types=1);
 
 namespace Arkitect\RuleBuilders\Architecture;
 
+use Arkitect\Expression\ForClasses\DependsOnlyOnTheseNamespaces;
 use Arkitect\Expression\ForClasses\NotDependsOnTheseNamespaces;
 use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
 use Arkitect\Rules\Rule;
 
-class Architecture implements Component, DefinedBy, Where, MayDependOnComponents, MayDependOnAnyComponent, ShouldNotDependOnAnyComponent, Rules
+class Architecture implements Component, DefinedBy, Where, MayDependOnComponents, MayDependOnAnyComponent, ShouldNotDependOnAnyComponent, ShouldOnlyDependOnComponents, Rules
 {
     /** @var string */
     private $componentName;
@@ -15,12 +16,15 @@ class Architecture implements Component, DefinedBy, Where, MayDependOnComponents
     private $componentSelectors;
     /** @var array<string, string[]> */
     private $allowedDependencies;
+    /** @var array<string, string[]> */
+    private $allowedSpecificDependencies;
 
     private function __construct()
     {
         $this->componentName = '';
         $this->componentSelectors = [];
         $this->allowedDependencies = [];
+        $this->allowedSpecificDependencies = [];
     }
 
     public static function withComponents(): Component
@@ -38,7 +42,6 @@ class Architecture implements Component, DefinedBy, Where, MayDependOnComponents
     public function definedBy(string $selector)
     {
         $this->componentSelectors[$this->componentName] = $selector;
-        $this->allowedDependencies[$this->componentName] = [];
 
         return $this;
     }
@@ -53,6 +56,13 @@ class Architecture implements Component, DefinedBy, Where, MayDependOnComponents
     public function shouldNotDependOnAnyComponent()
     {
         $this->allowedDependencies[$this->componentName] = [];
+
+        return $this;
+    }
+
+    public function shouldOnlyDependOnComponents(string ...$componentNames)
+    {
+        $this->allowedSpecificDependencies[$this->componentName] = $componentNames;
 
         return $this;
     }
@@ -76,19 +86,32 @@ class Architecture implements Component, DefinedBy, Where, MayDependOnComponents
         $layerNames = array_keys($this->componentSelectors);
 
         foreach ($this->componentSelectors as $name => $selector) {
-            $forbiddenComponents = array_diff($layerNames, [$name], $this->allowedDependencies[$name]);
+            if (isset($this->allowedDependencies[$name])) {
+                $forbiddenComponents = array_diff($layerNames, [$name], $this->allowedDependencies[$name]);
 
-            if (empty($forbiddenComponents)) {
+                if (!empty($forbiddenComponents)) {
+                    $forbiddenSelectors = array_map(function (string $componentName): string {
+                        return $this->componentSelectors[$componentName];
+                    }, $forbiddenComponents);
+
+                    yield Rule::allClasses()
+                        ->that(new ResideInOneOfTheseNamespaces($selector))
+                        ->should(new NotDependsOnTheseNamespaces(...$forbiddenSelectors))
+                        ->because('of component architecture');
+                }
+            }
+
+            if (!isset($this->allowedSpecificDependencies[$name])) {
                 continue;
             }
 
-            $forbiddenSelectors = array_map(function (string $componentName): string {
+            $allowedDependencies = array_map(function (string $componentName): string {
                 return $this->componentSelectors[$componentName];
-            }, $forbiddenComponents);
+            }, $this->allowedSpecificDependencies[$name]);
 
             yield Rule::allClasses()
                 ->that(new ResideInOneOfTheseNamespaces($selector))
-                ->should(new NotDependsOnTheseNamespaces(...$forbiddenSelectors))
+                ->should(new DependsOnlyOnTheseNamespaces(...$allowedDependencies))
                 ->because('of component architecture');
         }
     }

--- a/src/RuleBuilders/Architecture/ShouldOnlyDependOnComponents.php
+++ b/src/RuleBuilders/Architecture/ShouldOnlyDependOnComponents.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\RuleBuilders\Architecture;
+
+interface ShouldOnlyDependOnComponents
+{
+    /** @return Where&Rules */
+    public function shouldOnlyDependOnComponents(string ...$componentNames);
+}

--- a/src/RuleBuilders/Architecture/Where.php
+++ b/src/RuleBuilders/Architecture/Where.php
@@ -5,6 +5,6 @@ namespace Arkitect\RuleBuilders\Architecture;
 
 interface Where
 {
-    /** @return ShouldNotDependOnAnyComponent&MayDependOnComponents&MayDependOnAnyComponent */
+    /** @return ShouldNotDependOnAnyComponent&ShouldOnlyDependOnComponents&MayDependOnComponents&MayDependOnAnyComponent */
     public function where(string $componentName);
 }

--- a/tests/Unit/Architecture/ArchitectureTest.php
+++ b/tests/Unit/Architecture/ArchitectureTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Architecture;
 
+use Arkitect\Expression\ForClasses\DependsOnlyOnTheseNamespaces;
 use Arkitect\Expression\ForClasses\NotDependsOnTheseNamespaces;
 use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
 use Arkitect\RuleBuilders\Architecture\Architecture;
@@ -32,6 +33,24 @@ class ArchitectureTest extends TestCase
             Rule::allClasses()
                 ->that(new ResideInOneOfTheseNamespaces('App\*\Application\*'))
                 ->should(new NotDependsOnTheseNamespaces('App\*\Infrastructure\*'))
+                ->because('of component architecture'),
+        ];
+
+        self::assertEquals($expectedRules, iterator_to_array($rules));
+    }
+
+    public function test_layered_architecture_with_depends_only_on_components(): void
+    {
+        $rules = Architecture::withComponents()
+            ->component('Domain')->definedBy('App\*\Domain\*')
+            ->where('Domain')->shouldOnlyDependOnComponents('Domain')
+
+            ->rules();
+
+        $expectedRules = [
+            Rule::allClasses()
+                ->that(new ResideInOneOfTheseNamespaces('App\*\Domain\*'))
+                ->should(new DependsOnlyOnTheseNamespaces('App\*\Domain\*'))
                 ->because('of component architecture'),
         ];
 


### PR DESCRIPTION
In this PR I added the possibility to filter components with `shouldOnlyDependOnComponents` function that generates a rule: `DependsOnlyOnTheseNamespaces`

This can fix some problems about issue #277 