### PR TITLE
Fix #126 improve error messages including classname when possible

### DIFF
--- a/src/Expression/ForClasses/DependsOnlyOnTheseNamespaces.php
+++ b/src/Expression/ForClasses/DependsOnlyOnTheseNamespaces.php
@@ -9,6 +9,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class DependsOnlyOnTheseNamespaces implements Expression
@@ -44,7 +45,10 @@ class DependsOnlyOnTheseNamespaces implements Expression
             if (!$dependency->matchesOneOf(...$this->namespaces)) {
                 $violation = Violation::createWithErrorLine(
                     $theClass->getFQCN(),
-                    $this->describe($theClass, $because)->toString(),
+                    ViolationMessage::withDescription(
+                        $this->describe($theClass, $because),
+                        "depends on {$dependency->getFQCN()->toString()}"
+                    ),
                     $dependency->getLine()
                 );
 

--- a/src/Expression/ForClasses/DocBlockContains.php
+++ b/src/Expression/ForClasses/DocBlockContains.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class DocBlockContains implements Expression
@@ -30,7 +31,7 @@ class DocBlockContains implements Expression
         if (!$theClass->containsDocBlock($this->docBlock)) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString()
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/DocBlockNotContains.php
+++ b/src/Expression/ForClasses/DocBlockNotContains.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class DocBlockNotContains implements Expression
@@ -30,7 +31,7 @@ class DocBlockNotContains implements Expression
         if ($theClass->containsDocBlock($this->docBlock)) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString()
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/Extend.php
+++ b/src/Expression/ForClasses/Extend.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class Extend implements Expression
@@ -35,7 +36,7 @@ class Extend implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            $this->describe($theClass, $because)->toString()
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/HaveAttribute.php
+++ b/src/Expression/ForClasses/HaveAttribute.php
@@ -7,6 +7,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 final class HaveAttribute implements Expression
@@ -33,7 +34,7 @@ final class HaveAttribute implements Expression
         $violations->add(
             Violation::create(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString()
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
             )
         );
     }

--- a/src/Expression/ForClasses/HaveNameMatching.php
+++ b/src/Expression/ForClasses/HaveNameMatching.php
@@ -9,6 +9,7 @@ use Arkitect\Analyzer\FullyQualifiedClassName;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class HaveNameMatching implements Expression
@@ -32,7 +33,7 @@ class HaveNameMatching implements Expression
         if (!$fqcn->classMatches($this->name)) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString()
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/Implement.php
+++ b/src/Expression/ForClasses/Implement.php
@@ -9,6 +9,7 @@ use Arkitect\Analyzer\FullyQualifiedClassName;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class Implement implements Expression
@@ -37,7 +38,7 @@ class Implement implements Expression
         if (0 === \count(array_filter($interfaces, $implements))) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString()
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/IsAbstract.php
+++ b/src/Expression/ForClasses/IsAbstract.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class IsAbstract implements Expression
@@ -25,7 +26,7 @@ class IsAbstract implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            $this->describe($theClass, $because)->toString()
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsFinal.php
+++ b/src/Expression/ForClasses/IsFinal.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class IsFinal implements Expression
@@ -25,7 +26,7 @@ class IsFinal implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            $this->describe($theClass, $because)->toString()
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsNotAbstract.php
+++ b/src/Expression/ForClasses/IsNotAbstract.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class IsNotAbstract implements Expression
@@ -25,7 +26,7 @@ class IsNotAbstract implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            $this->describe($theClass, $because)->toString()
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsNotFinal.php
+++ b/src/Expression/ForClasses/IsNotFinal.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class IsNotFinal implements Expression
@@ -25,7 +26,7 @@ class IsNotFinal implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            $this->describe($theClass, $because)->toString()
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/NotDependsOnTheseNamespaces.php
+++ b/src/Expression/ForClasses/NotDependsOnTheseNamespaces.php
@@ -9,6 +9,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class NotDependsOnTheseNamespaces implements Expression
@@ -41,7 +42,10 @@ class NotDependsOnTheseNamespaces implements Expression
             if ($dependency->matchesOneOf(...$this->namespaces)) {
                 $violation = Violation::createWithErrorLine(
                     $theClass->getFQCN(),
-                    $this->describe($theClass, $because)->toString(),
+                    ViolationMessage::withDescription(
+                        $this->describe($theClass, $because),
+                        "depends on {$dependency->getFQCN()->toString()}"
+                    ),
                     $dependency->getLine()
                 );
 

--- a/src/Expression/ForClasses/NotExtend.php
+++ b/src/Expression/ForClasses/NotExtend.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class NotExtend implements Expression
@@ -39,7 +40,7 @@ class NotExtend implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            $this->describe($theClass, $because)->toString()
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/NotHaveDependencyOutsideNamespace.php
+++ b/src/Expression/ForClasses/NotHaveDependencyOutsideNamespace.php
@@ -9,6 +9,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class NotHaveDependencyOutsideNamespace implements Expression
@@ -47,7 +48,10 @@ class NotHaveDependencyOutsideNamespace implements Expression
 
             $violation = Violation::createWithErrorLine(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString(),
+                ViolationMessage::withDescription(
+                    $this->describe($theClass, $because),
+                    "depends on {$externalDep->getFQCN()->toString()}"
+                ),
                 $externalDep->getLine()
             );
             $violations->add($violation);

--- a/src/Expression/ForClasses/NotHaveNameMatching.php
+++ b/src/Expression/ForClasses/NotHaveNameMatching.php
@@ -9,6 +9,7 @@ use Arkitect\Analyzer\FullyQualifiedClassName;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class NotHaveNameMatching implements Expression
@@ -32,7 +33,7 @@ class NotHaveNameMatching implements Expression
         if ($fqcn->classMatches($this->name)) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString()
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/NotImplement.php
+++ b/src/Expression/ForClasses/NotImplement.php
@@ -9,6 +9,7 @@ use Arkitect\Analyzer\FullyQualifiedClassName;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class NotImplement implements Expression
@@ -37,7 +38,7 @@ class NotImplement implements Expression
         if (\count(array_filter($interfaces, $implements)) > 0) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString()
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/NotResideInTheseNamespaces.php
+++ b/src/Expression/ForClasses/NotResideInTheseNamespaces.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class NotResideInTheseNamespaces implements Expression
@@ -39,7 +40,7 @@ class NotResideInTheseNamespaces implements Expression
         if ($resideInNamespace) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString()
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
+++ b/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
@@ -8,6 +8,7 @@ use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
 class ResideInOneOfTheseNamespaces implements Expression
@@ -39,7 +40,7 @@ class ResideInOneOfTheseNamespaces implements Expression
         if (!$resideInNamespace) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                $this->describe($theClass, $because)->toString()
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
             );
             $violations->add($violation);
         }

--- a/src/Rules/Violation.php
+++ b/src/Rules/Violation.php
@@ -22,14 +22,14 @@ class Violation
         $this->line = $line;
     }
 
-    public static function create(string $fqcn, string $error): self
+    public static function create(string $fqcn, ViolationMessage $error): self
     {
-        return new self($fqcn, $error);
+        return new self($fqcn, $error->toString());
     }
 
-    public static function createWithErrorLine(string $fqcn, string $error, int $line): self
+    public static function createWithErrorLine(string $fqcn, ViolationMessage $error, int $line): self
     {
-        return new self($fqcn, $error, $line);
+        return new self($fqcn, $error->toString(), $line);
     }
 
     public function getFqcn(): string

--- a/src/Rules/ViolationMessage.php
+++ b/src/Rules/ViolationMessage.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Rules;
+
+use Arkitect\Expression\Description;
+
+class ViolationMessage
+{
+    /** @var string */
+    private $rule;
+    /** @var string|null */
+    private $violation;
+
+    private function __construct(string $rule, ?string $violation)
+    {
+        $this->rule = $rule;
+        $this->violation = $violation;
+    }
+
+    public static function withDescription(Description $brokenRule, string $description): self
+    {
+        return new self($brokenRule->toString(), $description);
+    }
+
+    public static function selfExplanatory(Description $brokenRule): self
+    {
+        return new self($brokenRule->toString(), null);
+    }
+
+    public function toString(): string
+    {
+        if (null === $this->violation) {
+            return $this->rule;
+        }
+
+        return "$this->violation, but $this->rule";
+    }
+}

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -72,7 +72,8 @@ class Violations implements \IteratorAggregate, \Countable
          * @var Violation[] $violationsByFqcn
          */
         foreach ($violationsCollection as $key => $violationsByFqcn) {
-            $errors .= "\n".$key.' violates rules';
+            $violationForThisFqcn = \count($violationsByFqcn);
+            $errors .= "\n$key has {$violationForThisFqcn} violations";
 
             foreach ($violationsByFqcn as $violation) {
                 $errors .= "\n  ".$violation->getError();

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -35,8 +35,8 @@ App\Controller\YieldController violates rules
   should implement ContainerAwareInterface because all controllers should be container aware
 
 App\Domain\Model violates rules
-  should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
-  should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
+  depends on App\Services\UserService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
+  depends on App\Services\CartService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
 
         $this->assertCheckHasErrors($cmdTester, $expectedErrors);
     }

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -21,20 +21,20 @@ class CheckCommandTest extends TestCase
 
         $expectedErrors = 'ERRORS!
 
-App\Controller\Foo violates rules
+App\Controller\Foo has 2 violations
   should implement ContainerAwareInterface because all controllers should be container aware
   should have a name that matches *Controller because we want uniform naming
 
-App\Controller\ProductsController violates rules
+App\Controller\ProductsController has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware
 
-App\Controller\UserController violates rules
+App\Controller\UserController has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware
 
-App\Controller\YieldController violates rules
+App\Controller\YieldController has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware
 
-App\Domain\Model violates rules
+App\Domain\Model has 2 violations
   depends on App\Services\UserService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
   depends on App\Services\CartService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
 
@@ -46,11 +46,11 @@ App\Domain\Model violates rules
         $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvc.php', true);
 
         $expectedErrors = 'ERRORS!
-App\Controller\Foo violates rules
+App\Controller\Foo has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware';
 
         $this->assertCheckHasErrors($cmdTester, $expectedErrors);
-        $this->assertCheckHasNoErrorsLike($cmdTester, "App\Controller\ProductsController violates rules");
+        $this->assertCheckHasNoErrorsLike($cmdTester, "App\Controller\ProductsController has 1 violations");
     }
 
     public function test_does_not_explode_if_an_exception_is_thrown(): void
@@ -73,7 +73,7 @@ App\Controller\Foo violates rules
 
         $expectedErrors = 'ERRORS!
 
-App\Controller\Foo violates rules
+App\Controller\Foo has 1 violations
   should have a name that matches *Controller';
 
         $this->assertCheckHasErrors($cmdTester, $expectedErrors);

--- a/tests/E2E/PHPUnit/CheckClassHaveAttributeTest.php
+++ b/tests/E2E/PHPUnit/CheckClassHaveAttributeTest.php
@@ -38,7 +38,7 @@ final class CheckClassHaveAttributeTest extends TestCase
             ->because('its a symfony thing');
 
         $expectedExceptionMessage = '
-App\Controller\Foo violates rules
+App\Controller\Foo has 1 violations
   should have a name that matches *Controller because its a symfony thing';
 
         $this->expectException(ExpectationFailedException::class);

--- a/tests/E2E/PHPUnit/CheckClassImplementInterfaceTest.php
+++ b/tests/E2E/PHPUnit/CheckClassImplementInterfaceTest.php
@@ -25,19 +25,19 @@ class CheckClassImplementInterfaceTest extends TestCase
             ->because('i said so');
 
         $expectedExceptionMessage = '
-App\Controller\Foo violates rules
+App\Controller\Foo has 1 violations
   should implement ContainerAwareInterface because i said so
 
-App\Controller\ProductsController violates rules
+App\Controller\ProductsController has 1 violations
   should implement ContainerAwareInterface because i said so
 
-App\Controller\UserController violates rules
+App\Controller\UserController has 1 violations
   should implement ContainerAwareInterface because i said so
 
-App\Controller\YieldController violates rules
+App\Controller\YieldController has 1 violations
   should implement ContainerAwareInterface because i said so
 
-App\Services\UserService violates rules
+App\Services\UserService has 1 violations
   should implement ContainerAwareInterface because i said so';
 
         $this->expectException(ExpectationFailedException::class);

--- a/tests/E2E/Smoke/RunArkitectBinTest.php
+++ b/tests/E2E/Smoke/RunArkitectBinTest.php
@@ -22,20 +22,20 @@ class RunArkitectBinTest extends TestCase
 
         $expectedErrors = 'ERRORS!
 
-App\Controller\Foo violates rules
+App\Controller\Foo has 2 violations
   should implement ContainerAwareInterface because all controllers should be container aware
   should have a name that matches *Controller because we want uniform naming
 
-App\Controller\ProductsController violates rules
+App\Controller\ProductsController has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware
 
-App\Controller\UserController violates rules
+App\Controller\UserController has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware
 
-App\Controller\YieldController violates rules
+App\Controller\YieldController has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware
 
-App\Domain\Model violates rules
+App\Domain\Model has 2 violations
   depends on App\Services\UserService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
   depends on App\Services\CartService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
 
@@ -49,20 +49,20 @@ App\Domain\Model violates rules
 
         $expectedErrors = 'ERRORS!
 
-App\Controller\Foo violates rules
+App\Controller\Foo has 2 violations
   should implement ContainerAwareInterface because all controllers should be container aware
   should have a name that matches *Controller because we want uniform naming
 
-App\Controller\ProductsController violates rules
+App\Controller\ProductsController has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware
 
-App\Controller\UserController violates rules
+App\Controller\UserController has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware
 
-App\Controller\YieldController violates rules
+App\Controller\YieldController has 1 violations
   should implement ContainerAwareInterface because all controllers should be container aware
 
-App\Domain\Model violates rules
+App\Domain\Model has 2 violations
   depends on App\Services\UserService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
   depends on App\Services\CartService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
 
@@ -91,7 +91,7 @@ App\Domain\Model violates rules
 
         $expectedErrors = 'ERRORS!
 
-App\Controller\Foo violates rules
+App\Controller\Foo has 1 violations
   should have a name that matches *Controller';
 
         $this->assertEquals(self::ERROR_CODE, $process->getExitCode());

--- a/tests/E2E/Smoke/RunArkitectBinTest.php
+++ b/tests/E2E/Smoke/RunArkitectBinTest.php
@@ -36,8 +36,8 @@ App\Controller\YieldController violates rules
   should implement ContainerAwareInterface because all controllers should be container aware
 
 App\Domain\Model violates rules
-  should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
-  should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
+  depends on App\Services\UserService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
+  depends on App\Services\CartService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
 
         $this->assertEquals(self::ERROR_CODE, $process->getExitCode());
         $this->assertStringContainsString($expectedErrors, $process->getOutput());
@@ -63,8 +63,8 @@ App\Controller\YieldController violates rules
   should implement ContainerAwareInterface because all controllers should be container aware
 
 App\Domain\Model violates rules
-  should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
-  should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
+  depends on App\Services\UserService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
+  depends on App\Services\CartService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
 
         $this->assertStringContainsString($expectedErrors, $process->getOutput());
         $this->assertEquals(self::ERROR_CODE, $process->getExitCode());

--- a/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
@@ -42,6 +42,10 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
         $dependOnClasses->evaluate($classDescription, $violations, $because);
 
         self::assertNotEquals(0, $violations->count());
+        self::assertEquals(
+            'depends on anotherNamespace\Banana, but should depend only on classes in one of these namespaces: myNamespace because we want to add this rule for our software',
+            $violations->get(0)->getError()
+        );
     }
 
     public function test_it_should_return_true_if_depends_on_class_in_root_namespace(): void

--- a/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
@@ -39,8 +39,8 @@ class NotDependsOnTheseNamespacesTest extends TestCase
 
         self::assertEquals(1, $violations->count());
         $this->assertEquals(
-            'should not depend on these namespaces: myNamespace because we want to add this rule for our software',
-            $notDependOnClasses->describe($classDescription, $because)->toString()
+            'depends on myNamespace\Banana, but should not depend on these namespaces: myNamespace because we want to add this rule for our software',
+            $violations->get(0)->getError()
         );
     }
 
@@ -60,8 +60,8 @@ class NotDependsOnTheseNamespacesTest extends TestCase
 
         self::assertCount(1, $violations);
         $this->assertEquals(
-            'should not depend on these namespaces: myNamespace because we want to add this rule for our software',
-            $notDependOnClasses->describe($classDescription, $because)->toString()
+            'depends on myNamespace\Banana, but should not depend on these namespaces: myNamespace because we want to add this rule for our software',
+            $violations->get(0)->getError()
         );
     }
 
@@ -80,8 +80,8 @@ class NotDependsOnTheseNamespacesTest extends TestCase
 
         self::assertEquals(2, $violations->count());
         $this->assertEquals(
-            'should not depend on these namespaces: myNamespace because we want to add this rule for our software',
-            $notDependOnClasses->describe($classDescription, $because)->toString()
+            'depends on myNamespace\Banana, but should not depend on these namespaces: myNamespace because we want to add this rule for our software',
+            $violations->get(0)->getError()
         );
     }
 }

--- a/tests/Unit/Expressions/ViolationDescriptionTest.php
+++ b/tests/Unit/Expressions/ViolationDescriptionTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Expressions;
+
+use Arkitect\Expression\Description;
+use Arkitect\Rules\ViolationMessage;
+use PHPUnit\Framework\TestCase;
+
+class ViolationDescriptionTest extends TestCase
+{
+    public function test_it_should_just_return_expression_description_when_self_explanatory(): void
+    {
+        $expressionDescription = new Description('should not', 'just cause');
+        $description = ViolationMessage::selfExplanatory($expressionDescription);
+        self::assertEquals($expressionDescription->toString(), $description->toString());
+    }
+
+    public function test_it_should_prepend_description_when_present(): void
+    {
+        $expressionDescription = new Description('should not', 'reasons');
+        $description = ViolationMessage::withDescription($expressionDescription, 'it does something');
+        self::assertEquals('it does something, but should not because reasons', $description->toString());
+    }
+}

--- a/tests/Unit/Rules/ConstraintsTest.php
+++ b/tests/Unit/Rules/ConstraintsTest.php
@@ -10,6 +10,7 @@ use Arkitect\Expression\Description;
 use Arkitect\Expression\Expression;
 use Arkitect\Rules\Constraints;
 use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +21,7 @@ class ConstraintsTest extends TestCase
         $trueExpression = new class() implements Expression {
             public function describe(ClassDescription $theClass, string $because): Description
             {
-                return new Description('');
+                return new Description('', '');
             }
 
             public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
@@ -54,7 +55,7 @@ class ConstraintsTest extends TestCase
             {
                 $violation = Violation::create(
                     $theClass->getFQCN(),
-                    $this->describe($theClass, $because)->toString()
+                    ViolationMessage::selfExplanatory($this->describe($theClass, $because))
                 );
 
                 $violations->add($violation);

--- a/tests/Unit/Rules/RuleCheckerTest.php
+++ b/tests/Unit/Rules/RuleCheckerTest.php
@@ -67,7 +67,7 @@ class FakeRule implements ArchRule
 {
     public function check(ClassDescription $classDescription, Violations $violations): void
     {
-        $violations->add(Violation::create('fqcn', 'error'));
+        $violations->add(new Violation('fqcn', 'error'));
     }
 }
 

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -63,10 +63,10 @@ class ViolationsTest extends TestCase
 
         $this->violationStore->add($violation);
         $expected = '
-App\Controller\ProductController violates rules
+App\Controller\ProductController has 1 violations
   should implement ContainerInterface
 
-App\Controller\Foo violates rules
+App\Controller\Foo has 1 violations
   should have name end with Controller
 ';
 

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -25,10 +25,9 @@ class ViolationsTest extends TestCase
         $this->violationData = 'violation';
 
         $this->violationStore = new Violations();
-        $this->violation = Violation::create(
+        $this->violation = new Violation(
             'App\Controller\ProductController',
-            'should implement ContainerInterface',
-            1
+            'should implement ContainerInterface'
         );
         $this->violationStore->add($this->violation);
     }
@@ -47,10 +46,9 @@ class ViolationsTest extends TestCase
 
     public function test_count(): void
     {
-        $violation = Violation::create(
+        $violation = new Violation(
             'App\Controller\Shop',
-            'should have name end with Controller',
-            2
+            'should have name end with Controller'
         );
         $this->violationStore->add($violation);
         $this->assertEquals(2, $this->violationStore->count());
@@ -58,10 +56,9 @@ class ViolationsTest extends TestCase
 
     public function test_to_string(): void
     {
-        $violation = Violation::create(
+        $violation = new Violation(
             'App\Controller\Foo',
-            'should have name end with Controller',
-            3
+            'should have name end with Controller'
         );
 
         $this->violationStore->add($violation);


### PR DESCRIPTION
- Added ViolationDescription, as input for a Violation
- Added a description to the ViolationDescription
  - Only for Expressions where it made sense