### PR TITLE
fix bug when a wrong composer.json was used to read the version number

### DIFF
--- a/src/CLI/Version.php
+++ b/src/CLI/Version.php
@@ -6,7 +6,6 @@ namespace Arkitect\CLI;
 
 class Version
 {
-
     public static function get(): string
     {
         $pharPath = \Phar::running();
@@ -14,7 +13,7 @@ class Version
         if ($pharPath) {
             $content = file_get_contents("$pharPath/composer.json");
         } else {
-            $phparkitectRootPath = __DIR__."/../../";
+            $phparkitectRootPath = __DIR__.'/../../';
             $content = file_get_contents($phparkitectRootPath.'composer.json');
         }
 

--- a/src/CLI/Version.php
+++ b/src/CLI/Version.php
@@ -6,13 +6,6 @@ namespace Arkitect\CLI;
 
 class Version
 {
-    private const COMPOSER_PATHS = [
-        'composer.json',
-        '../composer.json',
-        '../../composer.json',
-        '../../../composer.json',
-        './vendor/phparkitect/phparkitect/composer.json',
-    ];
 
     public static function get(): string
     {
@@ -20,22 +13,13 @@ class Version
 
         if ($pharPath) {
             $content = file_get_contents("$pharPath/composer.json");
-            $composerData = json_decode($content, true);
-
-            return $composerData['version'] ?? 'UNKNOWN';
+        } else {
+            $phparkitectRootPath = __DIR__."/../../";
+            $content = file_get_contents($phparkitectRootPath.'composer.json');
         }
 
-        foreach (self::COMPOSER_PATHS as $composerPath) {
-            if (!file_exists($composerPath)) {
-                continue;
-            }
+        $composerData = json_decode($content, true);
 
-            $content = file_get_contents($composerPath);
-            $composerData = json_decode($content, true);
-
-            return $composerData['version'] ?? 'UNKNOWN';
-        }
-
-        return 'UNKNOWN';
+        return $composerData['version'] ?? 'UNKNOWN';
     }
 }


### PR DESCRIPTION
There was an error in showing the version number when phparkitect is installed via composer.

You can reproduce the bug running https://github.com/phparkitect/arkitect-demo .

![Schermata del 2022-08-18 11-22-11](https://user-images.githubusercontent.com/5879/185360386-7e69bec8-0355-4e6b-b874-3f07f6549fad.png)

Now it should work in all cases.