### PR TITLE
added filter option to run a specific rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,16 @@ phparkitect check --config=/project/yourConfigFile.php
 ```
 * `--target-php-version`: With this parameter, you can specify which PHP version should use the parser. This can be useful to debug problems and to understand if there are problems with a different PHP version.
 Supported PHP versions are: 7.1, 7.2, 7.3, 7.4, 8.0, 8.1
- * `--stop-on-failure`: With this option the process will end immediately after the first violation.
+* `--stop-on-failure`: With this option the process will end immediately after the first violation.
+* `--filter`: With this option you can run a specific rule with the same name example: `--filter=myRule`.
+To use this filter you can give a name to your rule like this:
+```php
+$rules['myRule'] = Rule::allClasses()
+    ->except('App\Controller\FolderController\*')
+    ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+    ->should(new HaveNameMatching('*Controller'))
+    ->because('we want uniform naming');
+```
 
 # Integrations
 

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -32,6 +32,8 @@ class Check extends Command
 
     private const ERROR_CODE = 1;
 
+    private const RULE_FILTER = 'filter';
+
     public function __construct()
     {
         parent::__construct('check');
@@ -59,6 +61,12 @@ class Check extends Command
                 's',
                 InputOption::VALUE_NONE,
                 'Stop on failure'
+            )
+            ->addOption(
+                self::RULE_FILTER,
+                'r',
+                InputOption::VALUE_OPTIONAL,
+                'Filter a specific rule by name'
             );
     }
 
@@ -86,7 +94,9 @@ class Check extends Command
 
             $this->readRules($config, $rulesFilename);
 
-            $runner = new Runner($stopOnFailure);
+            /** @var string|null $ruleFilter */
+            $ruleFilter = $input->getOption(self::RULE_FILTER);
+            $runner = new Runner($stopOnFailure, $ruleFilter);
             try {
                 $runner->run($config, $progress, $targetPhpVersion);
             } catch (FailOnFirstViolationException $e) {

--- a/src/CLI/Config.php
+++ b/src/CLI/Config.php
@@ -5,7 +5,6 @@ namespace Arkitect\CLI;
 
 use Arkitect\ClassSet;
 use Arkitect\ClassSetRules;
-use Arkitect\Rules\DSL\ArchRule;
 
 class Config
 {
@@ -17,15 +16,37 @@ class Config
         $this->classSetRules = [];
     }
 
-    public function add(ClassSet $classSet, ArchRule ...$rules): self
+    public function add(ClassSet $classSet, array $rules): self
     {
-        $this->classSetRules[] = ClassSetRules::create($classSet, ...$rules);
+        $this->classSetRules[] = ClassSetRules::create($classSet, $rules);
 
         return $this;
     }
 
-    public function getClassSetRules(): array
+    public function getClassSetRules(?string $ruleFilter = null): array
     {
+        if (null !== $ruleFilter) {
+            return $this->filterRuleIntoClassSetRules($ruleFilter);
+        }
+
+        return $this->classSetRules;
+    }
+
+    private function filterRuleIntoClassSetRules(string $ruleFilter): array
+    {
+        /** @var ClassSetRules $classSetRules */
+        foreach ($this->classSetRules as $index => $classSetRules) {
+            $rule = $classSetRules->getRulesByName($ruleFilter);
+            if (null === $rule) {
+                unset($this->classSetRules[$index]);
+                continue;
+            }
+
+            $ruleFiltered = [];
+            $ruleFiltered[$ruleFilter] = $rule;
+            $this->classSetRules[$index] = ClassSetRules::create($classSetRules->getClassSet(), $ruleFiltered);
+        }
+
         return $this->classSetRules;
     }
 }

--- a/src/CLI/Runner.php
+++ b/src/CLI/Runner.php
@@ -21,11 +21,14 @@ class Runner
 
     /** @var ParsingErrors */
     private $parsingErrors;
+    /** @var string|null */
+    private $ruleFilter;
 
-    public function __construct(bool $stopOnFailure = false)
+    public function __construct(bool $stopOnFailure = false, ?string $ruleFilter = null)
     {
         $this->violations = new Violations($stopOnFailure);
         $this->parsingErrors = new ParsingErrors();
+        $this->ruleFilter = $ruleFilter;
     }
 
     public function run(Config $config, Progress $progress, TargetPhpVersion $targetPhpVersion): void
@@ -34,7 +37,7 @@ class Runner
         $fileParser = FileParserFactory::createFileParser($targetPhpVersion);
 
         /** @var ClassSetRules $classSetRule */
-        foreach ($config->getClassSetRules() as $classSetRule) {
+        foreach ($config->getClassSetRules($this->ruleFilter) as $classSetRule) {
             $progress->startFileSetAnalysis($classSetRule->getClassSet());
 
             $this->check($classSetRule, $progress, $fileParser, $this->violations, $this->parsingErrors);

--- a/src/ClassSetRules.php
+++ b/src/ClassSetRules.php
@@ -15,15 +15,15 @@ class ClassSetRules
      */
     private $rules;
 
-    private function __construct(ClassSet $classSet, ArchRule ...$rules)
+    private function __construct(ClassSet $classSet, array $rules)
     {
         $this->classSet = $classSet;
         $this->rules = $rules;
     }
 
-    public static function create(ClassSet $classSet, ArchRule ...$rules): self
+    public static function create(ClassSet $classSet, array $rules): self
     {
-        return new self($classSet, ...$rules);
+        return new self($classSet, $rules);
     }
 
     public function getClassSet(): ClassSet
@@ -34,5 +34,10 @@ class ClassSetRules
     public function getRules(): array
     {
         return $this->rules;
+    }
+
+    public function getRulesByName(string $ruleName): ?ArchRule
+    {
+        return $this->rules[$ruleName] ?? null;
     }
 }

--- a/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
+++ b/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
@@ -50,7 +50,7 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
     protected function matches(/** @var $rule ArchRule */ $other): bool
     {
         $this->runner->check(
-            ClassSetRules::create($this->classSet, $other),
+            ClassSetRules::create($this->classSet, [$other]),
             new VoidProgress(),
             $this->fileparser,
             $this->violations,

--- a/tests/E2E/Cli/phparkitect.php
+++ b/tests/E2E/Cli/phparkitect.php
@@ -30,5 +30,5 @@ return static function (Config $config): void {
         ->because('we want protect our domain');
 
     $config
-        ->add($mvc_class_set, ...[$rule_1, $rule_2, $rule_3]);
+        ->add($mvc_class_set, [$rule_1, $rule_2, $rule_3]);
 };

--- a/tests/E2E/Smoke/phparkitect.php
+++ b/tests/E2E/Smoke/phparkitect.php
@@ -29,5 +29,5 @@ return static function (Config $config): void {
         ->because('we want protect our domain');
 
     $config
-        ->add($mvc_class_set, ...[$rule_1, $rule_2, $rule_3]);
+        ->add($mvc_class_set, [$rule_1, $rule_2, $rule_3]);
 };

--- a/tests/E2E/_fixtures/configMvc.php
+++ b/tests/E2E/_fixtures/configMvc.php
@@ -29,5 +29,5 @@ return static function (Config $config): void {
         ->because('we want protect our domain');
 
     $config
-        ->add($mvc_class_set, ...[$rule_1, $rule_2, $rule_3]);
+        ->add($mvc_class_set, [$rule_1, $rule_2, $rule_3]);
 };

--- a/tests/E2E/_fixtures/configMvcForYieldBug.php
+++ b/tests/E2E/_fixtures/configMvcForYieldBug.php
@@ -17,5 +17,5 @@ return static function (Config $config): void {
         ->because('all controllers should be end name with Controller');
 
     $config
-        ->add($mvc_class_set, ...[$rule_1]);
+        ->add($mvc_class_set, [$rule_1]);
 };

--- a/tests/E2E/_fixtures/configMvcWithoutErrors.php
+++ b/tests/E2E/_fixtures/configMvcWithoutErrors.php
@@ -18,5 +18,5 @@ return static function (Config $config): void {
         ->because('all services should be end name with Service');
 
     $config
-        ->add($mvc_class_set, ...[$rule_1]);
+        ->add($mvc_class_set, [$rule_1]);
 };

--- a/tests/Unit/ClassSetRulesTest.php
+++ b/tests/Unit/ClassSetRulesTest.php
@@ -14,25 +14,60 @@ use PHPUnit\Framework\TestCase;
 
 class ClassSetRulesTest extends TestCase
 {
-    public function test_create_class_set_rules_correctly(): void
-    {
-        $classSet = ClassSet::fromDir(__DIR__.'/../E2E/fixtures/happy_island');
+    /** @var ClassSet */
+    private $classSet;
+    /** @var \Arkitect\Rules\DSL\ArchRule */
+    private $rule_1;
+    /** @var \Arkitect\Rules\DSL\ArchRule */
+    private $rule_2;
 
-        $rule_1 = Rule::allClasses()
+    protected function setUp(): void
+    {
+        $this->classSet = ClassSet::fromDir(__DIR__.'/../E2E/fixtures/happy_island');
+
+        $this->rule_1 = Rule::allClasses()
             ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
             ->should(new Implement('ContainerAwareInterface'))
             ->because('all controllers should be container aware');
 
-        $rule_2 = Rule::allClasses()
+        $this->rule_2 = Rule::allClasses()
             ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
             ->should(new HaveNameMatching('*Controller'))
             ->because('we want uniform naming');
+    }
 
-        $rules = [$rule_1, $rule_2];
+    public function test_create_class_set_rules_correctly(): void
+    {
+        $rules = [$this->rule_1, $this->rule_2];
 
-        $classSetRules = ClassSetRules::create($classSet, ...$rules);
+        $classSetRules = ClassSetRules::create($this->classSet, $rules);
 
-        $this->assertEquals($classSet, $classSetRules->getClassSet());
+        $this->assertEquals($this->classSet, $classSetRules->getClassSet());
         $this->assertEquals($rules, $classSetRules->getRules());
+    }
+
+    public function test_filter_rules(): void
+    {
+        $rules = [
+            'foo' => $this->rule_1,
+            'bar' => $this->rule_2,
+        ];
+
+        $classSetRules = ClassSetRules::create($this->classSet, $rules);
+
+        $this->assertEquals($this->rule_1, $classSetRules->getRulesByName('foo'));
+        $this->assertNull($classSetRules->getRulesByName('notExistingRule'));
+    }
+
+    public function test_filter_rules_return_null_if_rule_not_exists(): void
+    {
+        $rules = [
+            'foo' => $this->rule_1,
+            'bar' => $this->rule_2,
+        ];
+
+        $classSetRules = ClassSetRules::create($this->classSet, $rules);
+
+        $this->assertNull($classSetRules->getRulesByName('notExistingRule'));
     }
 }

--- a/tests/Unit/Rules/RuleCheckerTest.php
+++ b/tests/Unit/Rules/RuleCheckerTest.php
@@ -28,7 +28,7 @@ class RuleCheckerTest extends TestCase
         $runner = new Runner();
 
         $runner->check(
-            ClassSetRules::create(new FakeClassSet(), ...[$rule]),
+            ClassSetRules::create(new FakeClassSet(), [$rule]),
             new VoidProgress(),
             $fileParser,
             $violations,


### PR DESCRIPTION
In this PR I added the option to filter a specific rule.
In this step, the rule name must be the same as the filter.
I remove the spread operator to allow string keys for our rules.

Future steps:
* using a specific collection for our rules instead of an array
* allows filtering multiple rules like: `--filter=controller` can filter these: `controller_extends`,  `controller_rule_2` ecc.