### PR TITLE
Handle attributes on enums (PHP8.1)

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -125,6 +125,13 @@ class FileVisitor extends NodeVisitorAbstract
             $this->classDescriptionBuilder = ClassDescriptionBuilder::create(
                 $node->namespacedName->toCodeString()
             );
+
+            foreach ($node->attrGroups as $attributeGroup) {
+                foreach ($attributeGroup->attrs as $attribute) {
+                    $this->classDescriptionBuilder
+                        ->addAttribute($attribute->name->toString(), $attribute->getLine());
+                }
+            }
         }
 
         if (null !== $this->classDescriptionBuilder && null !== $node->getDocComment()) {

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -450,6 +450,40 @@ EOF;
         $this->assertCount(1, $violations);
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function test_should_parse_enum_attributes(): void
+    {
+        $code = <<< 'EOF'
+<?php
+namespace Root\Cars;
+use Bar\FooAttr;
+#[FooAttr('bar')]
+#[Baz]
+enum Enum
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
+EOF;
+
+        $fp = FileParserFactory::createFileParser(TargetPhpVersion::create('8.1'));
+        $fp->parse($code, 'relativePathName');
+
+        $cd = $fp->getClassDescriptions();
+
+        self::assertEquals(
+            [
+                FullyQualifiedClassName::fromString('Bar\\FooAttr'),
+                FullyQualifiedClassName::fromString('Root\\Cars\\Baz'),
+            ],
+            $cd[0]->getAttributes()
+        );
+    }
+
     public function test_it_parse_docblocks(): void
     {
         $code = <<< 'EOF'


### PR DESCRIPTION
# Description
Just as with classes, PHPArkitect should handle attributes for enums as well, not resulting in a violation when attributes are present in the enum.

More information in the issue https://github.com/phparkitect/arkitect/issues/306

## Changes
- [x] Handle attributes for enums as well in `FileVisitor`