### PR TITLE
Fix bug with typed properties and scalar types (#308)

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -149,6 +149,10 @@ class FileVisitor extends NodeVisitorAbstract
                 return;
             }
 
+            if ($this->isScalarType($node->type->toString())) {
+                return;
+            }
+
             $this->classDescriptionBuilder->addDependency(new ClassDependency($node->type->toString(), $node->getLine()));
         }
 
@@ -219,5 +223,10 @@ class FileVisitor extends NodeVisitorAbstract
 
         $this->classDescriptionBuilder
             ->addDependency(new ClassDependency($node->type->toString(), $node->getLine()));
+    }
+
+    private function isScalarType(string $typeName): bool
+    {
+        return \in_array($typeName, ['bool', 'int', 'float', 'string']);
     }
 }

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -551,4 +551,33 @@ EOF;
 
         $this->assertCount(1, $violations);
     }
+
+    public function test_it_parse_scalar_typed_property(): void
+    {
+        $code = <<< 'EOF'
+<?php
+namespace MyProject\AppBundle\Application;
+
+class ApplicationLevelDto
+{
+    public bool $fooBool;
+    public int $fooInt;
+    public float $fooFloat;
+    public string $fooString;
+}
+EOF;
+
+        /** @var FileParser $fp */
+        $fp = FileParserFactory::createFileParser(TargetPhpVersion::create('8.1'));
+        $fp->parse($code, 'relativePathName');
+
+        $cd = $fp->getClassDescriptions();
+
+        $violations = new Violations();
+
+        $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('MyProject\AppBundle\Application');
+        $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
+
+        $this->assertCount(0, $violations);
+    }
 }


### PR DESCRIPTION
This fix the bug reported by @mmenozi on issue (#308) about scalar types in typed properties. With this fix scalar types will be not detected as dependencies.