### PR TITLE
Add baseline feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,21 +60,33 @@ By default, a progress bar will show the status of the ongoing analysis.
 
 ### Using a baseline file
 
-If there are a lot of violations in your codebase and you can't at the moment fix them, 
+If there are a lot of violations in your codebase and you can't fix them now, 
 you can use the baseline feature to instruct the tool to ignore past violations.
 
-To create a baseline file, run the `check` command with the `set-baseline` parameter as follows:
+To create a baseline file, run the `check` command with the `generate-baseline` parameter as follows:
 
+```
+phparkitect check --generate-baseline
+```
+This will create a `phparkitect-baseline.json`, if you want a different file name you can do it with:
 ```
 phparkitect check --generate-baseline=my-baseline.json
 ```
 
 It will produce a json file with the current list of violations.  
 
-To instruct the tool to use the baseline file, run the `check` command with the `use-baseline` parameter as follows:
+If is present a baseline file with the default name will be used automatically.
+
+To use a different baseline file, run the `check` command with the `use-baseline` parameter as follows:
 
 ```
 phparkitect check --use-baseline=my-baseline.json
+```
+
+To avoid using the default baseline file, you can use the `skip-baseline` option:
+
+```
+phparkitect check --skip-baseline
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ phparkitect check --config=/project/yourConfigFile.php
 
 By default, a progress bar will show the status of the ongoing analysis.
 
+### Using a baseline file
+
+If there are a lot of violations in your codebase and you can't at the moment fix them, 
+you can use the baseline feature to instruct the tool to ignore past violations.
+
+To create a baseline file, run the `check` command with the `set-baseline` parameter as follows:
+
+```
+phparkitect check --set-baseline=my-baseline.json
+```
+
+It will produce a json file with the current list of violations.  
+
+To instruct the tool to use the baseline file, run the `check` command with the `use-baseline` parameter as follows:
+
+```
+phparkitect check --use-baseline=my-baseline.json
+```
+
 ## Configuration
 
 Example of configuration file `phparkitect.php`
@@ -92,7 +111,6 @@ return static function (Config $config): void {
         ->add($mvcClassSet, ...$rules);
 };
 ```
-
 
 # Available rules
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ you can use the baseline feature to instruct the tool to ignore past violations.
 To create a baseline file, run the `check` command with the `set-baseline` parameter as follows:
 
 ```
-phparkitect check --set-baseline=my-baseline.json
+phparkitect check --generate-baseline=my-baseline.json
 ```
 
 It will produce a json file with the current list of violations.  

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -24,13 +24,14 @@ class Check extends Command
     private const TARGET_PHP_PARAM = 'target-php-version';
     private const STOP_ON_FAILURE_PARAM = 'stop-on-failure';
     private const USE_BASELINE_PARAM = 'use-baseline';
-    private const GENERATE_BASELINE_PARAM = 'generate-baseline';
+    private const SKIP_BASELINE_PARAM = 'skip-baseline';
 
+    private const GENERATE_BASELINE_PARAM = 'generate-baseline';
     private const DEFAULT_RULES_FILENAME = 'phparkitect.php';
+
     private const DEFAULT_BASELINE_FILENAME = 'phparkitect-baseline.json';
 
     private const SUCCESS_CODE = 0;
-
     private const ERROR_CODE = 1;
 
     public function __construct()
@@ -72,7 +73,13 @@ class Check extends Command
                 self::USE_BASELINE_PARAM,
                 'b',
                 InputOption::VALUE_REQUIRED,
-                'Ignore errors in baseline fine'
+                'Ignore errors in baseline file'
+            )
+            ->addOption(
+                self::SKIP_BASELINE_PARAM,
+                'k',
+                InputOption::VALUE_NONE,
+                'Don\'t use the default baseline'
             );
     }
 
@@ -86,7 +93,9 @@ class Check extends Command
             $verbose = $input->getOption('verbose');
             $stopOnFailure = $input->getOption(self::STOP_ON_FAILURE_PARAM);
             $useBaseline = $input->getOption(self::USE_BASELINE_PARAM);
-            if (!$useBaseline && file_exists(self::DEFAULT_BASELINE_FILENAME)) {
+            $skipBaseline = $input->getOption(self::SKIP_BASELINE_PARAM);
+
+            if (true !== $skipBaseline && !$useBaseline && file_exists(self::DEFAULT_BASELINE_FILENAME)) {
                 $useBaseline = self::DEFAULT_BASELINE_FILENAME;
             }
 

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -109,12 +109,12 @@ class Check extends Command
             $violations = $runner->getViolations();
 
             if ($setBaseline) {
-                file_put_contents($setBaseline, serialize($violations));
+                file_put_contents($setBaseline, json_encode($violations, \JSON_PRETTY_PRINT));
 
                 $output->writeln('Baseline file created');
             } elseif ($useBaseline) {
                 /** @var Violations $baseline */
-                $baseline = unserialize(file_get_contents($useBaseline));
+                $baseline = Violations::fromJson(file_get_contents($useBaseline));
 
                 $violations->remove($baseline);
             }

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -115,8 +115,8 @@ class Check extends Command
             }
             $violations = $runner->getViolations();
 
-            if ($generateBaseline !== false) {
-                if ($generateBaseline === null) {
+            if (false !== $generateBaseline) {
+                if (null === $generateBaseline) {
                     $generateBaseline = self::DEFAULT_BASELINE_FILENAME;
                 }
                 $this->saveBaseline($generateBaseline, $violations);

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -24,7 +24,7 @@ class Check extends Command
     private const TARGET_PHP_PARAM = 'target-php-version';
     private const STOP_ON_FAILURE_PARAM = 'stop-on-failure';
     private const USE_BASELINE_PARAM = 'use-baseline';
-    private const SET_BASELINE_PARAM = 'set-baseline';
+    private const GENERATE_BASELINE_PARAM = 'generate-baseline';
 
     private const DEFAULT_FILENAME = 'phparkitect.php';
 
@@ -61,7 +61,7 @@ class Check extends Command
                 'Stop on failure'
             )
             ->addOption(
-                self::SET_BASELINE_PARAM,
+                self::GENERATE_BASELINE_PARAM,
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Generate a file containing the current errors'
@@ -89,7 +89,7 @@ class Check extends Command
 
                 return self::ERROR_CODE;
             }
-            $setBaseline = $input->getOption(self::SET_BASELINE_PARAM);
+            $generateBaseline = $input->getOption(self::GENERATE_BASELINE_PARAM);
 
             /** @var string|null $phpVersion */
             $phpVersion = $input->getOption('target-php-version');
@@ -113,8 +113,8 @@ class Check extends Command
             }
             $violations = $runner->getViolations();
 
-            if ($setBaseline) {
-                $this->saveBaseline($setBaseline, $violations);
+            if ($generateBaseline) {
+                $this->saveBaseline($generateBaseline, $violations);
 
                 $output->writeln('<info>Baseline file created!</info>');
                 $this->printExecutionTime($output, $startTime);

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -86,6 +86,10 @@ class Check extends Command
             $verbose = $input->getOption('verbose');
             $stopOnFailure = $input->getOption(self::STOP_ON_FAILURE_PARAM);
             $useBaseline = $input->getOption(self::USE_BASELINE_PARAM);
+            if (!$useBaseline && file_exists(self::DEFAULT_BASELINE_FILENAME)) {
+                $useBaseline = self::DEFAULT_BASELINE_FILENAME;
+            }
+
             if ($useBaseline && !file_exists($useBaseline)) {
                 $output->writeln('<error>Baseline file not found.</error>');
 
@@ -125,7 +129,9 @@ class Check extends Command
                 $this->printExecutionTime($output, $startTime);
 
                 return self::SUCCESS_CODE;
-            } elseif ($useBaseline) {
+            }
+
+            if ($useBaseline) {
                 $baseline = $this->loadBaseline($useBaseline);
 
                 $violations->remove($baseline);

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -95,6 +95,8 @@ class Check extends Command
 
                 return self::ERROR_CODE;
             }
+            $output->writeln('<info>Baseline found: '.$useBaseline.'</info>');
+
             $generateBaseline = $input->getOption(self::GENERATE_BASELINE_PARAM);
 
             /** @var string|null $phpVersion */

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -63,13 +63,13 @@ class Check extends Command
             ->addOption(
                 self::SET_BASELINE_PARAM,
                 null,
-                InputOption::VALUE_NONE,
+                InputOption::VALUE_REQUIRED,
                 'Generate a file containing the current errors'
             )
             ->addOption(
                 self::USE_BASELINE_PARAM,
                 'b',
-                InputOption::VALUE_NONE,
+                InputOption::VALUE_REQUIRED,
                 'Ignore errors in baseline fine'
             );
     }
@@ -84,6 +84,11 @@ class Check extends Command
             $verbose = $input->getOption('verbose');
             $stopOnFailure = $input->getOption(self::STOP_ON_FAILURE_PARAM);
             $useBaseline = $input->getOption(self::USE_BASELINE_PARAM);
+            if ($useBaseline && !file_exists($useBaseline)) {
+                $output->writeln('<error>Baseline file not found.</error>');
+
+                return self::ERROR_CODE;
+            }
             $setBaseline = $input->getOption(self::SET_BASELINE_PARAM);
 
             /** @var string|null $phpVersion */

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -114,12 +114,14 @@ class Check extends Command
             $violations = $runner->getViolations();
 
             if ($setBaseline) {
-                file_put_contents($setBaseline, json_encode($violations, \JSON_PRETTY_PRINT));
+                $this->saveBaseline($setBaseline, $violations);
 
-                $output->writeln('Baseline file created');
+                $output->writeln('<info>Baseline file created!</info>');
+                $this->printExecutionTime($output, $startTime);
+
+                return self::SUCCESS_CODE;
             } elseif ($useBaseline) {
-                /** @var Violations $baseline */
-                $baseline = Violations::fromJson(file_get_contents($useBaseline));
+                $baseline = $this->loadBaseline($useBaseline);
 
                 $violations->remove($baseline);
             }
@@ -178,6 +180,16 @@ class Check extends Command
         $executionTime = number_format($endTime - $startTime, 2);
 
         $output->writeln('<info>Execution time: '.$executionTime."s</info>\n");
+    }
+
+    private function loadBaseline(string $filename): Violations
+    {
+        return Violations::fromJson(file_get_contents($filename));
+    }
+
+    private function saveBaseline(string $filename, Violations $violations): void
+    {
+        file_put_contents($filename, json_encode($violations, \JSON_PRETTY_PRINT));
     }
 
     private function getConfigFilename(InputInterface $input): string

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -26,7 +26,8 @@ class Check extends Command
     private const USE_BASELINE_PARAM = 'use-baseline';
     private const GENERATE_BASELINE_PARAM = 'generate-baseline';
 
-    private const DEFAULT_FILENAME = 'phparkitect.php';
+    private const DEFAULT_RULES_FILENAME = 'phparkitect.php';
+    private const DEFAULT_BASELINE_FILENAME = 'phparkitect-baseline.json';
 
     private const SUCCESS_CODE = 0;
 
@@ -62,9 +63,10 @@ class Check extends Command
             )
             ->addOption(
                 self::GENERATE_BASELINE_PARAM,
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Generate a file containing the current errors'
+                'g',
+                InputOption::VALUE_OPTIONAL,
+                'Generate a file containing the current errors',
+                false
             )
             ->addOption(
                 self::USE_BASELINE_PARAM,
@@ -113,10 +115,13 @@ class Check extends Command
             }
             $violations = $runner->getViolations();
 
-            if ($generateBaseline) {
+            if ($generateBaseline !== false) {
+                if ($generateBaseline === null) {
+                    $generateBaseline = self::DEFAULT_BASELINE_FILENAME;
+                }
                 $this->saveBaseline($generateBaseline, $violations);
 
-                $output->writeln('<info>Baseline file created!</info>');
+                $output->writeln('<info>Baseline file \''.$generateBaseline.'\'created!</info>');
                 $this->printExecutionTime($output, $startTime);
 
                 return self::SUCCESS_CODE;
@@ -197,7 +202,7 @@ class Check extends Command
         $filename = $input->getOption(self::CONFIG_FILENAME_PARAM);
 
         if (null === $filename) {
-            $filename = self::DEFAULT_FILENAME;
+            $filename = self::DEFAULT_RULES_FILENAME;
         }
 
         Assert::file($filename, 'Config file not found');

--- a/src/Rules/Violation.php
+++ b/src/Rules/Violation.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Rules;
 
-class Violation
+class Violation implements \JsonSerializable
 {
     /** @var string */
     private $fqcn;
@@ -45,5 +45,15 @@ class Violation
     public function getLine(): ?int
     {
         return $this->line;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+
+    public static function fromJson(array $json): self
+    {
+        return new self($json['fqcn'], $json['error'], $json['line']);
     }
 }

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -92,4 +92,15 @@ class Violations implements \IteratorAggregate, \Countable
     {
         return $this->violations;
     }
+
+    public function remove(self $violations): void
+    {
+        $this->violations = array_udiff(
+            $this->violations,
+            $violations->violations,
+            function (Violation $a, Violation $b): int {
+                return $a == $b ? 0 : 1;
+            }
+        );
+    }
 }

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -7,7 +7,7 @@ namespace Arkitect\Rules;
 use Arkitect\Exceptions\FailOnFirstViolationException;
 use Arkitect\Exceptions\IndexNotFoundException;
 
-class Violations implements \IteratorAggregate, \Countable
+class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
 {
     /**
      * @var Violation[]
@@ -22,6 +22,19 @@ class Violations implements \IteratorAggregate, \Countable
     {
         $this->violations = [];
         $this->stopOnFailure = $stopOnFailure;
+    }
+
+    public static function fromJson(string $json): self
+    {
+        $json = json_decode($json, true);
+
+        $instance = new self($json['stopOnFailure']);
+
+        $instance->violations = array_map(function (array $json): Violation {
+            return Violation::fromJson($json);
+        }, $json['violations']);
+
+        return $instance;
     }
 
     public function add(Violation $violation): void
@@ -102,5 +115,10 @@ class Violations implements \IteratorAggregate, \Countable
                 return $a == $b ? 0 : 1;
             }
         );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
     }
 }

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -14,6 +14,16 @@ class CheckCommandTest extends TestCase
 
     const ERROR_CODE = 1;
 
+    /** @var string */
+    private $baselineFilename = 'my-baseline.json';
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->baselineFilename)) {
+            unlink($this->baselineFilename);
+        }
+    }
+
     public function test_app_returns_error_with_multiple_violations(): void
     {
         $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvc.php');
@@ -88,16 +98,11 @@ App\Controller\Foo has 1 violations
 
     public function test_baseline(): void
     {
-        $baselineFilename = 'my-baseline.json';
         $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
 
         // Produce the baseline
 
-        $cmdTester = $this->runCheck($configFilePath, null, null, $baselineFilename);
-
-        $expectedErrors = 'Baseline file created';
-
-        $this->assertCheckHasErrors($cmdTester, $expectedErrors);
+        $this->runCheck($configFilePath, null, null, $this->baselineFilename);
 
         // Check it detects error if baseline is not used
 
@@ -107,11 +112,9 @@ App\Controller\Foo has 1 violations
 
         // Check it ignores error if baseline is used
 
-        $cmdTester = $this->runCheck($configFilePath, null, $baselineFilename);
+        $cmdTester = $this->runCheck($configFilePath, null, $this->baselineFilename);
 
         $this->assertCheckHasSuccess($cmdTester);
-
-        unlink($baselineFilename);
     }
 
     protected function runCheck(

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -88,19 +88,21 @@ App\Controller\Foo has 1 violations
 
     public function test_baseline(): void
     {
+        // Produce the baseline
+
         $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcForYieldBug.php', null, null, 'my-baseline.xml');
 
         $expectedErrors = 'Baseline file created';
 
         $this->assertCheckHasErrors($cmdTester, $expectedErrors);
 
-        // /////////
+        // Check it detects error if baseline is not used
 
         $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcForYieldBug.php', null, null, null);
 
         $this->assertCheckHasErrors($cmdTester);
 
-        // //////////
+        // Check it ignores error if baseline is used
 
         $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcForYieldBug.php', null, 'my-baseline.xml');
 

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -15,7 +15,7 @@ class CheckCommandTest extends TestCase
     const ERROR_CODE = 1;
 
     /** @var string */
-    private $baselineFilename = 'my-baseline.json';
+    private $baselineFilename = __DIR__.'/my-baseline.json';
 
     protected function tearDown(): void
     {
@@ -113,7 +113,6 @@ App\Controller\Foo has 1 violations
         // Check it ignores error if baseline is used
 
         $cmdTester = $this->runCheck($configFilePath, null, $this->baselineFilename);
-
         $this->assertCheckHasSuccess($cmdTester);
     }
 
@@ -121,7 +120,7 @@ App\Controller\Foo has 1 violations
         $configFilePath = null,
         bool $stopOnFailure = null,
         ?string $useBaseline = null,
-        ?string $setBaseline = null
+        ?string $generateBaseline = null
     ): ApplicationTester {
         $input = ['check'];
         if (null !== $configFilePath) {
@@ -133,8 +132,8 @@ App\Controller\Foo has 1 violations
         if (null !== $useBaseline) {
             $input['--use-baseline'] = $useBaseline;
         }
-        if (null !== $setBaseline) {
-            $input['--set-baseline'] = $setBaseline;
+        if (null !== $generateBaseline) {
+            $input['--generate-baseline'] = $generateBaseline;
         }
 
         $app = new PhpArkitectApplication();

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -88,9 +88,12 @@ App\Controller\Foo has 1 violations
 
     public function test_baseline(): void
     {
+        $baselineFilename = 'my-baseline.json';
+        $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
+
         // Produce the baseline
 
-        $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcForYieldBug.php', null, null, 'my-baseline.xml');
+        $cmdTester = $this->runCheck($configFilePath, null, null, $baselineFilename);
 
         $expectedErrors = 'Baseline file created';
 
@@ -98,17 +101,17 @@ App\Controller\Foo has 1 violations
 
         // Check it detects error if baseline is not used
 
-        $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcForYieldBug.php', null, null, null);
+        $cmdTester = $this->runCheck($configFilePath, null, null, null);
 
         $this->assertCheckHasErrors($cmdTester);
 
         // Check it ignores error if baseline is used
 
-        $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcForYieldBug.php', null, 'my-baseline.xml');
+        $cmdTester = $this->runCheck($configFilePath, null, $baselineFilename);
 
         $this->assertCheckHasSuccess($cmdTester);
 
-        unlink('my-baseline.xml');
+        unlink($baselineFilename);
     }
 
     protected function runCheck(

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -86,14 +86,47 @@ App\Controller\Foo has 1 violations
         $this->assertCheckHasErrors($cmdTester, $expectedErrors);
     }
 
-    protected function runCheck($configFilePath = null, bool $stopOnFailure = null): ApplicationTester
+    public function test_baseline(): void
     {
+        $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcForYieldBug.php', null, null, 'my-baseline.xml');
+
+        $expectedErrors = 'Baseline file created';
+
+        $this->assertCheckHasErrors($cmdTester, $expectedErrors);
+
+        // /////////
+
+        $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcForYieldBug.php', null, null, null);
+
+        $this->assertCheckHasErrors($cmdTester);
+
+        // //////////
+
+        $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcForYieldBug.php', null, 'my-baseline.xml');
+
+        $this->assertCheckHasSuccess($cmdTester);
+
+        unlink('my-baseline.xml');
+    }
+
+    protected function runCheck(
+        $configFilePath = null,
+        bool $stopOnFailure = null,
+        ?string $useBaseline = null,
+        ?string $setBaseline = null
+    ): ApplicationTester {
         $input = ['check'];
         if (null !== $configFilePath) {
             $input['--config'] = $configFilePath;
         }
         if (null !== $stopOnFailure) {
             $input['--stop-on-failure'] = true;
+        }
+        if (null !== $useBaseline) {
+            $input['--use-baseline'] = $useBaseline;
+        }
+        if (null !== $setBaseline) {
+            $input['--set-baseline'] = $setBaseline;
         }
 
         $app = new PhpArkitectApplication();
@@ -127,7 +160,7 @@ App\Controller\Foo has 1 violations
 
     protected function assertCheckHasSuccess(ApplicationTester $applicationTester): void
     {
-        $this->assertEquals(self::SUCCESS_CODE, $applicationTester->getStatusCode());
-        $this->assertStringNotContainsString('ERRORS!', $applicationTester->getDisplay());
+        $this->assertEquals(self::SUCCESS_CODE, $applicationTester->getStatusCode(), 'Error code not expected in successful execution');
+        $this->assertStringNotContainsString('ERRORS!', $applicationTester->getDisplay(), 'Error message not expected in successful execution');
     }
 }

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -120,7 +120,7 @@ App\Controller\Foo has 1 violations
         $this->assertCheckHasSuccess($cmdTester);
     }
 
-    public function test_baseline_with_default_filename(): void
+    public function test_baseline_with_default_filename_is_enabled_automatically(): void
     {
         $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
 
@@ -128,15 +128,9 @@ App\Controller\Foo has 1 violations
 
         $this->runCheck($configFilePath, null, null, null);
 
-        // Check it detects error if baseline is not used
-
-        $cmdTester = $this->runCheck($configFilePath, null, null);
-
-        $this->assertCheckHasErrors($cmdTester);
-
         // Check it ignores error if baseline is used
 
-        $cmdTester = $this->runCheck($configFilePath, null, $this->defaultBaselineFilename);
+        $cmdTester = $this->runCheck($configFilePath, null, null);
         $this->assertCheckHasSuccess($cmdTester);
     }
 

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -134,11 +134,24 @@ App\Controller\Foo has 1 violations
         $this->assertCheckHasSuccess($cmdTester);
     }
 
+    public function test_you_can_ignore_the_default_baseline(): void
+    {
+        $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
+
+        // Produce the baseline
+        $this->runCheck($configFilePath, null, null, null);
+
+        // Check it ignores the default baseline
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, true);
+        $this->assertCheckHasErrors($cmdTester);
+    }
+
     protected function runCheck(
         $configFilePath = null,
         bool $stopOnFailure = null,
         ?string $useBaseline = null,
-        $generateBaseline = false
+        $generateBaseline = false,
+        bool $skipBaseline = false
     ): ApplicationTester {
         $input = ['check'];
         if (null !== $configFilePath) {
@@ -149,6 +162,9 @@ App\Controller\Foo has 1 violations
         }
         if (null !== $useBaseline) {
             $input['--use-baseline'] = $useBaseline;
+        }
+        if ($skipBaseline) {
+            $input['--skip-baseline'] = true;
         }
 
         // false = option not set, null = option set but without value, string = option with value


### PR DESCRIPTION
If there are a lot of violations in your codebase and you can't at the moment fix them, 
you can use the baseline feature to instruct the tool to ignore past violations.

To create a baseline file, run the `check` command with the `set-baseline` parameter as follows:

```
phparkitect check --set-baseline=my-baseline.json
```

It will produce a json file with the current list of violations.  

To instruct the tool to use the baseline file, run the `check` command with the `use-baseline` parameter as follows:

```
phparkitect check --use-baseline=my-baseline.json
```


## TODO

- [x] change `--set-baseline` in `--generate-baseline`
- [x] create baseline with a standard filename if is not given
- [x] use baseline file if is present
- [x] prints if a baseline is used
- [x] adds `--skip-baseline` option
- [x] fix documentation