### PR TITLE
Restore support in regex for namespaces and path

### DIFF
--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -14,9 +14,6 @@ class ClassDescription
     /** @var list<FullyQualifiedClassName> */
     private $interfaces;
 
-    /** @var string */
-    private $fullPath;
-
     /** @var ?FullyQualifiedClassName */
     private $extends;
 
@@ -58,15 +55,9 @@ class ClassDescription
         $this->extends = $extends;
         $this->final = $final;
         $this->abstract = $abstract;
-        $this->fullPath = '';
         $this->docBlock = $docBlock;
         $this->attributes = $attributes;
         $this->interface = $interface;
-    }
-
-    public function setFullPath(string $fullPath): void
-    {
-        $this->fullPath = $fullPath;
     }
 
     public static function build(string $FQCN): ClassDescriptionBuilder

--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -87,38 +87,6 @@ class ClassDescription
         return $this->FQCN->toString();
     }
 
-    public function dependsOnClass(string $pattern): bool
-    {
-        $depends = function (ClassDependency $dependency) use ($pattern): bool {
-            return $dependency->getFQCN()->matches($pattern);
-        };
-
-        return (bool) \count(array_filter($this->dependencies, $depends));
-    }
-
-    public function dependsOnNamespace(string $pattern): bool
-    {
-        $depends = function (ClassDependency $dependency) use ($pattern): bool {
-            return $dependency->getFQCN()->namespaceMatches($pattern);
-        };
-
-        return (bool) \count(array_filter($this->dependencies, $depends));
-    }
-
-    public function dependsOn(string $pattern): bool
-    {
-        $depends = function (ClassDependency $dependency) use ($pattern): bool {
-            return $dependency->matches($pattern);
-        };
-
-        return (bool) \count(array_filter($this->dependencies, $depends));
-    }
-
-    public function nameMatches(string $pattern): bool
-    {
-        return $this->FQCN->classMatches($pattern);
-    }
-
     public function namespaceMatches(string $pattern): bool
     {
         return $this->FQCN->matches($pattern);
@@ -133,11 +101,6 @@ class ClassDescription
         }
 
         return false;
-    }
-
-    public function fullPath(): string
-    {
-        return $this->fullPath;
     }
 
     /**

--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -62,7 +62,7 @@ class ClassDescription
 
     public static function build(string $FQCN): ClassDescriptionBuilder
     {
-        $cb = ClassDescriptionBuilder::create();
+        $cb = new ClassDescriptionBuilder();
         $cb->setClassName($FQCN);
 
         return $cb;

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -8,77 +8,31 @@ use Webmozart\Assert\Assert;
 class ClassDescriptionBuilder
 {
     /** @var list<ClassDependency> */
-    private $classDependencies;
+    private $classDependencies = [];
 
     /** @var ?FullyQualifiedClassName */
-    private $FQCN;
+    private $FQCN = null;
 
     /** @var list<FullyQualifiedClassName> */
-    private $interfaces;
+    private $interfaces = [];
 
     /** @var ?FullyQualifiedClassName */
-    private $extend;
-
-    /** @var string */
-    private $filePath;
+    private $extend = null;
 
     /** @var bool */
-    private $final;
+    private $final = false;
 
     /** @var bool */
-    private $abstract;
+    private $abstract = false;
 
     /** @var list<string> */
-    private $docBlock;
+    private $docBlock = [];
 
     /** @var list<FullyQualifiedClassName> */
-    private $attributes;
+    private $attributes = [];
 
     /** @var bool */
-    private $interface;
-
-    /**
-     * @param list<ClassDependency>         $classDependencies
-     * @param list<FullyQualifiedClassName> $interfaces
-     * @param list<FullyQualifiedClassName> $attributes
-     * @param ?FullyQualifiedClassName      $FQCN
-     */
-    private function __construct(
-        ?FullyQualifiedClassName $FQCN,
-        string $filePath,
-        array $classDependencies,
-        array $interfaces,
-        bool $final,
-        bool $abstract,
-        bool $interface,
-        array $docBlock = [],
-        array $attributes = []
-    ) {
-        $this->FQCN = $FQCN;
-        $this->filePath = $filePath;
-        $this->classDependencies = $classDependencies;
-        $this->interfaces = $interfaces;
-        $this->final = $final;
-        $this->abstract = $abstract;
-        $this->docBlock = $docBlock;
-        $this->attributes = $attributes;
-        $this->interface = $interface;
-    }
-
-    public static function create(): self
-    {
-        return new self(
-            null,
-            '',
-            [],
-            [],
-            false,
-            false,
-            false,
-            [],
-            []
-        );
-    }
+    private $interface = false;
 
     public function setClassName(string $FQCN): void
     {
@@ -88,7 +42,6 @@ class ClassDescriptionBuilder
     public function clear(): void
     {
         $this->FQCN = null;
-        $this->filePath = '';
         $this->classDependencies = [];
         $this->interfaces = [];
         $this->final = false;
@@ -96,13 +49,6 @@ class ClassDescriptionBuilder
         $this->docBlock = [];
         $this->attributes = [];
         $this->interface = false;
-    }
-
-    public function setFilePath(string $filePath): self
-    {
-        $this->filePath = $filePath;
-
-        return $this;
     }
 
     public function addInterface(string $FQCN, int $line): self
@@ -132,7 +78,7 @@ class ClassDescriptionBuilder
     {
         Assert::notNull($this->FQCN);
 
-        $cd = new ClassDescription(
+        return new ClassDescription(
             $this->FQCN,
             $this->classDependencies,
             $this->interfaces,
@@ -143,8 +89,6 @@ class ClassDescriptionBuilder
             $this->docBlock,
             $this->attributes
         );
-
-        return $cd;
     }
 
     public function setFinal(bool $final): self

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -143,7 +143,6 @@ class ClassDescriptionBuilder
             $this->docBlock,
             $this->attributes
         );
-        $cd->setFullPath($this->filePath);
 
         return $cd;
     }

--- a/src/Analyzer/FileParserFactory.php
+++ b/src/Analyzer/FileParserFactory.php
@@ -13,7 +13,7 @@ class FileParserFactory
     {
         return new FileParser(
             new NodeTraverser(),
-            new FileVisitor(ClassDescriptionBuilder::create()),
+            new FileVisitor(new ClassDescriptionBuilder()),
             new NameResolver(null, ['parseCustomAnnotations' => $parseCustomAnnotations]),
             $targetPhpVersion
         );

--- a/src/Analyzer/FullyQualifiedClassName.php
+++ b/src/Analyzer/FullyQualifiedClassName.php
@@ -61,5 +61,4 @@ class FullyQualifiedClassName
 
         return new self(new PatternString($fqcn), new PatternString($namespace), new PatternString($className));
     }
-
 }

--- a/src/Analyzer/FullyQualifiedClassName.php
+++ b/src/Analyzer/FullyQualifiedClassName.php
@@ -31,11 +31,6 @@ class FullyQualifiedClassName
         return $this->class->matches($pattern);
     }
 
-    public function namespaceMatches(string $pattern): bool
-    {
-        return $this->namespace->matches($pattern);
-    }
-
     public function matches(string $pattern): bool
     {
         return $this->fqcnString->matches($pattern);
@@ -66,4 +61,5 @@ class FullyQualifiedClassName
 
         return new self(new PatternString($fqcn), new PatternString($namespace), new PatternString($className));
     }
+
 }

--- a/src/Analyzer/PatternString.php
+++ b/src/Analyzer/PatternString.php
@@ -42,14 +42,11 @@ class PatternString
 
     private function containsWildcard(string $pattern): bool
     {
-        $wildcards = ['*', '?', '.', '[', '('];
-        foreach ($wildcards as $wildcard) {
-            if (str_contains($pattern, $wildcard)) {
-                return true;
-            }
-        }
-
-        return false;
+        return
+            str_contains($pattern, '*') ||
+            str_contains($pattern, '?') ||
+            str_contains($pattern, '.') ||
+            str_contains($pattern, '[');
     }
 
     private function startsWithPattern(string $pattern): bool

--- a/src/Analyzer/PatternString.php
+++ b/src/Analyzer/PatternString.php
@@ -30,11 +30,6 @@ class PatternString
         return $this->startsWithPattern($pattern);
     }
 
-    public function explode(string $delimiter): array
-    {
-        return explode($delimiter, $this->value);
-    }
-
     public function toString(): string
     {
         return $this->value;

--- a/src/Analyzer/PatternString.php
+++ b/src/Analyzer/PatternString.php
@@ -42,11 +42,14 @@ class PatternString
 
     private function containsWildcard(string $pattern): bool
     {
-        return
-            str_contains($pattern, '*') ||
-            str_contains($pattern, '?') ||
-            str_contains($pattern, '.') ||
-            str_contains($pattern, '[');
+        $wildcards = ['*', '?', '.', '[', '('];
+        foreach ($wildcards as $wildcard) {
+            if (str_contains($pattern, $wildcard)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function startsWithPattern(string $pattern): bool

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -15,7 +15,7 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_builder_with_dependency_and_interface(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setClassName($FQCN);
 
         $classDependency = new ClassDependency('DepClass', 10);
@@ -34,7 +34,7 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_final_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setFinal(true);
 
@@ -48,7 +48,7 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_not_final_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setFinal(false);
 
@@ -62,7 +62,7 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_abstract_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setAbstract(true);
 
@@ -76,7 +76,7 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_not_abstract_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setAbstract(false);
 
@@ -90,7 +90,7 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_annotated_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->addDocBlock('/**
  * @psalm-immutable

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -111,7 +111,7 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_add_attributes(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->addAttribute('AttrClass', 27);
 
@@ -126,7 +126,7 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_interface(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setInterface(true);
 
@@ -140,7 +140,7 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_not_interface(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setInterface(false);
 

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -123,17 +123,6 @@ class ClassDescriptionBuilderTest extends TestCase
         );
     }
 
-    public function test_it_should_set_file_path(): void
-    {
-        $filePath = 'filePath/filePath2';
-        $classDescriptionBuilder = ClassDescriptionBuilder::create();
-        $classDescriptionBuilder->setClassName('FQCN');
-        $classDescriptionBuilder->setFilePath($filePath);
-
-        $classDescription = $classDescriptionBuilder->get();
-        $this->assertEquals($filePath, $classDescription->fullPath());
-    }
-
     public function test_it_should_create_interface(): void
     {
         $FQCN = 'HappyIsland';

--- a/tests/Unit/Analyzer/ClassDescriptionTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Analyzer;
 
-use Arkitect\Analyzer\ClassDependency;
 use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Analyzer\ClassDescriptionBuilder;
 use PHPUnit\Framework\TestCase;
@@ -17,25 +16,6 @@ class ClassDescriptionTest extends TestCase
     protected function setUp(): void
     {
         $this->builder = ClassDescription::build('Fruit\Banana');
-    }
-
-    public function test_should_return_true_if_name_matches(): void
-    {
-        $cd = $this->builder->get();
-
-        $this->assertTrue($cd->nameMatches('Banana'));
-    }
-
-    public function test_should_return_true_if_there_is_a_dependency(): void
-    {
-        $cd = $this->builder
-            ->addDependency(new ClassDependency('Fruit\Mango', 12))
-            ->addDependency(new ClassDependency('Vegetablus\Radish', 12))
-            ->get();
-
-        $this->assertTrue($cd->dependsOn('Fruit\Mango'));
-        $this->assertTrue($cd->dependsOnClass('F*\Mango'));
-        $this->assertTrue($cd->dependsOnNamespace('Vegetabl*'));
     }
 
     public function test_should_return_true_if_there_class_is_in_namespace(): void

--- a/tests/Unit/Analyzer/FullyQualifiedClassNameTest.php
+++ b/tests/Unit/Analyzer/FullyQualifiedClassNameTest.php
@@ -11,15 +11,15 @@ class FullyQualifiedClassNameTest extends TestCase
     public function patternProvider(): array
     {
         return [
-          ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\Fruits\Banana', true],
-          ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\*\Banana', true],
-          ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables', true],
+            ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\Fruits\Banana', true],
+            ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\*\Banana', true],
+            ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\(Fruits|Greens)\Banana', true],
+            ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables', true],
             ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\\', true],
-
             ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\*', true],
-          ['Food\Vegetables\Fruits\Mango', '', false],
-          ['Food\Veg', 'Food\Vegetables', false],
-          ['Food\Vegetables', 'Food\Veg', false],
+            ['Food\Vegetables\Fruits\Mango', '', false],
+            ['Food\Veg', 'Food\Vegetables', false],
+            ['Food\Vegetables', 'Food\Veg', false],
         ];
     }
 

--- a/tests/Unit/Analyzer/FullyQualifiedClassNameTest.php
+++ b/tests/Unit/Analyzer/FullyQualifiedClassNameTest.php
@@ -11,15 +11,15 @@ class FullyQualifiedClassNameTest extends TestCase
     public function patternProvider(): array
     {
         return [
-            ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\Fruits\Banana', true],
-            ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\*\Banana', true],
-            ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\(Fruits|Greens)\Banana', true],
-            ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables', true],
+          ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\Fruits\Banana', true],
+          ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\*\Banana', true],
+          ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables', true],
             ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\\', true],
+
             ['Food\Vegetables\Fruits\Banana', 'Food\Vegetables\*', true],
-            ['Food\Vegetables\Fruits\Mango', '', false],
-            ['Food\Veg', 'Food\Vegetables', false],
-            ['Food\Vegetables', 'Food\Veg', false],
+          ['Food\Vegetables\Fruits\Mango', '', false],
+          ['Food\Veg', 'Food\Vegetables', false],
+          ['Food\Vegetables', 'Food\Veg', false],
         ];
     }
 

--- a/tests/Unit/Analyzer/PatternStringTest.php
+++ b/tests/Unit/Analyzer/PatternStringTest.php
@@ -21,10 +21,4 @@ class PatternStringTest extends TestCase
         $this->assertTrue($pattern->matches('*This*'));
         $this->assertFalse($pattern->matches('This*'));
     }
-
-    public function test_explode(): void
-    {
-        $pattern = new PatternString('So This Is An Example');
-        $this->assertEquals(['So', 'This', 'Is', 'An', 'Example'], $pattern->explode(' '));
-    }
 }

--- a/tests/Unit/Rules/ConstraintsTest.php
+++ b/tests/Unit/Rules/ConstraintsTest.php
@@ -34,7 +34,7 @@ class ConstraintsTest extends TestCase
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
 
-        $cb = ClassDescriptionBuilder::create();
+        $cb = new ClassDescriptionBuilder();
         $cb->setClassName('Banana');
 
         $expressionStore->checkAll(
@@ -70,7 +70,7 @@ class ConstraintsTest extends TestCase
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
 
-        $cb = ClassDescriptionBuilder::create();
+        $cb = new ClassDescriptionBuilder();
         $cb->setClassName('Banana');
 
         $expressionStore->checkAll(


### PR DESCRIPTION
We thought to permits only unix shell wildcard for defining namespaces.

In the PR #188 we accidentally added the support for some regexes.

With the PR #327 we made the check a little bit more strict, to avoid bug with partial name matching, but broke the support for some regexes #329 .

We have 3 options:

 1 - support both regex and unix wildcard in the same method (this PR fix the problem that we saw now, but I fear there will be a lot more problems in the future)
 2 - support only unix wildcard and remove the support for regexes
 3 - remove the support for unix wildcard and make a major version that uses only regexes

@micheleorselli @AlessandroMinoccheri what do you think?

I am thinking about solution 2...