### PR TITLE
Fix remove violations from baseline

### DIFF
--- a/src/Rules/Violation.php
+++ b/src/Rules/Violation.php
@@ -57,7 +57,7 @@ class Violation implements \JsonSerializable
         return new self($json['fqcn'], $json['error'], $json['line']);
     }
 
-    public function isEqualsTo(Violation $violation): bool
+    public function isEqualsTo(self $violation): bool
     {
         return $this === $violation || ($this->fqcn === $violation->getFqcn()
             && $this->error === $violation->getError()

--- a/src/Rules/Violation.php
+++ b/src/Rules/Violation.php
@@ -56,4 +56,11 @@ class Violation implements \JsonSerializable
     {
         return new self($json['fqcn'], $json['error'], $json['line']);
     }
+
+    public function isEqualsTo(Violation $violation): bool
+    {
+        return $this === $violation || ($this->fqcn === $violation->getFqcn()
+            && $this->error === $violation->getError()
+            && $this->line === $violation->getLine());
+    }
 }

--- a/src/Rules/Violation.php
+++ b/src/Rules/Violation.php
@@ -56,11 +56,4 @@ class Violation implements \JsonSerializable
     {
         return new self($json['fqcn'], $json['error'], $json['line']);
     }
-
-    public function isEqualsTo(self $violation): bool
-    {
-        return $this === $violation || ($this->fqcn === $violation->getFqcn()
-            && $this->error === $violation->getError()
-            && $this->line === $violation->getLine());
-    }
 }

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -108,13 +108,13 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
 
     public function remove(self $violations): void
     {
-        $this->violations = array_udiff(
+        $this->violations = array_values(array_udiff(
             $this->violations,
             $violations->violations,
-            function (Violation $a, Violation $b): int {
-                return $a == $b ? 0 : 1;
+            static function (Violation $a, Violation $b): int {
+                return $a->isEqualsTo($b) ? 0 : -1;
             }
-        );
+        ));
     }
 
     public function jsonSerialize(): array

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -112,7 +112,7 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
             $this->violations,
             $violations->violations,
             static function (Violation $a, Violation $b): int {
-                return $a->isEqualsTo($b) ? 0 : -1;
+                return $a <=> $b;
             }
         ));
     }

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -124,7 +124,7 @@ App\Controller\Foo has 1 violations
 
         $this->assertCount(3, $this->violationStore->toArray());
 
-        $violationsBaseline= new Violations();
+        $violationsBaseline = new Violations();
         $violationsBaseline->add($this->violation);
 
         $this->violationStore->remove($violationsBaseline);

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -107,4 +107,32 @@ App\Controller\Foo has 1 violations
             $violation2,
         ], $this->violationStore->toArray());
     }
+
+    public function test_remove_violations_from_violations(): void
+    {
+        $violation1 = new Violation(
+            'App\Controller\Shop',
+            'should have name end with Controller'
+        );
+        $this->violationStore->add($violation1);
+
+        $violation2 = new Violation(
+            'App\Controller\Shop',
+            'should implement AbstractController'
+        );
+        $this->violationStore->add($violation2);
+
+        $this->assertCount(3, $this->violationStore->toArray());
+
+        $violationsBaseline= new Violations();
+        $violationsBaseline->add($this->violation);
+
+        $this->violationStore->remove($violationsBaseline);
+
+        $this->assertCount(2, $this->violationStore->toArray());
+        $this->assertEquals([
+            $violation1,
+            $violation2,
+        ], $this->violationStore->toArray());
+    }
 }


### PR DESCRIPTION
On a PHP 7.4 project, after define a baseline, if a violation occurs, all violations are showed, the new violations and the violations defined in the baseline instead to show only new violations.

