### PR TITLE
Parsing interfaces and return types

### DIFF
--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -26,6 +26,9 @@ class ClassDescription
     /** @var bool */
     private $abstract;
 
+    /** @var bool */
+    private $interface;
+
     /** @var list<string> */
     private $docBlock;
 
@@ -45,6 +48,7 @@ class ClassDescription
         ?FullyQualifiedClassName $extends,
         bool $final,
         bool $abstract,
+        bool $interface,
         array $docBlock = [],
         array $attributes = []
     ) {
@@ -57,6 +61,7 @@ class ClassDescription
         $this->fullPath = '';
         $this->docBlock = $docBlock;
         $this->attributes = $attributes;
+        $this->interface = $interface;
     }
 
     public function setFullPath(string $fullPath): void
@@ -164,6 +169,11 @@ class ClassDescription
     public function isAbstract(): bool
     {
         return $this->abstract;
+    }
+
+    public function isInterface(): bool
+    {
+        return $this->interface;
     }
 
     public function getDocBlock(): array

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -34,6 +34,9 @@ class ClassDescriptionBuilder
     /** @var list<FullyQualifiedClassName> */
     private $attributes;
 
+    /** @var bool */
+    private $interface;
+
     /**
      * @param list<ClassDependency>         $classDependencies
      * @param list<FullyQualifiedClassName> $interfaces
@@ -47,6 +50,7 @@ class ClassDescriptionBuilder
         array $interfaces,
         bool $final,
         bool $abstract,
+        bool $interface,
         array $docBlock = [],
         array $attributes = []
     ) {
@@ -58,6 +62,7 @@ class ClassDescriptionBuilder
         $this->abstract = $abstract;
         $this->docBlock = $docBlock;
         $this->attributes = $attributes;
+        $this->interface = $interface;
     }
 
     public static function create(): self
@@ -67,6 +72,7 @@ class ClassDescriptionBuilder
             '',
             [],
             [],
+            false,
             false,
             false,
             [],
@@ -89,6 +95,7 @@ class ClassDescriptionBuilder
         $this->abstract = false;
         $this->docBlock = [];
         $this->attributes = [];
+        $this->interface = false;
     }
 
     public function setFilePath(string $filePath): self
@@ -132,6 +139,7 @@ class ClassDescriptionBuilder
             $this->extend,
             $this->final,
             $this->abstract,
+            $this->interface,
             $this->docBlock,
             $this->attributes
         );
@@ -150,6 +158,13 @@ class ClassDescriptionBuilder
     public function setAbstract(bool $abstract): self
     {
         $this->abstract = $abstract;
+
+        return $this;
+    }
+
+    public function setInterface(bool $interface): self
+    {
+        $this->interface = $interface;
 
         return $this;
     }

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -166,6 +166,30 @@ class FileVisitor extends NodeVisitorAbstract
         if ($node instanceof Node\Param) {
             $this->addParamDependency($node);
         }
+
+        if ($node instanceof Node\Stmt\Interface_) {
+            if (null === $node->namespacedName) {
+                return;
+            }
+
+            $this->classDescriptionBuilder->setClassName($node->namespacedName->toCodeString());
+            $this->classDescriptionBuilder->setInterface(true);
+
+            foreach ($node->attrGroups as $attributeGroup) {
+                foreach ($attributeGroup->attrs as $attribute) {
+                    $this->classDescriptionBuilder
+                        ->addAttribute($attribute->name->toString(), $attribute->getLine());
+                }
+            }
+        }
+
+        if ($node instanceof Node\Stmt\ClassMethod) {
+            $returnType = $node->returnType;
+            if ($returnType instanceof Node\Name\FullyQualified) {
+                $this->classDescriptionBuilder
+                  ->addDependency(new ClassDependency($returnType->toCodeString(), $returnType->getLine()));
+            }
+        }
     }
 
     public function getClassDescriptions(): array
@@ -186,6 +210,11 @@ class FileVisitor extends NodeVisitorAbstract
         }
 
         if ($node instanceof Node\Stmt\Enum_) {
+            $this->classDescriptions[] = $this->classDescriptionBuilder->get();
+            $this->classDescriptionBuilder->clear();
+        }
+
+        if ($node instanceof Node\Stmt\Interface_) {
             $this->classDescriptions[] = $this->classDescriptionBuilder->get();
             $this->classDescriptionBuilder->clear();
         }

--- a/src/Expression/ForClasses/Implement.php
+++ b/src/Expression/ForClasses/Implement.php
@@ -29,6 +29,10 @@ class Implement implements Expression
 
     public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
     {
+        if ($theClass->isInterface()) {
+            return;
+        }
+
         $interface = $this->interface;
         $interfaces = $theClass->getInterfaces();
         $implements = function (FullyQualifiedClassName $FQCN) use ($interface): bool {

--- a/src/Expression/ForClasses/NotImplement.php
+++ b/src/Expression/ForClasses/NotImplement.php
@@ -29,6 +29,10 @@ class NotImplement implements Expression
 
     public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
     {
+        if ($theClass->isInterface()) {
+            return;
+        }
+
         $interface = $this->interface;
         $interfaces = $theClass->getInterfaces();
         $implements = function (FullyQualifiedClassName $FQCN) use ($interface): bool {

--- a/tests/E2E/Cli/DebugExpressionCommandTest.php
+++ b/tests/E2E/Cli/DebugExpressionCommandTest.php
@@ -70,6 +70,7 @@ class DebugExpressionCommandTest extends TestCase
         $appTester = $this->createAppTester();
         $appTester->run(['debug:expression', 'expression' => 'NotExtend', 'arguments' => ['NotFound'], '--from-dir' => __DIR__.'/../_fixtures/parse_error']);
         $errorMessage = <<<END
+ContainerAwareInterface
 WARNING: Some files could not be parsed for these errors:
  - Syntax error, unexpected T_STRING, expecting '{' on line 8: Services/CartService.php
 

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -133,4 +133,32 @@ class ClassDescriptionBuilderTest extends TestCase
         $classDescription = $classDescriptionBuilder->get();
         $this->assertEquals($filePath, $classDescription->fullPath());
     }
+
+    public function test_it_should_create_interface(): void
+    {
+        $FQCN = 'HappyIsland';
+        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setInterface(true);
+
+        $classDescription = $classDescriptionBuilder->get();
+
+        $this->assertInstanceOf(ClassDescription::class, $classDescription);
+
+        $this->assertTrue($classDescription->isInterface());
+    }
+
+    public function test_it_should_create_not_interface(): void
+    {
+        $FQCN = 'HappyIsland';
+        $classDescriptionBuilder = ClassDescriptionBuilder::create();
+        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setInterface(false);
+
+        $classDescription = $classDescriptionBuilder->get();
+
+        $this->assertInstanceOf(ClassDescription::class, $classDescription);
+
+        $this->assertFalse($classDescription->isInterface());
+    }
 }

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -669,8 +669,8 @@ EOF;
 
         $violations = new Violations();
 
-        $notHaveDependencyOutsideNamespace = new Implement('Foo\Order');
-        $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
+        $implement = new Implement('Foo\Order');
+        $implement->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
         $this->assertCount(0, $violations, $violations->toString());
     }
@@ -688,6 +688,32 @@ class ApplicationLevelDto
      * @Assert\NotBlank
      */
     public string|null $foo;
+}
+EOF;
+
+        /** @var FileParser $fp */
+        $fp = FileParserFactory::createFileParser(TargetPhpVersion::create('8.1'));
+        $fp->parse($code, 'relativePathName');
+
+        $cd = $fp->getClassDescriptions();
+
+        $violations = new Violations();
+
+        $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('MyProject\AppBundle\Application');
+        $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
+
+        $this->assertCount(1, $violations);
+    }
+
+    public function test_it_parse_interfaces(): void
+    {
+        $code = <<< 'EOF'
+<?php
+namespace MyProject\AppBundle\Application;
+use Doctrine\ORM\QueryBuilder;
+interface BookRepositoryInterface
+{
+    public function getBookList(): QueryBuilder;
 }
 EOF;
 

--- a/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
@@ -23,6 +23,7 @@ class ContainDocBlockLikeTest extends TestCase
             null,
             false,
             false,
+            false,
             ['/**  */myDocBlock with other information']
         );
         $because = 'we want to add this rule for our software';
@@ -47,6 +48,7 @@ class ContainDocBlockLikeTest extends TestCase
             null,
             false,
             false,
+            false,
             ['/**  */myDocBlock with other information']
         );
         $violations = new Violations();
@@ -68,6 +70,7 @@ class ContainDocBlockLikeTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false,
             ['/**  */myDocBlock with other information']

--- a/tests/Unit/Expressions/ForClasses/ExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/ExtendTest.php
@@ -22,6 +22,7 @@ class ExtendTest extends TestCase
             [],
             FullyQualifiedClassName::fromString('My\AnotherClass'),
             false,
+            false,
             false
         );
 
@@ -44,6 +45,7 @@ class ExtendTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false
         );

--- a/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
@@ -23,6 +23,7 @@ class HaveAttributeTest extends TestCase
             null,
             false,
             false,
+            false,
             [],
             [FullyQualifiedClassName::fromString('myAttribute')]
         );
@@ -48,6 +49,7 @@ class HaveAttributeTest extends TestCase
             null,
             false,
             false,
+            false,
             [],
             [FullyQualifiedClassName::fromString('myAttribute')]
         );
@@ -70,6 +72,7 @@ class HaveAttributeTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false,
             [],

--- a/tests/Unit/Expressions/ForClasses/ImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/ImplementTest.php
@@ -23,6 +23,7 @@ class ImplementTest extends TestCase
             [],
             null,
             false,
+            false,
             false
         );
 
@@ -47,6 +48,7 @@ class ImplementTest extends TestCase
             [FullyQualifiedClassName::fromString('foo')],
             null,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -65,6 +67,7 @@ class ImplementTest extends TestCase
             [],
             [FullyQualifiedClassName::fromString('interface')],
             null,
+            false,
             false,
             false
         );
@@ -86,10 +89,32 @@ class ImplementTest extends TestCase
             [FullyQualifiedClassName::fromString('\Foo\Orderable')],
             null,
             false,
+            false,
             false
         );
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, '');
         self::assertEquals(1, $violations->count());
+    }
+
+    public function test_it_should_return_if_is_an_interface(): void
+    {
+        $interface = 'interface';
+
+        $implementConstraint = new Implement($interface);
+        $classDescription = new ClassDescription(
+            FullyQualifiedClassName::fromString('HappyIsland'),
+            [],
+            [],
+            null,
+            false,
+            false,
+            true
+        );
+        $because = 'we want to add this rule for our software';
+
+        $violations = new Violations();
+        $implementConstraint->evaluate($classDescription, $violations, $because);
+        self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
@@ -21,6 +21,7 @@ class IsAbstractTest extends TestCase
             [],
             null,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -42,7 +43,8 @@ class IsAbstractTest extends TestCase
             [],
             null,
             true,
-            true
+            true,
+            false
         );
         $because = 'we want to add this rule for our software';
         $violations = new Violations();

--- a/tests/Unit/Expressions/ForClasses/IsFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsFinalTest.php
@@ -21,6 +21,7 @@ class IsFinalTest extends TestCase
             [],
             null,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -44,6 +45,7 @@ class IsFinalTest extends TestCase
             [],
             null,
             true,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
@@ -21,7 +21,8 @@ class IsNotAbstractTest extends TestCase
             [],
             null,
             true,
-            true
+            true,
+            false
         );
         $because = 'we want to add this rule for our software';
         $violationError = $isAbstract->describe($classDescription, $because)->toString();
@@ -41,6 +42,7 @@ class IsNotAbstractTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false
         );

--- a/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
@@ -21,6 +21,7 @@ class IsNotFinalTest extends TestCase
             [],
             null,
             true,
+            false,
             false
         );
 
@@ -42,6 +43,7 @@ class IsNotFinalTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false
         );

--- a/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
@@ -23,6 +23,7 @@ class NotContainDocBlockLikeTest extends TestCase
             null,
             false,
             false,
+            false,
             ['/**  */myDocBlock with other information']
         );
         $because = 'we want to add this rule for our software';
@@ -47,6 +48,7 @@ class NotContainDocBlockLikeTest extends TestCase
             null,
             false,
             false,
+            false,
             ['/**  */myDocBlock with other information']
         );
         $violations = new Violations();
@@ -68,6 +70,7 @@ class NotContainDocBlockLikeTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false,
             ['/**  */myDocBlock with other information']

--- a/tests/Unit/Expressions/ForClasses/NotExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotExtendTest.php
@@ -22,6 +22,7 @@ class NotExtendTest extends TestCase
             [],
             FullyQualifiedClassName::fromString('My\BaseClass'),
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
@@ -23,6 +23,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
             [],
             null,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -43,6 +44,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
             [],
             null,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -60,6 +62,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
             [],
             null,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -76,6 +79,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
             [new ClassDependency('foo', 100)],
             [],
             null,
+            false,
             false,
             false
         );

--- a/tests/Unit/Expressions/ForClasses/NotImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotImplementTest.php
@@ -23,6 +23,7 @@ class NotImplementTest extends TestCase
             [],
             null,
             false,
+            false,
             false
         );
 
@@ -45,6 +46,7 @@ class NotImplementTest extends TestCase
             [FullyQualifiedClassName::fromString('foo')],
             null,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -64,6 +66,7 @@ class NotImplementTest extends TestCase
             [FullyQualifiedClassName::fromString('interface')],
             null,
             false,
+            false,
             false
         );
 
@@ -78,5 +81,26 @@ class NotImplementTest extends TestCase
             'should not implement '.$interface.' because we want to add this rule for our software',
             $violationError
         );
+    }
+
+    public function test_it_should_return_if_is_an_interface(): void
+    {
+        $interface = 'interface';
+
+        $implementConstraint = new NotImplement($interface);
+        $classDescription = new ClassDescription(
+            FullyQualifiedClassName::fromString('HappyIsland'),
+            [],
+            [],
+            null,
+            false,
+            false,
+            true
+        );
+        $because = 'we want to add this rule for our software';
+
+        $violations = new Violations();
+        $implementConstraint->evaluate($classDescription, $violations, $because);
+        self::assertEquals(0, $violations->count());
     }
 }


### PR DESCRIPTION
This should solve #334 

I added to the `ClassDescription` the property `interface` to understand if the file is an interface or not.
I added to the `FileVisitor` two things that are missing now:
* parsing interfaces
* parsing return types

In another PR we can refactor a little bit the `ClassDescription` adding some default to properties like `interface` to avoid building the class with a lot of mandatory arguments.