### PR TITLE
removed first character from dependencies string if is a backslash

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -187,7 +187,7 @@ class FileVisitor extends NodeVisitorAbstract
             $returnType = $node->returnType;
             if ($returnType instanceof Node\Name\FullyQualified) {
                 $this->classDescriptionBuilder
-                  ->addDependency(new ClassDependency($returnType->toCodeString(), $returnType->getLine()));
+                  ->addDependency(new ClassDependency($returnType->toString(), $returnType->getLine()));
             }
         }
     }

--- a/tests/Unit/Analyzer/FullyQualifiedClassNameTest.php
+++ b/tests/Unit/Analyzer/FullyQualifiedClassNameTest.php
@@ -57,9 +57,10 @@ class FullyQualifiedClassNameTest extends TestCase
 
     public function test_should_have_ns_normalized(): void
     {
-        $fqcn = FullyQualifiedClassName::fromString('\Food\Vegetables\Fruits\Banana');
+        $fqcn = FullyQualifiedClassName::fromString('Food\Vegetables\Fruits\Banana');
 
         $this->assertEquals('Banana', $fqcn->className());
         $this->assertEquals('Food\Vegetables\Fruits', $fqcn->namespace());
+        $this->assertEquals('Food\Vegetables\Fruits\Banana', $fqcn->toString());
     }
 }


### PR DESCRIPTION
This PR should solve #341 
The problem is that: when we get the return type dependencies the string from `$returnType->toCodeString()` (Line 190 FileVisitor.php) starts with a backslash.
The other dependencies are not starting with the backslash, so to standardize our dependencies strings, I decided to remove the first character from the dependencies string if it is a backslash.