### PR TITLE
Add error message for regex

### DIFF
--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -60,7 +60,7 @@ class ClassDescription
         $this->interface = $interface;
     }
 
-    public static function build(string $FQCN): ClassDescriptionBuilder
+    public static function getBuilder(string $FQCN): ClassDescriptionBuilder
     {
         $cb = new ClassDescriptionBuilder();
         $cb->setClassName($FQCN);

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -76,7 +76,7 @@ class ClassDescriptionBuilder
 
     public function get(): ClassDescription
     {
-        Assert::notNull($this->FQCN);
+        Assert::notNull($this->FQCN, 'You must set an FQCN');
 
         return new ClassDescription(
             $this->FQCN,

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -34,11 +34,6 @@ class ClassDescriptionBuilder
     /** @var bool */
     private $interface = false;
 
-    public function setClassName(string $FQCN): void
-    {
-        $this->FQCN = FullyQualifiedClassName::fromString($FQCN);
-    }
-
     public function clear(): void
     {
         $this->FQCN = null;
@@ -49,6 +44,13 @@ class ClassDescriptionBuilder
         $this->docBlock = [];
         $this->attributes = [];
         $this->interface = false;
+    }
+
+    public function setClassName(string $FQCN): self
+    {
+        $this->FQCN = FullyQualifiedClassName::fromString($FQCN);
+
+        return $this;
     }
 
     public function addInterface(string $FQCN, int $line): self
@@ -72,23 +74,6 @@ class ClassDescriptionBuilder
         $this->extend = FullyQualifiedClassName::fromString($FQCN);
 
         return $this;
-    }
-
-    public function build(): ClassDescription
-    {
-        Assert::notNull($this->FQCN, 'You must set an FQCN');
-
-        return new ClassDescription(
-            $this->FQCN,
-            $this->classDependencies,
-            $this->interfaces,
-            $this->extend,
-            $this->final,
-            $this->abstract,
-            $this->interface,
-            $this->docBlock,
-            $this->attributes
-        );
     }
 
     public function setFinal(bool $final): self
@@ -125,5 +110,22 @@ class ClassDescriptionBuilder
         $this->attributes[] = FullyQualifiedClassName::fromString($FQCN);
 
         return $this;
+    }
+
+    public function build(): ClassDescription
+    {
+        Assert::notNull($this->FQCN, 'You must set an FQCN');
+
+        return new ClassDescription(
+            $this->FQCN,
+            $this->classDependencies,
+            $this->interfaces,
+            $this->extend,
+            $this->final,
+            $this->abstract,
+            $this->interface,
+            $this->docBlock,
+            $this->attributes
+        );
     }
 }

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -74,7 +74,7 @@ class ClassDescriptionBuilder
         return $this;
     }
 
-    public function get(): ClassDescription
+    public function build(): ClassDescription
     {
         Assert::notNull($this->FQCN, 'You must set an FQCN');
 

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -205,17 +205,17 @@ class FileVisitor extends NodeVisitorAbstract
     public function leaveNode(Node $node): void
     {
         if ($node instanceof Node\Stmt\Class_ && !$node->isAnonymous()) {
-            $this->classDescriptions[] = $this->classDescriptionBuilder->get();
+            $this->classDescriptions[] = $this->classDescriptionBuilder->build();
             $this->classDescriptionBuilder->clear();
         }
 
         if ($node instanceof Node\Stmt\Enum_) {
-            $this->classDescriptions[] = $this->classDescriptionBuilder->get();
+            $this->classDescriptions[] = $this->classDescriptionBuilder->build();
             $this->classDescriptionBuilder->clear();
         }
 
         if ($node instanceof Node\Stmt\Interface_) {
-            $this->classDescriptions[] = $this->classDescriptionBuilder->get();
+            $this->classDescriptions[] = $this->classDescriptionBuilder->build();
             $this->classDescriptionBuilder->clear();
         }
     }

--- a/src/Analyzer/FullyQualifiedClassName.php
+++ b/src/Analyzer/FullyQualifiedClassName.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Arkitect\Analyzer;
 
+use Arkitect\Exceptions\InvalidPatternException;
+
 class FullyQualifiedClassName
 {
     /** @var PatternString */
@@ -28,11 +30,19 @@ class FullyQualifiedClassName
 
     public function classMatches(string $pattern): bool
     {
+        if ($this->isNotAValidPattern($pattern)) {
+            throw new InvalidPatternException("'$pattern' is not a valid class or namespace pattern. Regex are not allowed, only * and ? wildcard.");
+        }
+
         return $this->class->matches($pattern);
     }
 
     public function matches(string $pattern): bool
     {
+        if ($this->isNotAValidPattern($pattern)) {
+            throw new InvalidPatternException("'$pattern' is not a valid class or namespace pattern. Regex are not allowed, only * and ? wildcard.");
+        }
+
         return $this->fqcnString->matches($pattern);
     }
 
@@ -60,5 +70,10 @@ class FullyQualifiedClassName
         $namespace = implode('\\', $piecesWithoutEmpty);
 
         return new self(new PatternString($fqcn), new PatternString($namespace), new PatternString($className));
+    }
+
+    public function isNotAValidPattern(string $pattern): bool
+    {
+        return 0 === preg_match('/^([A-Za-z]|\\\\|\*|\?)*$/', $pattern);
     }
 }

--- a/src/Exceptions/InvalidPatternException.php
+++ b/src/Exceptions/InvalidPatternException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Exceptions;
+
+class InvalidPatternException extends \RuntimeException
+{
+}

--- a/src/Expression/ForClasses/Extend.php
+++ b/src/Expression/ForClasses/Extend.php
@@ -30,7 +30,7 @@ class Extend implements Expression
     {
         $extends = $theClass->getExtends();
 
-        if (null !== $extends && $extends->toString() === $this->className) {
+        if (null !== $extends && $extends->matches($this->className)) {
             return;
         }
 

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -23,7 +23,7 @@ class ClassDescriptionBuilderTest extends TestCase
         $classDescriptionBuilder->addDependency($classDependency);
         $classDescriptionBuilder->addInterface('InterfaceClass', 10);
 
-        $classDescription = $classDescriptionBuilder->get();
+        $classDescription = $classDescriptionBuilder->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -38,7 +38,7 @@ class ClassDescriptionBuilderTest extends TestCase
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setFinal(true);
 
-        $classDescription = $classDescriptionBuilder->get();
+        $classDescription = $classDescriptionBuilder->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -52,7 +52,7 @@ class ClassDescriptionBuilderTest extends TestCase
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setFinal(false);
 
-        $classDescription = $classDescriptionBuilder->get();
+        $classDescription = $classDescriptionBuilder->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -66,7 +66,7 @@ class ClassDescriptionBuilderTest extends TestCase
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setAbstract(true);
 
-        $classDescription = $classDescriptionBuilder->get();
+        $classDescription = $classDescriptionBuilder->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -80,7 +80,7 @@ class ClassDescriptionBuilderTest extends TestCase
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setAbstract(false);
 
-        $classDescription = $classDescriptionBuilder->get();
+        $classDescription = $classDescriptionBuilder->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -96,7 +96,7 @@ class ClassDescriptionBuilderTest extends TestCase
  * @psalm-immutable
  */');
 
-        $classDescription = $classDescriptionBuilder->get();
+        $classDescription = $classDescriptionBuilder->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -115,7 +115,7 @@ class ClassDescriptionBuilderTest extends TestCase
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->addAttribute('AttrClass', 27);
 
-        $classDescription = $classDescriptionBuilder->get();
+        $classDescription = $classDescriptionBuilder->build();
 
         self::assertEquals(
             [FullyQualifiedClassName::fromString('AttrClass')],
@@ -130,7 +130,7 @@ class ClassDescriptionBuilderTest extends TestCase
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setInterface(true);
 
-        $classDescription = $classDescriptionBuilder->get();
+        $classDescription = $classDescriptionBuilder->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -144,7 +144,7 @@ class ClassDescriptionBuilderTest extends TestCase
         $classDescriptionBuilder->setClassName($FQCN);
         $classDescriptionBuilder->setInterface(false);
 
-        $classDescription = $classDescriptionBuilder->get();
+        $classDescription = $classDescriptionBuilder->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 

--- a/tests/Unit/Analyzer/ClassDescriptionTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionTest.php
@@ -20,21 +20,21 @@ class ClassDescriptionTest extends TestCase
 
     public function test_should_return_true_if_there_class_is_in_namespace(): void
     {
-        $cd = $this->builder->get();
+        $cd = $this->builder->build();
 
         $this->assertTrue($cd->namespaceMatches('Fruit'));
     }
 
     public function test_should_return_name(): void
     {
-        $cd = $this->builder->get();
+        $cd = $this->builder->build();
 
         $this->assertEquals('Banana', $cd->getName());
     }
 
     public function test_should_return_true_if_there_class_is_in_namespace_array(): void
     {
-        $cd = $this->builder->get();
+        $cd = $this->builder->build();
 
         $this->assertTrue($cd->namespaceMatchesOneOfTheseNamespaces(['Fruit']));
     }
@@ -45,7 +45,7 @@ class ClassDescriptionTest extends TestCase
             ->addDocBlock('/**
  * @psalm-immutable
  */')
-            ->get();
+            ->build();
 
         $this->assertTrue($cd->containsDocBlock('@psalm-immutable'));
     }
@@ -56,7 +56,7 @@ class ClassDescriptionTest extends TestCase
             ->addDocBlock('/**
  * @psalm-immutable
  */')
-            ->get();
+            ->build();
 
         $this->assertFalse($cd->containsDocBlock('@another-annotation'));
     }
@@ -65,7 +65,7 @@ class ClassDescriptionTest extends TestCase
     {
         $cd = $this->builder
             ->addAttribute('FooAttr', 27)
-            ->get();
+            ->build();
 
         self::assertTrue($cd->hasAttribute('FooAttr'));
         self::assertTrue($cd->hasAttribute('Foo*'));
@@ -75,7 +75,7 @@ class ClassDescriptionTest extends TestCase
     {
         $cd = $this->builder
             ->addAttribute('FooAttr', 27)
-            ->get();
+            ->build();
 
         self::assertFalse($cd->hasAttribute('Bar'));
     }

--- a/tests/Unit/Analyzer/ClassDescriptionTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionTest.php
@@ -15,7 +15,7 @@ class ClassDescriptionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->builder = ClassDescription::build('Fruit\Banana');
+        $this->builder = ClassDescription::getBuilder('Fruit\Banana');
     }
 
     public function test_should_return_true_if_there_class_is_in_namespace(): void

--- a/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
@@ -16,7 +16,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')->build();
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $dependOnClasses->evaluate($classDescription, $violations, $because);
@@ -32,7 +32,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('anotherNamespace\Banana', 1))
             ->build();
@@ -52,7 +52,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('\anotherNamespace\Banana', 1))
             ->addDependency(new ClassDependency('\DateTime', 10))
@@ -70,7 +70,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('myNamespace\Mango', 10))
             ->build();
@@ -86,7 +86,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces();
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('HappyIsland\Banana', 0))
             ->addDependency(new ClassDependency('myNamespace\Mango', 10))
             ->build();

--- a/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
@@ -16,7 +16,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')->get();
+        $classDescription = ClassDescription::build('HappyIsland\Myclass')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $dependOnClasses->evaluate($classDescription, $violations, $because);
@@ -35,7 +35,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
         $classDescription = ClassDescription::build('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('anotherNamespace\Banana', 1))
-            ->get();
+            ->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
@@ -56,7 +56,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('\anotherNamespace\Banana', 1))
             ->addDependency(new ClassDependency('\DateTime', 10))
-            ->get();
+            ->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
@@ -73,7 +73,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
         $classDescription = ClassDescription::build('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('myNamespace\Mango', 10))
-            ->get();
+            ->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
@@ -89,7 +89,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
         $classDescription = ClassDescription::build('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('HappyIsland\Banana', 0))
             ->addDependency(new ClassDependency('myNamespace\Mango', 10))
-            ->get();
+            ->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();

--- a/tests/Unit/Expressions/ForClasses/ExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/ExtendTest.php
@@ -21,7 +21,7 @@ class ExtendTest extends TestCase
         $builder->setClassName('My\Class');
         $builder->setExtends('My\BaseClass', 10);
 
-        $classDescription = $builder->get();
+        $classDescription = $builder->build();
 
         $violations = new Violations();
         $extend->evaluate($classDescription, $violations, 'because');

--- a/tests/Unit/Expressions/ForClasses/ExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/ExtendTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
 use Arkitect\Analyzer\ClassDescription;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Analyzer\FullyQualifiedClassName;
 use Arkitect\Expression\ForClasses\Extend;
 use Arkitect\Rules\Violations;
@@ -12,6 +13,22 @@ use PHPUnit\Framework\TestCase;
 
 class ExtendTest extends TestCase
 {
+    public function test_it_should_return_no_violation_on_success(): void
+    {
+        $extend = new Extend('My\BaseClass');
+
+        $builder = new ClassDescriptionBuilder();
+        $builder->setClassName('My\Class');
+        $builder->setExtends('My\BaseClass', 10);
+
+        $classDescription = $builder->get();
+
+        $violations = new Violations();
+        $extend->evaluate($classDescription, $violations, 'because');
+
+        self::assertEquals(0, $violations->count());
+    }
+
     public function test_it_should_return_violation_error(): void
     {
         $extend = new Extend('My\BaseClass');

--- a/tests/Unit/Expressions/ForClasses/ExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/ExtendTest.php
@@ -28,28 +28,34 @@ class ExtendTest extends TestCase
         self::assertEquals(0, $violations->count());
     }
 
+    public function test_it_should_return_violation_error_when_argument_is_a_regex(): void
+    {
+        $extend = new Extend('App\Providers\(Auth|Event|Route|Horizon)ServiceProvider');
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('My\Class')
+            ->setExtends('My\BaseClass', 10)
+            ->build();
+
+        $violations = new Violations();
+        self::expectExceptionMessage("'App\Providers\(Auth|Event|Route|Horizon)ServiceProvider' is not a valid class or namespace pattern. Regex are not allowed, only * and ? wildcard.");
+        $extend->evaluate($classDescription, $violations, 'I said so');
+    }
+
     public function test_it_should_return_violation_error_when_class_not_extend(): void
     {
         $extend = new Extend('My\BaseClass');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            FullyQualifiedClassName::fromString('My\AnotherClass'),
-            false,
-            false,
-            false
-        );
-
-        $because = 'we want to add this rule for our software';
-        $violationError = $extend->describe($classDescription, $because)->toString();
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setExtends('My\AnotherClass', 10)
+            ->build();
 
         $violations = new Violations();
-        $extend->evaluate($classDescription, $violations, $because);
+        $extend->evaluate($classDescription, $violations, 'we want to add this rule for our software');
 
         self::assertEquals(1, $violations->count());
-        self::assertEquals('should extend My\BaseClass because we want to add this rule for our software', $violationError);
+        self::assertEquals('should extend My\BaseClass because we want to add this rule for our software', $violations->get(0)->getError());
     }
 
     public function test_it_should_return_violation_error_if_extend_is_null(): void

--- a/tests/Unit/Expressions/ForClasses/ExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/ExtendTest.php
@@ -17,11 +17,10 @@ class ExtendTest extends TestCase
     {
         $extend = new Extend('My\BaseClass');
 
-        $builder = new ClassDescriptionBuilder();
-        $builder->setClassName('My\Class');
-        $builder->setExtends('My\BaseClass', 10);
-
-        $classDescription = $builder->build();
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('My\Class')
+            ->setExtends('My\BaseClass', 10)
+            ->build();
 
         $violations = new Violations();
         $extend->evaluate($classDescription, $violations, 'because');
@@ -29,7 +28,7 @@ class ExtendTest extends TestCase
         self::assertEquals(0, $violations->count());
     }
 
-    public function test_it_should_return_violation_error(): void
+    public function test_it_should_return_violation_error_when_class_not_extend(): void
     {
         $extend = new Extend('My\BaseClass');
 

--- a/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
@@ -14,7 +14,7 @@ class HaveNameMatchingTest extends TestCase
     {
         $expression = new HaveNameMatching('*Class');
 
-        $goodClass = ClassDescription::build('\App\MyClass')->build();
+        $goodClass = ClassDescription::getBuilder('\App\MyClass')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($goodClass, $violations, $because);
@@ -25,7 +25,7 @@ class HaveNameMatchingTest extends TestCase
     {
         $expression = new HaveNameMatching('*GoodName*');
 
-        $badClass = ClassDescription::build('\App\BadNameClass')->build();
+        $badClass = ClassDescription::getBuilder('\App\BadNameClass')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($badClass, $violations, $because);

--- a/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
@@ -14,7 +14,7 @@ class HaveNameMatchingTest extends TestCase
     {
         $expression = new HaveNameMatching('*Class');
 
-        $goodClass = ClassDescription::build('\App\MyClass')->get();
+        $goodClass = ClassDescription::build('\App\MyClass')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($goodClass, $violations, $because);
@@ -25,7 +25,7 @@ class HaveNameMatchingTest extends TestCase
     {
         $expression = new HaveNameMatching('*GoodName*');
 
-        $badClass = ClassDescription::build('\App\BadNameClass')->get();
+        $badClass = ClassDescription::build('\App\BadNameClass')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($badClass, $violations, $because);

--- a/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
@@ -16,7 +16,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
     {
         $notDependOnClasses = new NotDependsOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')->get();
+        $classDescription = ClassDescription::build('HappyIsland\Myclass')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $notDependOnClasses->evaluate($classDescription, $violations, $because);
@@ -31,7 +31,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
         $classDescription = ClassDescription::build('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('anotherNamespace\Banana', 1))
-            ->get();
+            ->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
@@ -52,7 +52,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('\anotherNamespace\Banana', 1))
             ->addDependency(new ClassDependency('\DateTime', 10))
-            ->get();
+            ->build();
 
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
@@ -72,7 +72,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
         $classDescription = ClassDescription::build('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('myNamespace\Mango', 10))
-            ->get();
+            ->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();

--- a/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
@@ -16,7 +16,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
     {
         $notDependOnClasses = new NotDependsOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')->build();
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $notDependOnClasses->evaluate($classDescription, $violations, $because);
@@ -28,7 +28,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
     {
         $notDependOnClasses = new NotDependsOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('anotherNamespace\Banana', 1))
             ->build();
@@ -48,7 +48,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
     {
         $notDependOnClasses = new NotDependsOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('\anotherNamespace\Banana', 1))
             ->addDependency(new ClassDependency('\DateTime', 10))
@@ -69,7 +69,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
     {
         $notDependOnClasses = new NotDependsOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::build('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('myNamespace\Mango', 10))
             ->build();

--- a/tests/Unit/Expressions/ForClasses/NotHaveNameMatchingTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveNameMatchingTest.php
@@ -14,7 +14,7 @@ class NotHaveNameMatchingTest extends TestCase
     {
         $expression = new NotHaveNameMatching('*Class');
 
-        $myClass = ClassDescription::build('\App\MyClass')->build();
+        $myClass = ClassDescription::getBuilder('\App\MyClass')->build();
 
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
@@ -30,7 +30,7 @@ class NotHaveNameMatchingTest extends TestCase
     {
         $expression = new NotHaveNameMatching('*GoodName*');
 
-        $badClass = ClassDescription::build('\App\BadNameClass')->build();
+        $badClass = ClassDescription::getBuilder('\App\BadNameClass')->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();

--- a/tests/Unit/Expressions/ForClasses/NotHaveNameMatchingTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveNameMatchingTest.php
@@ -14,7 +14,7 @@ class NotHaveNameMatchingTest extends TestCase
     {
         $expression = new NotHaveNameMatching('*Class');
 
-        $myClass = ClassDescription::build('\App\MyClass')->get();
+        $myClass = ClassDescription::build('\App\MyClass')->build();
 
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
@@ -30,7 +30,7 @@ class NotHaveNameMatchingTest extends TestCase
     {
         $expression = new NotHaveNameMatching('*GoodName*');
 
-        $badClass = ClassDescription::build('\App\BadNameClass')->get();
+        $badClass = ClassDescription::build('\App\BadNameClass')->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();

--- a/tests/Unit/Expressions/ForClasses/NotResideInTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotResideInTheseNamespacesTest.php
@@ -15,7 +15,7 @@ class NotResideInTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new NotResideInTheseNamespaces('MyNamespace');
 
-        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -28,7 +28,7 @@ class NotResideInTheseNamespacesTest extends TestCase
         $namespace = 'MyNamespace';
         $haveNameMatching = new NotResideInTheseNamespaces($namespace);
 
-        $classDesc = ClassDescription::build('MyNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('MyNamespace\HappyIsland')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -44,18 +44,18 @@ class NotResideInTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new NotResideInTheseNamespaces('AnotherNamespace', 'ASecondNamespace', 'AThirdNamespace');
 
-        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland')->build();
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(1, $violations->count());
 
-        $classDesc = ClassDescription::build('MyNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('MyNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::build('AThirdNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AThirdNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(1, $violations->count());

--- a/tests/Unit/Expressions/ForClasses/NotResideInTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotResideInTheseNamespacesTest.php
@@ -15,7 +15,7 @@ class NotResideInTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new NotResideInTheseNamespaces('MyNamespace');
 
-        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -28,7 +28,7 @@ class NotResideInTheseNamespacesTest extends TestCase
         $namespace = 'MyNamespace';
         $haveNameMatching = new NotResideInTheseNamespaces($namespace);
 
-        $classDesc = ClassDescription::build('MyNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('MyNamespace\HappyIsland')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -44,18 +44,18 @@ class NotResideInTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new NotResideInTheseNamespaces('AnotherNamespace', 'ASecondNamespace', 'AThirdNamespace');
 
-        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->build();
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(1, $violations->count());
 
-        $classDesc = ClassDescription::build('MyNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('MyNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::build('AThirdNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('AThirdNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(1, $violations->count());

--- a/tests/Unit/Expressions/ForClasses/ResideInOneOfTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/ResideInOneOfTheseNamespacesTest.php
@@ -39,7 +39,7 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new ResideInOneOfTheseNamespaces($expectedNamespace);
 
-        $classDesc = ClassDescription::build($actualFQCN)->get();
+        $classDesc = ClassDescription::build($actualFQCN)->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -51,7 +51,7 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new ResideInOneOfTheseNamespaces('MyNamespace');
 
-        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -63,23 +63,23 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new ResideInOneOfTheseNamespaces('MyNamespace', 'AnotherNamespace', 'AThirdNamespace');
 
-        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->build();
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::build('MyNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('MyNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::build('AThirdNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('AThirdNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::build('NopeNamespace\HappyIsland')->get();
+        $classDesc = ClassDescription::build('NopeNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertNotEquals(0, $violations->count());

--- a/tests/Unit/Expressions/ForClasses/ResideInOneOfTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/ResideInOneOfTheseNamespacesTest.php
@@ -39,7 +39,7 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new ResideInOneOfTheseNamespaces($expectedNamespace);
 
-        $classDesc = ClassDescription::build($actualFQCN)->build();
+        $classDesc = ClassDescription::getBuilder($actualFQCN)->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -51,7 +51,7 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new ResideInOneOfTheseNamespaces('MyNamespace');
 
-        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -63,23 +63,23 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new ResideInOneOfTheseNamespaces('MyNamespace', 'AnotherNamespace', 'AThirdNamespace');
 
-        $classDesc = ClassDescription::build('AnotherNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland')->build();
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::build('MyNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('MyNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::build('AThirdNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AThirdNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::build('NopeNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('NopeNamespace\HappyIsland')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertNotEquals(0, $violations->count());

--- a/tests/Unit/Rules/ConstraintsTest.php
+++ b/tests/Unit/Rules/ConstraintsTest.php
@@ -38,7 +38,7 @@ class ConstraintsTest extends TestCase
         $cb->setClassName('Banana');
 
         $expressionStore->checkAll(
-            $cb->get(),
+            $cb->build(),
             $violations,
             $because
         );
@@ -74,7 +74,7 @@ class ConstraintsTest extends TestCase
         $cb->setClassName('Banana');
 
         $expressionStore->checkAll(
-            $cb->get(),
+            $cb->build(),
             $violations,
             $because
         );

--- a/tests/Unit/Rules/RuleCheckerTest.php
+++ b/tests/Unit/Rules/RuleCheckerTest.php
@@ -89,7 +89,7 @@ class FakeParser implements Parser
 
     public function getClassDescriptions(): array
     {
-        return [ClassDescription::build('uno')->get()];
+        return [ClassDescription::build('uno')->build()];
     }
 
     public function getParsingErrors(): array

--- a/tests/Unit/Rules/RuleCheckerTest.php
+++ b/tests/Unit/Rules/RuleCheckerTest.php
@@ -89,7 +89,7 @@ class FakeParser implements Parser
 
     public function getClassDescriptions(): array
     {
-        return [ClassDescription::build('uno')->build()];
+        return [ClassDescription::getBuilder('uno')->build()];
     }
 
     public function getParsingErrors(): array

--- a/tests/Unit/Rules/SpecsTest.php
+++ b/tests/Unit/Rules/SpecsTest.php
@@ -17,7 +17,7 @@ class SpecsTest extends TestCase
         $specStore = new Specs();
         $specStore->add(new HaveNameMatching('Foo'));
 
-        $classDescription = ClassDescription::build('MyNamespace\HappyIsland')->build();
+        $classDescription = ClassDescription::getBuilder('MyNamespace\HappyIsland')->build();
         $because = 'we want to add this rule for our software';
 
         $this->assertFalse($specStore->allSpecsAreMatchedBy($classDescription, $because));
@@ -28,7 +28,7 @@ class SpecsTest extends TestCase
         $specStore = new Specs();
         $specStore->add(new HaveNameMatching('Happy*'));
 
-        $classDescription = ClassDescription::build('MyNamespace\HappyIsland')
+        $classDescription = ClassDescription::getBuilder('MyNamespace\HappyIsland')
             ->addDependency(new ClassDependency('Foo', 100))
             ->build();
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Rules/SpecsTest.php
+++ b/tests/Unit/Rules/SpecsTest.php
@@ -17,7 +17,7 @@ class SpecsTest extends TestCase
         $specStore = new Specs();
         $specStore->add(new HaveNameMatching('Foo'));
 
-        $classDescription = ClassDescription::build('MyNamespace\HappyIsland')->get();
+        $classDescription = ClassDescription::build('MyNamespace\HappyIsland')->build();
         $because = 'we want to add this rule for our software';
 
         $this->assertFalse($specStore->allSpecsAreMatchedBy($classDescription, $because));
@@ -30,7 +30,7 @@ class SpecsTest extends TestCase
 
         $classDescription = ClassDescription::build('MyNamespace\HappyIsland')
             ->addDependency(new ClassDependency('Foo', 100))
-            ->get();
+            ->build();
         $because = 'we want to add this rule for our software';
 
         $this->assertTrue($specStore->allSpecsAreMatchedBy($classDescription, $because));


### PR DESCRIPTION
I added the error message as an exception.
The message is not perfectly aligned, but I don't know how to improve this cleanly.

![Schermata del 2023-02-09 15-39-51](https://user-images.githubusercontent.com/5879/217845230-6c98d5b8-d5e7-43cb-b618-94b51b5563cd.png)

I took the opportunity to do some other little refactorings:

- the ClassDescriptionBuilder now is more a builder
- the Extends Rule now supports wildcard in the argument
- I simplified the Rule tests a lot.. I think we could use the same pattern in the other unit tests of rules
