### PR TITLE
Fixed "IsFinal" for abstract classes and interfaces

### DIFF
--- a/src/Expression/ForClasses/IsFinal.php
+++ b/src/Expression/ForClasses/IsFinal.php
@@ -20,7 +20,7 @@ class IsFinal implements Expression
 
     public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
     {
-        if ($theClass->isFinal()) {
+        if ($theClass->isAbstract() || $theClass->isInterface() || $theClass->isFinal()) {
             return;
         }
 

--- a/tests/Unit/Expressions/ForClasses/IsFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsFinalTest.php
@@ -53,4 +53,44 @@ class IsFinalTest extends TestCase
         $isFinal->evaluate($classDescription, $violations, $because);
         self::assertEquals(0, $violations->count());
     }
+
+    public function test_abstract_classes_can_not_be_final_and_should_be_ignored(): void
+    {
+        $class = 'myClass';
+
+        $isFinal = new IsFinal();
+        $classDescription = new ClassDescription(
+            FullyQualifiedClassName::fromString('HappyIsland'),
+            [],
+            [],
+            null,
+            false,
+            true,
+            false
+        );
+        $because = 'we want to add this rule for our software';
+        $violations = new Violations();
+        $isFinal->evaluate($classDescription, $violations, $because);
+        self::assertEquals(0, $violations->count());
+    }
+
+    public function test_interfaces_can_not_be_final_and_should_be_ignored(): void
+    {
+        $class = 'myClass';
+
+        $isFinal = new IsFinal();
+        $classDescription = new ClassDescription(
+            FullyQualifiedClassName::fromString('HappyIsland'),
+            [],
+            [],
+            null,
+            false,
+            false,
+            true
+        );
+        $because = 'we want to add this rule for our software';
+        $violations = new Violations();
+        $isFinal->evaluate($classDescription, $violations, $because);
+        self::assertEquals(0, $violations->count());
+    }
 }


### PR DESCRIPTION
Fixed `\Arkitect\Expression\ForClasses\IsFinal` because:
- abstract classes can not be final
- interfaces can not be final