### PR TITLE
flag to ignore line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ To avoid using the default baseline file, you can use the `skip-baseline` option
 phparkitect check --skip-baseline
 ```
 
+### Line numbers in baseline
+
+By default, the baseline check also looks at line numbers of known violations.
+When a line before the offending line changes, the line numbers change and the check fails despite the baseline.
+
+With the optional flag `ignore-baseline-linenumbers`, you can ignore the line numbers of violations:
+
+```
+phparkitect check --ignore-baseline-linenumbers
+```
+
+*Warning*: When ignoring line numbers, phparkitect can no longer discover if a rule is violated additional times in the same file.
+
 ## Configuration
 
 Example of configuration file `phparkitect.php`

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -25,6 +25,7 @@ class Check extends Command
     private const STOP_ON_FAILURE_PARAM = 'stop-on-failure';
     private const USE_BASELINE_PARAM = 'use-baseline';
     private const SKIP_BASELINE_PARAM = 'skip-baseline';
+    private const IGNORE_BASELINE_LINENUMBERS_PARAM = 'ignore-baseline-linenumbers';
 
     private const GENERATE_BASELINE_PARAM = 'generate-baseline';
     private const DEFAULT_RULES_FILENAME = 'phparkitect.php';
@@ -80,6 +81,12 @@ class Check extends Command
                 'k',
                 InputOption::VALUE_NONE,
                 'Don\'t use the default baseline'
+            )
+            ->addOption(
+                self::IGNORE_BASELINE_LINENUMBERS_PARAM,
+                'i',
+                InputOption::VALUE_NONE,
+                'Ignore line numbers when checking the baseline'
             );
     }
 
@@ -94,6 +101,7 @@ class Check extends Command
             $stopOnFailure = $input->getOption(self::STOP_ON_FAILURE_PARAM);
             $useBaseline = $input->getOption(self::USE_BASELINE_PARAM);
             $skipBaseline = $input->getOption(self::SKIP_BASELINE_PARAM);
+            $ignoreBaselineLinenumbers = $input->getOption(self::IGNORE_BASELINE_LINENUMBERS_PARAM);
 
             if (true !== $skipBaseline && !$useBaseline && file_exists(self::DEFAULT_BASELINE_FILENAME)) {
                 $useBaseline = self::DEFAULT_BASELINE_FILENAME;
@@ -146,7 +154,7 @@ class Check extends Command
             if ($useBaseline) {
                 $baseline = $this->loadBaseline($useBaseline);
 
-                $violations->remove($baseline);
+                $violations->remove($baseline, $ignoreBaselineLinenumbers);
             }
 
             if ($violations->count() > 0) {

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -11,9 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class ViolationsTest extends TestCase
 {
-    /** @var string */
-    private $violationData;
-
     /** @var Violations */
     private $violationStore;
 
@@ -22,8 +19,6 @@ class ViolationsTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->violationData = 'violation';
-
         $this->violationStore = new Violations();
         $this->violation = new Violation(
             'App\Controller\ProductController',
@@ -179,5 +174,38 @@ App\Controller\Foo has 1 violations
             $violation2, // then error message
             $violation1,
         ], $violationStore->toArray());
+    }
+
+    public function test_remove_violations_from_violations_ignore_linenumber(): void
+    {
+        $violation1 = new Violation(
+            'App\Controller\Shop',
+            'should have name end with Controller',
+            42
+        );
+        $this->violationStore->add($violation1);
+
+        $violation2 = new Violation(
+            'App\Controller\Shop',
+            'should implement AbstractController'
+        );
+        $this->violationStore->add($violation2);
+
+        $this->assertCount(3, $this->violationStore->toArray());
+
+        $violationsBaseline = new Violations();
+        $violationsBaseline->add(new Violation(
+            'App\Controller\Shop',
+            'should have name end with Controller',
+            21
+        ));
+
+        $this->violationStore->remove($violationsBaseline, true);
+
+        $this->assertCount(2, $this->violationStore->toArray());
+        $this->assertEquals([
+            $this->violation,
+            $violation2,
+        ], $this->violationStore->toArray());
     }
 }


### PR DESCRIPTION
in addition to #364, this PR adds a flag that allows to ignore line number changes completely. (note that the commit from #364 is also contained in this branch)

when using the flag, the line numbers in the baseline might drift out of sync with reality (but the report uses the line numbers from the actual code). we could potentially not store line numbers in the baseline when the flag is active and instead store that line numbers are ignored, so that the flag is only needed when generating the baseline but not when checking with such a baseline.

there is a drawback when the flag is used: if a specific class has a specific violation, new lines that do the same violation will not be detected anymore, because the ignore is globally.
if we would store the count of a specific violation in the baseline, we could check the count and report if there are more violations than in the baseline. which could also be used for a nicer reporting that groups the violations about the same class into one report, listing on which lines that violation occurs.

how do the maintainers feel about this? i can't promise to work on all this, and for us ignoring the line numbers of the baseline is good enough. but happy to hear your thoughts.