### PR TITLE
Questing about strict pattern matching

### DIFF
--- a/src/Analyzer/PatternString.php
+++ b/src/Analyzer/PatternString.php
@@ -46,13 +46,13 @@ class PatternString
 
     private function startsWithPattern(string $pattern): bool
     {
-        return 1 === preg_match('#^'.$this->convertShellToRegExPattern($pattern).'#', $this->value);
+        return 1 === preg_match('#^'.$this->convertShellToRegExPattern($pattern).'$#', $this->value);
     }
 
     private function convertShellToRegExPattern(string $pattern): string
     {
         return strtr($pattern, [
-            '*' => '.*',
+            '*' => '.+',
             '?' => '.',
             '.' => '\.',
             '[!' => '[^',

--- a/tests/Unit/Analyzer/PatternStringTest.php
+++ b/tests/Unit/Analyzer/PatternStringTest.php
@@ -21,4 +21,40 @@ class PatternStringTest extends TestCase
         $this->assertTrue($pattern->matches('*This*'));
         $this->assertFalse($pattern->matches('This*'));
     }
+
+    public function test_it_can_strictly_match_explicit_prefixes(): void
+    {
+        $pattern = new PatternString('AlphaBravoCharlie');
+        $this->assertTrue($pattern->matches('Alpha*'));
+        $this->assertTrue($pattern->matches('AlphaBravo*'));
+        $this->assertFalse(
+            $pattern->matches('*Alpha*'),
+            'There is nothing to match before the first string "Alpha" (e.g. "_AlphaBravoCharlie")'
+        );
+    }
+
+    public function test_it_can_strictly_match_explicit_postfixes(): void
+    {
+        $pattern = new PatternString('AlphaBravoCharlie');
+        $this->assertTrue($pattern->matches('*Charlie'));
+        $this->assertTrue($pattern->matches('*BravoCharlie'));
+        $this->assertFalse(
+            $pattern->matches('*Charlie*'),
+            'There is nothing to match after the last string "Charlie" (e.g. "AlphaBravoCharlie_")'
+        );
+    }
+
+    public function test_it_can_strictly_match_explicit_infixes(): void
+    {
+        $pattern = new PatternString('AlphaBravoCharlie');
+        $this->assertTrue($pattern->matches('*Bravo*'));
+        $this->assertFalse(
+            $pattern->matches('*Bravo'),
+            'This should resolve to "AlphaBravo" and not match "AlphaBravoCharlie"'
+        );
+        $this->assertFalse(
+            $pattern->matches('Bravo*'),
+            'This should resolve to "BravoCharlie" and not match "AlphaBravoCharlie"'
+        );
+    }
 }


### PR DESCRIPTION
Hello,

I stumbled upon this issue earlier today. [In the current implementation](https://github.com/phparkitect/arkitect/blob/13ff662df4ab28607d0853fb39d6d69c92b995b0/src/Analyzer/PatternString.php#L55), when converting shell/glob to regex, `*` is simply converted to `.*`. This allows for zero-to-many matches and the behavior shown in the added tests ([see first commit](https://github.com/phparkitect/arkitect/pull/379/commits/f99b44002b51fae77c460f3597323e2556167569)).

Now, converting `*` to e.g. `.+` results in stricter "one-to-many"-matches ([see second commit](https://github.com/phparkitect/arkitect/pull/379/commits/53dd789b459e90e2c8068a5de00852758e7a09e0)).

But I'm afraid this PR will result in BC breaks along with a lot of false-positive findings all around... Instead, can we just use Regex directly? Maybe something like a `RegexPatternString`-class?

Or is this behavior explicity desired? Please advise. 