### PR TITLE
Fixed "IsFinal" for Traits

### DIFF
--- a/src/Expression/ForClasses/IsFinal.php
+++ b/src/Expression/ForClasses/IsFinal.php
@@ -20,7 +20,7 @@ class IsFinal implements Expression
 
     public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
     {
-        if ($theClass->isAbstract() || $theClass->isInterface() || $theClass->isFinal()) {
+        if ($theClass->isAbstract() || $theClass->isInterface() || $theClass->isFinal() || $theClass->isTrait()) {
             return;
         }
 

--- a/tests/Unit/Expressions/ForClasses/IsFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsFinalTest.php
@@ -97,4 +97,25 @@ class IsFinalTest extends TestCase
         $isFinal->evaluate($classDescription, $violations, $because);
         self::assertEquals(0, $violations->count());
     }
+
+    public function test_traits_can_not_be_final_and_should_be_ignored(): void
+    {
+        $class = 'myClass';
+
+        $isFinal = new IsFinal();
+        $classDescription = new ClassDescription(
+            FullyQualifiedClassName::fromString('HappyIsland'),
+            [],
+            [],
+            null,
+            false,
+            false,
+            false,
+            true
+        );
+        $because = 'we want to add this rule for our software';
+        $violations = new Violations();
+        $isFinal->evaluate($classDescription, $violations, $because);
+        self::assertEquals(0, $violations->count());
+    }
 }


### PR DESCRIPTION
Fixed `\Arkitect\Expression\ForClasses\IsFinal` because:
- Traits can not be final