### PR TITLE
Fixed "IsFinal" for Enums

### DIFF
--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -29,6 +29,9 @@ class ClassDescription
     /** @var bool */
     private $trait;
 
+    /** @var bool */
+    private $enum;
+
     /** @var list<string> */
     private $docBlock;
 
@@ -138,6 +141,11 @@ class ClassDescription
     public function isTrait(): bool
     {
         return $this->trait;
+    }
+
+    public function isEnum(): bool
+    {
+        return $this->enum;
     }
 
     public function getDocBlock(): array

--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -53,6 +53,7 @@ class ClassDescription
         bool $abstract,
         bool $interface,
         bool $trait,
+        bool $enum,
         array $docBlock = [],
         array $attributes = []
     ) {
@@ -66,6 +67,7 @@ class ClassDescription
         $this->attributes = $attributes;
         $this->interface = $interface;
         $this->trait = $trait;
+        $this->enum = $enum;
     }
 
     public static function getBuilder(string $FQCN): ClassDescriptionBuilder

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -37,6 +37,9 @@ class ClassDescriptionBuilder
     /** @var bool */
     private $trait = false;
 
+    /** @var bool */
+    private $enum = false;
+
     public function clear(): void
     {
         $this->FQCN = null;
@@ -49,6 +52,7 @@ class ClassDescriptionBuilder
         $this->attributes = [];
         $this->interface = false;
         $this->trait = false;
+        $this->enum = false;
     }
 
     public function setClassName(string $FQCN): self
@@ -109,6 +113,13 @@ class ClassDescriptionBuilder
         return $this;
     }
 
+    public function setEnum(bool $enum): self
+    {
+        $this->enum = $enum;
+
+        return $this;
+    }
+
     public function addDocBlock(string $docBlock): self
     {
         $this->docBlock[] = $docBlock;
@@ -137,6 +148,7 @@ class ClassDescriptionBuilder
             $this->abstract,
             $this->interface,
             $this->trait,
+            $this->enum,
             $this->docBlock,
             $this->attributes
         );

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -56,6 +56,7 @@ class FileVisitor extends NodeVisitorAbstract
 
         if ($node instanceof Node\Stmt\Enum_ && null !== $node->namespacedName) {
             $this->classDescriptionBuilder->setClassName($node->namespacedName->toCodeString());
+            $this->classDescriptionBuilder->setEnum(true);
 
             foreach ($node->attrGroups as $attributeGroup) {
                 foreach ($attributeGroup->attrs as $attribute) {

--- a/src/Expression/ForClasses/IsFinal.php
+++ b/src/Expression/ForClasses/IsFinal.php
@@ -20,7 +20,7 @@ class IsFinal implements Expression
 
     public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
     {
-        if ($theClass->isAbstract() || $theClass->isInterface() || $theClass->isFinal()) {
+        if ($theClass->isAbstract() || $theClass->isInterface() || $theClass->isFinal() || $theClass->isEnum()) {
             return;
         }
 

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -1238,6 +1238,8 @@ EOF;
     }
 
     /**
+     * @requires PHP >= 8.1
+     *
      * @dataProvider provide_enums
      */
     public function test_it_parse_enums(string $code): void
@@ -1251,7 +1253,7 @@ EOF;
         }
     }
 
-    private function provide_enums(): \Generator
+    public function provide_enums(): \Generator
     {
         yield 'default enum' => [
             <<< 'EOF'

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -15,7 +15,6 @@ use Arkitect\Expression\ForClasses\NotContainDocBlockLike;
 use Arkitect\Expression\ForClasses\NotHaveDependencyOutsideNamespace;
 use Arkitect\Rules\ParsingError;
 use Arkitect\Rules\Violations;
-use Generator;
 use PHPUnit\Framework\TestCase;
 
 class FileVisitorTest extends TestCase
@@ -1252,7 +1251,7 @@ EOF;
         }
     }
 
-    private function provide_enums(): Generator
+    private function provide_enums(): \Generator
     {
         yield 'default enum' => [
             <<< 'EOF'

--- a/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
@@ -25,6 +25,7 @@ class ContainDocBlockLikeTest extends TestCase
             false,
             false,
             false,
+            false,
             ['/**  */myDocBlock with other information']
         );
         $because = 'we want to add this rule for our software';
@@ -51,6 +52,7 @@ class ContainDocBlockLikeTest extends TestCase
             false,
             false,
             false,
+            false,
             ['/**  */myDocBlock with other information']
         );
         $violations = new Violations();
@@ -72,6 +74,7 @@ class ContainDocBlockLikeTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false,
             false,

--- a/tests/Unit/Expressions/ForClasses/ExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/ExtendTest.php
@@ -85,6 +85,7 @@ class ExtendTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
 

--- a/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
@@ -25,6 +25,7 @@ class HaveAttributeTest extends TestCase
             false,
             false,
             false,
+            false,
             [],
             [FullyQualifiedClassName::fromString('myAttribute')]
         );
@@ -52,6 +53,7 @@ class HaveAttributeTest extends TestCase
             false,
             false,
             false,
+            false,
             [],
             [FullyQualifiedClassName::fromString('myAttribute')]
         );
@@ -74,6 +76,7 @@ class HaveAttributeTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false,
             false,

--- a/tests/Unit/Expressions/ForClasses/ImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/ImplementTest.php
@@ -25,6 +25,7 @@ class ImplementTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
 
@@ -51,6 +52,7 @@ class ImplementTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -69,6 +71,7 @@ class ImplementTest extends TestCase
             [],
             [FullyQualifiedClassName::fromString('interface')],
             null,
+            false,
             false,
             false,
             false,
@@ -94,6 +97,7 @@ class ImplementTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
         $violations = new Violations();
@@ -114,7 +118,8 @@ class ImplementTest extends TestCase
             false,
             false,
             false,
-            true
+            true,
+            false
         );
         $because = 'we want to add this rule for our software';
 

--- a/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
@@ -23,6 +23,7 @@ class IsAbstractTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -45,6 +46,7 @@ class IsAbstractTest extends TestCase
             null,
             true,
             true,
+            false,
             false,
             false
         );

--- a/tests/Unit/Expressions/ForClasses/IsFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsFinalTest.php
@@ -97,4 +97,26 @@ class IsFinalTest extends TestCase
         $isFinal->evaluate($classDescription, $violations, $because);
         self::assertEquals(0, $violations->count());
     }
+
+    public function test_enums_can_not_be_final_and_should_be_ignored(): void
+    {
+        $class = 'myClass';
+
+        $isFinal = new IsFinal();
+        $classDescription = new ClassDescription(
+            FullyQualifiedClassName::fromString('HappyIsland'),
+            [],
+            [],
+            null,
+            false,
+            false,
+            false,
+            false,
+            true
+        );
+        $because = 'we want to add this rule for our software';
+        $violations = new Violations();
+        $isFinal->evaluate($classDescription, $violations, $because);
+        self::assertEquals(0, $violations->count());
+    }
 }

--- a/tests/Unit/Expressions/ForClasses/IsFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsFinalTest.php
@@ -23,6 +23,7 @@ class IsFinalTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -48,6 +49,7 @@ class IsFinalTest extends TestCase
             true,
             false,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -68,6 +70,7 @@ class IsFinalTest extends TestCase
             null,
             false,
             true,
+            false,
             false,
             false
         );
@@ -90,6 +93,7 @@ class IsFinalTest extends TestCase
             false,
             false,
             true,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
@@ -23,6 +23,7 @@ class IsNotAbstractTest extends TestCase
             true,
             true,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -43,6 +44,7 @@ class IsNotAbstractTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false,
             false,

--- a/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
@@ -23,6 +23,7 @@ class IsNotFinalTest extends TestCase
             true,
             false,
             false,
+            false,
             false
         );
 
@@ -44,6 +45,7 @@ class IsNotFinalTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false,
             false,

--- a/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
@@ -25,6 +25,7 @@ class NotContainDocBlockLikeTest extends TestCase
             false,
             false,
             false,
+            false,
             ['/**  */myDocBlock with other information']
         );
         $because = 'we want to add this rule for our software';
@@ -51,6 +52,7 @@ class NotContainDocBlockLikeTest extends TestCase
             false,
             false,
             false,
+            false,
             ['/**  */myDocBlock with other information']
         );
         $violations = new Violations();
@@ -72,6 +74,7 @@ class NotContainDocBlockLikeTest extends TestCase
             [],
             [],
             null,
+            false,
             false,
             false,
             false,

--- a/tests/Unit/Expressions/ForClasses/NotExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotExtendTest.php
@@ -24,6 +24,7 @@ class NotExtendTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -45,6 +46,7 @@ class NotExtendTest extends TestCase
             [],
             [],
             FullyQualifiedClassName::fromString('My\AnotherClass'),
+            false,
             false,
             false,
             false,

--- a/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
@@ -25,6 +25,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -47,6 +48,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -66,6 +68,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -82,6 +85,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
             [new ClassDependency('foo', 100)],
             [],
             null,
+            false,
             false,
             false,
             false,

--- a/tests/Unit/Expressions/ForClasses/NotImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotImplementTest.php
@@ -25,6 +25,7 @@ class NotImplementTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
 
@@ -49,6 +50,7 @@ class NotImplementTest extends TestCase
             false,
             false,
             false,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';
@@ -67,6 +69,7 @@ class NotImplementTest extends TestCase
             [],
             [FullyQualifiedClassName::fromString('interface')],
             null,
+            false,
             false,
             false,
             false,
@@ -99,6 +102,7 @@ class NotImplementTest extends TestCase
             false,
             false,
             true,
+            false,
             false
         );
         $because = 'we want to add this rule for our software';


### PR DESCRIPTION
Fixed `\Arkitect\Expression\ForClasses\IsFinal` along with various `Arkitect\Analyzer`-classes because:
- Traits can not be final