### PR TITLE
Add IsEnum && IsNotEnum expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,15 @@ $rules = Rule::allClasses()
     ->because('we want to be sure that all interfaces are in one directory');
 ```
 
+### Is enum
+
+```php
+$rules = Rule::allClasses()
+    ->that(new ResideInOneOfTheseNamespaces('App\Enum'))
+    ->should(new IsEnum())
+    ->because('we want to be sure that all classes are enum');
+```
+
 ### Is not abstract
 
 ```php
@@ -294,6 +303,15 @@ $rules = Rule::allClasses()
     ->that(new ResideInOneOfTheseNamespaces('Tests\Integration'))
     ->should(new IsNotInterface())
     ->because('we want to be sure that we do not have interfaces in tests');
+```
+
+### Is not enum
+
+```php
+$rules = Rule::allClasses()
+    ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+    ->should(new IsNotEnum())
+    ->because('we want to be sure that all classes are not enum');
 ```
 
 ### Not depends on a namespace

--- a/src/Expression/ForClasses/IsEnum.php
+++ b/src/Expression/ForClasses/IsEnum.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Arkitect\Expression\ForClasses;
+
+use Arkitect\Analyzer\ClassDescription;
+use Arkitect\Expression\Description;
+use Arkitect\Expression\Expression;
+use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
+use Arkitect\Rules\Violations;
+
+class IsEnum implements Expression
+{
+    public function describe(ClassDescription $theClass, string $because): Description
+    {
+        return new Description("{$theClass->getName()} should be an enum", $because);
+    }
+
+    public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
+    {
+        if ($theClass->isEnum()) {
+            return;
+        }
+
+        $violation = Violation::create(
+            $theClass->getFQCN(),
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+        );
+
+        $violations->add($violation);
+    }
+}

--- a/src/Expression/ForClasses/IsEnum.php
+++ b/src/Expression/ForClasses/IsEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Arkitect\Expression\ForClasses;
 
 use Arkitect\Analyzer\ClassDescription;

--- a/src/Expression/ForClasses/IsNotEnum.php
+++ b/src/Expression/ForClasses/IsNotEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Arkitect\Expression\ForClasses;
 
 use Arkitect\Analyzer\ClassDescription;
@@ -18,7 +20,7 @@ class IsNotEnum implements Expression
 
     public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
     {
-        if ($theClass->isEnum() === false) {
+        if (false === $theClass->isEnum()) {
             return;
         }
 

--- a/src/Expression/ForClasses/IsNotEnum.php
+++ b/src/Expression/ForClasses/IsNotEnum.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Arkitect\Expression\ForClasses;
+
+use Arkitect\Analyzer\ClassDescription;
+use Arkitect\Expression\Description;
+use Arkitect\Expression\Expression;
+use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
+use Arkitect\Rules\Violations;
+
+class IsNotEnum implements Expression
+{
+    public function describe(ClassDescription $theClass, string $because): Description
+    {
+        return new Description("{$theClass->getName()} should not be an enum", $because);
+    }
+
+    public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
+    {
+        if ($theClass->isEnum() === false) {
+            return;
+        }
+
+        $violation = Violation::create(
+            $theClass->getFQCN(),
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+        );
+
+        $violations->add($violation);
+    }
+}

--- a/tests/Unit/Expressions/ForClasses/IsEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsEnumTest.php
@@ -1,11 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
 use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Analyzer\FullyQualifiedClassName;
 use Arkitect\Expression\ForClasses\IsEnum;
-use Arkitect\Expression\ForClasses\IsFinal;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Expressions/ForClasses/IsEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsEnumTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Arkitect\Tests\Unit\Expressions\ForClasses;
+
+use Arkitect\Analyzer\ClassDescription;
+use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Expression\ForClasses\IsEnum;
+use Arkitect\Expression\ForClasses\IsFinal;
+use Arkitect\Rules\Violations;
+use PHPUnit\Framework\TestCase;
+
+class IsEnumTest extends TestCase
+{
+    public function test_it_should_return_violation_error(): void
+    {
+        $isEnum = new IsEnum();
+        $classDescription = new ClassDescription(
+            FullyQualifiedClassName::fromString('HappyIsland'),
+            [],
+            [],
+            null,
+            false,
+            false,
+            false,
+            false,
+            false
+        );
+        $because = 'we want to add this rule for our software';
+        $violationError = $isEnum->describe($classDescription, $because)->toString();
+
+        $violations = new Violations();
+        $isEnum->evaluate($classDescription, $violations, $because);
+        self::assertNotEquals(0, $violations->count());
+
+        $this->assertEquals('HappyIsland should be enum because we want to add this rule for our software', $violationError);
+    }
+
+    public function test_it_should_return_true_if_is_enum(): void
+    {
+        $isEnum = new IsEnum();
+        $classDescription = new ClassDescription(
+            FullyQualifiedClassName::fromString('HappyIsland'),
+            [],
+            [],
+            null,
+            false,
+            false,
+            false,
+            false,
+            true
+        );
+        $because = 'we want to add this rule for our software';
+        $violations = new Violations();
+        $isEnum->evaluate($classDescription, $violations, $because);
+        self::assertEquals(0, $violations->count());
+    }
+}

--- a/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
@@ -1,11 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
 use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Analyzer\FullyQualifiedClassName;
 use Arkitect\Expression\ForClasses\IsEnum;
-use Arkitect\Expression\ForClasses\IsFinal;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
@@ -9,7 +9,7 @@ use Arkitect\Expression\ForClasses\IsFinal;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
 
-class IsEnumTest extends TestCase
+class IsNotEnumTest extends TestCase
 {
     public function test_it_should_return_violation_error(): void
     {
@@ -23,7 +23,7 @@ class IsEnumTest extends TestCase
             false,
             false,
             false,
-            false
+            true
         );
         $because = 'we want to add this rule for our software';
         $violationError = $isEnum->describe($classDescription, $because)->toString();
@@ -32,7 +32,7 @@ class IsEnumTest extends TestCase
         $isEnum->evaluate($classDescription, $violations, $because);
         self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should be an enum because we want to add this rule for our software', $violationError);
+        $this->assertEquals('HappyIsland should not be an enum because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_enum(): void
@@ -47,7 +47,7 @@ class IsEnumTest extends TestCase
             false,
             false,
             false,
-            true
+            false
         );
         $because = 'we want to add this rule for our software';
         $violations = new Violations();

--- a/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
@@ -5,7 +5,7 @@ namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
 use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Analyzer\FullyQualifiedClassName;
-use Arkitect\Expression\ForClasses\IsEnum;
+use Arkitect\Expression\ForClasses\IsNotEnum;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
 
@@ -13,7 +13,7 @@ class IsNotEnumTest extends TestCase
 {
     public function test_it_should_return_violation_error(): void
     {
-        $isEnum = new IsEnum();
+        $isEnum = new IsNotEnum();
         $classDescription = new ClassDescription(
             FullyQualifiedClassName::fromString('HappyIsland'),
             [],
@@ -37,7 +37,7 @@ class IsNotEnumTest extends TestCase
 
     public function test_it_should_return_true_if_is_not_enum(): void
     {
-        $isEnum = new IsEnum();
+        $isEnum = new IsNotEnum();
         $classDescription = new ClassDescription(
             FullyQualifiedClassName::fromString('HappyIsland'),
             [],

--- a/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
@@ -35,7 +35,7 @@ class IsNotEnumTest extends TestCase
         $this->assertEquals('HappyIsland should not be an enum because we want to add this rule for our software', $violationError);
     }
 
-    public function test_it_should_return_true_if_is_enum(): void
+    public function test_it_should_return_true_if_is_not_enum(): void
     {
         $isEnum = new IsEnum();
         $classDescription = new ClassDescription(


### PR DESCRIPTION
---
name: 🎉 Implements IsEnum && IsNotEnum
about: Test if some classes are enum (or not)
---

<!--
Thank you for submitting new feature!
-->

### New Feature

<!-- Fill in the relevant information below to help triage your issue. -->

|    Q        |   A
|------------ | ------
| New Feature | yes
| RFC         | yes
| BC Break    | no
| Issue       | Close #...

#### Summary

Allows to tests if some "classes" in a given namespace are enums
