### PR TITLE
Implement logical or expression

### DIFF
--- a/src/Expression/Boolean/Orx.php
+++ b/src/Expression/Boolean/Orx.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Expression\Boolean;
+
+use Arkitect\Analyzer\ClassDescription;
+use Arkitect\Expression\Description;
+use Arkitect\Expression\Expression;
+use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
+use Arkitect\Rules\Violations;
+
+final class Orx implements Expression
+{
+    /** @var Expression[] */
+    private $expressions;
+
+    public function __construct(array $expressions)
+    {
+        $this->expressions = $expressions;
+    }
+
+    public function describe(ClassDescription $theClass, string $because): Description
+    {
+        return new Description('at least one expression must be true', $because);
+    }
+
+    public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
+    {
+        foreach ($this->expressions as $expression) {
+            $newViolations = new Violations();
+            $expression->evaluate($theClass, $newViolations, $because);
+            if (0 === $newViolations->count()) {
+                return;
+            }
+        }
+
+        $violations->add(Violation::create(
+            $theClass->getFQCN(),
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+        ));
+    }
+}

--- a/tests/Unit/Expressions/Boolean/OrxTest.php
+++ b/tests/Unit/Expressions/Boolean/OrxTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Expressions\Boolean;
+
+use Arkitect\Analyzer\ClassDescriptionBuilder;
+use Arkitect\Expression\Boolean\Orx;
+use Arkitect\Expression\ForClasses\Extend;
+use Arkitect\Rules\Violations;
+use PHPUnit\Framework\TestCase;
+
+final class OrxTest extends TestCase
+{
+    public function test_it_should_return_no_violation_on_success(): void
+    {
+        $or = new Orx([new Extend('My\BaseClass'), new Extend('Your\OtherClass')]);
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('My\Class')
+            ->setExtends('My\BaseClass', 10)
+            ->build();
+
+        $violations = new Violations();
+        $or->evaluate($classDescription, $violations, 'because');
+
+        self::assertEquals(0, $violations->count());
+    }
+}


### PR DESCRIPTION
## Motivation

Allow to define logical expressions which will help with more advanced or complex expressions. Class name is not perfect but `Or` is keyword hence can't be used directly as class name. `Orx` was inspired by doctrine project.

If we are fine with that approach then I can implement more (like `and`).