### PR TITLE
Bug: Anonymous class extends is parsed instead of class extends

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -33,7 +33,7 @@ class FileVisitor extends NodeVisitorAbstract
                      ->addInterface($interface->toString(), $interface->getLine());
             }
 
-            if (null !== $node->extends) {
+            if (!$node->isAnonymous() && null !== $node->extends) {
                 $this->classDescriptionBuilder
                     ->setExtends($node->extends->toString(), $node->getLine());
             }

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -128,6 +128,35 @@ EOF;
         $this->assertEquals('Root\Animals\Animal', $cd->getExtends()->toString());
     }
 
+    public function test_it_should_not_parse_extends_from_insider_anonymousclass(): void
+    {
+        $code = <<< 'EOF'
+<?php
+
+namespace Root\Animals;
+
+class Animal
+{
+}
+
+class Cat extends Animal
+{
+    public function methodWithAnonymous(): void
+    {
+        $obj = new class extends \stdClass {};
+    }
+}
+EOF;
+
+        /** @var FileParser $fp */
+        $fp = FileParserFactory::createFileParser(TargetPhpVersion::create('7.1'));
+        $fp->parse($code, 'relativePathName');
+
+        $cd = $fp->getClassDescriptions()[1];
+
+        $this->assertEquals('Root\Animals\Animal', $cd->getExtends()->toString());
+    }
+
     public function test_should_depends_on_these_namespaces(): void
     {
         $code = <<< 'EOF'


### PR DESCRIPTION
An anonymous class declared inside a normal class makes the parser take the `extends` from the anonymous class, instead of the correct one.

```
<?php
namespace Root\Animals;

class Animal
{
}

class Cat extends Animal
{
    public function methodWithAnonymous(): void
    {
        $obj = new class extends \stdClass {};
    }
}
```
This code above takes `stdClass` instead of the expected `Animal`.