### PR TITLE
Bug: Class ends pattern matches classes that contain the pattern

### DIFF
--- a/src/Analyzer/PatternString.php
+++ b/src/Analyzer/PatternString.php
@@ -46,7 +46,7 @@ class PatternString
 
     private function startsWithPattern(string $pattern): bool
     {
-        return 1 === preg_match('#^'.$this->convertShellToRegExPattern($pattern).'#', $this->value);
+        return 1 === preg_match('#^'.$this->convertShellToRegExPattern($pattern).'$#', $this->value);
     }
 
     private function convertShellToRegExPattern(string $pattern): string

--- a/tests/Unit/Analyzer/PatternStringTest.php
+++ b/tests/Unit/Analyzer/PatternStringTest.php
@@ -21,4 +21,11 @@ class PatternStringTest extends TestCase
         $this->assertTrue($pattern->matches('*This*'));
         $this->assertFalse($pattern->matches('This*'));
     }
+
+    public function test_ends_with(): void
+    {
+        $pattern = new PatternString('SoThisIsAnExample');
+        $this->assertTrue($pattern->matches('*Example'));
+        $this->assertFalse($pattern->matches('*This'));
+    }
 }


### PR DESCRIPTION
This is due to not checking strictly that the matched name must end with the pattern.