### PR TITLE
Multiple dirs class set

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
 use Arkitect\Rules\Rule;
 
 return static function (Config $config): void {
-    $mvcClassSet = ClassSet::fromDir(__DIR__.'/mvc');
+    $mvcClassSet = ClassSet::fromDir(__DIR__.'/mvc', __DIR__.'/lib/my-lib/src');
 
     $rules = [];
 

--- a/src/CLI/Progress/DebugProgress.php
+++ b/src/CLI/Progress/DebugProgress.php
@@ -17,7 +17,7 @@ class DebugProgress implements Progress
 
     public function startFileSetAnalysis(ClassSet $set): void
     {
-        $this->output->writeln("Start analyze dirs {$set->getDir()}");
+        $this->output->writeln("Start analyze dirs {$set->getDirsDescription()}");
     }
 
     public function startParsingFile(string $file): void

--- a/src/CLI/Progress/DebugProgress.php
+++ b/src/CLI/Progress/DebugProgress.php
@@ -17,7 +17,7 @@ class DebugProgress implements Progress
 
     public function startFileSetAnalysis(ClassSet $set): void
     {
-        $this->output->writeln("Start analyze dir {$set->getDir()}");
+        $this->output->writeln("Start analyze dirs {$set->getDir()}");
     }
 
     public function startParsingFile(string $file): void

--- a/src/CLI/Progress/ProgressBarProgress.php
+++ b/src/CLI/Progress/ProgressBarProgress.php
@@ -33,7 +33,7 @@ class ProgressBarProgress implements Progress
 
     public function startFileSetAnalysis(ClassSet $set): void
     {
-        $this->output->writeln("analyze class set {$set->getDir()}");
+        $this->output->writeln("analyze class set {$set->getDirsDescription()}");
         $this->output->writeln('');
         $this->progress = new ProgressBar($this->output, iterator_count($set));
 

--- a/src/ClassSet.php
+++ b/src/ClassSet.php
@@ -11,13 +11,14 @@ use Symfony\Component\Finder\Finder;
  */
 class ClassSet implements \IteratorAggregate
 {
-    private string $directory;
+    /** @var string[] */
+    private array $directoryList;
 
     private array $exclude;
 
-    private function __construct(string $directory)
+    private function __construct(string ...$directoryList)
     {
-        $this->directory = $directory;
+        $this->directoryList = $directoryList;
         $this->exclude = [];
     }
 
@@ -28,21 +29,21 @@ class ClassSet implements \IteratorAggregate
         return $this;
     }
 
-    public static function fromDir(string $directory): self
+    public static function fromDir(string ...$directoryList): self
     {
-        return new self($directory);
+        return new self(...$directoryList);
     }
 
     public function getDir(): string
     {
-        return $this->directory;
+        return implode(', ', $this->directoryList);
     }
 
     public function getIterator(): \Traversable
     {
         $finder = (new Finder())
             ->files()
-            ->in($this->directory)
+            ->in($this->directoryList)
             ->name('*.php')
             ->sortByName()
             ->followLinks()

--- a/src/ClassSet.php
+++ b/src/ClassSet.php
@@ -34,7 +34,7 @@ class ClassSet implements \IteratorAggregate
         return new self(...$directoryList);
     }
 
-    public function getDir(): string
+    public function getDirsDescription(): string
     {
         return implode(', ', $this->directoryList);
     }

--- a/tests/Unit/CLI/Progress/DebugProgressTest.php
+++ b/tests/Unit/CLI/Progress/DebugProgressTest.php
@@ -28,8 +28,8 @@ class DebugProgressTest extends TestCase
         $output = $this->prophesize(OutputInterface::class);
         $debugProgress = new DebugProgress($output->reveal());
 
-        $output->writeln('Start analyze dir directory')->shouldBeCalled();
-        $debugProgress->startFileSetAnalysis(ClassSet::fromDir('directory'));
+        $output->writeln('Start analyze dirs directory1, directory2')->shouldBeCalled();
+        $debugProgress->startFileSetAnalysis(ClassSet::fromDir('directory1', 'directory2'));
     }
 
     public function test_it_should_not_generate_text_on_end_parsing_file(): void

--- a/tests/Unit/ClassSetTest.php
+++ b/tests/Unit/ClassSetTest.php
@@ -10,6 +10,30 @@ use PHPUnit\Framework\TestCase;
 
 class ClassSetTest extends TestCase
 {
+    public function test_can_exclude_files_or_directories_from_multiple_dir_class_set(): void
+    {
+        $path = $this->createMvcProjectStructure();
+
+        $set = ClassSet::fromDir($path.'/Controller', $path.'/Model')
+            ->excludePath('Repository');
+
+        $expected = [
+            $path.'/Controller/CatalogController.php',
+            $path.'/Controller/Foo.php',
+            $path.'/Controller/ProductsController.php',
+            $path.'/Controller/UserController.php',
+            $path.'/Controller/YieldController.php',
+            $path.'/Model/Catalog.php',
+            $path.'/Model/Products.php',
+            $path.'/Model/User.php',
+        ];
+        $actual = array_values(array_map(function ($item) {
+            /** @var \SplFileInfo $item */
+            return $item->getPathname();
+        }, iterator_to_array($set)));
+        self::assertEquals($expected, $actual);
+    }
+
     public function test_can_exclude_files_or_directories(): void
     {
         $path = $this->createMvcProjectStructure();


### PR DESCRIPTION
Currently, if we want to include two folders from the project root, we need to add the root of the project and then exclude everything we dont want to include, and remember to add a folder to the config if we add a new folder to the project root.

With the `MultipleDirClassSet` we can specify just the directories we want it to scan,
removing all cruft from our config.
