### PR TITLE
Don't assume PHPARKITECT_COMPOSER_INSTALL is not defined yet

### DIFF
--- a/bin-stub/phparkitect
+++ b/bin-stub/phparkitect
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 use Arkitect\CLI\PhpArkitectApplication;
 
-foreach (array(__DIR__ . '/../../../autoload.php', __DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
-    if (file_exists($file)) {
-        define('PHPARKITECT_COMPOSER_INSTALL', $file);
+if (!defined('PHPARKITECT_COMPOSER_INSTALL')) {
+    foreach (array(__DIR__ . '/../../../autoload.php', __DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+        if (file_exists($file)) {
+            define('PHPARKITECT_COMPOSER_INSTALL', $file);
 
-        break;
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
By default, the classmap is not loaded, so it's not possible to use functions like `is_a` to infer inheritance of classes under test. To solve this, the autoloader must be included in the config file, but then it will try to define this variable again, which will cause it to throw an error.