### PR TITLE
Simplify usage of FileParserFactory

### DIFF
--- a/src/Analyzer/FileParserFactory.php
+++ b/src/Analyzer/FileParserFactory.php
@@ -9,13 +9,15 @@ use PhpParser\NodeTraverser;
 
 class FileParserFactory
 {
-    public static function createFileParser(TargetPhpVersion $targetPhpVersion, bool $parseCustomAnnotations = true): FileParser
-    {
+    public static function createFileParser(
+        TargetPhpVersion $targetPhpVersion = null,
+        bool $parseCustomAnnotations = true
+    ): FileParser {
         return new FileParser(
             new NodeTraverser(),
             new FileVisitor(new ClassDescriptionBuilder()),
             new NameResolver(null, ['parseCustomAnnotations' => $parseCustomAnnotations]),
-            $targetPhpVersion
+            $targetPhpVersion ?? TargetPhpVersion::create()
         );
     }
 }

--- a/src/CLI/TargetPhpVersion.php
+++ b/src/CLI/TargetPhpVersion.php
@@ -26,7 +26,7 @@ class TargetPhpVersion
         $this->version = $version;
     }
 
-    public static function create(?string $version): self
+    public static function create(string $version = null): self
     {
         if (null === $version) {
             return new self(phpversion());


### PR DESCRIPTION
By allowing createFileParser to be called with null we need less code everywhere else to create a default file parser.