### PR TITLE
Prevent duplicate namespaces in ResideInOneOfTheseNamespaces

### DIFF
--- a/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
+++ b/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
@@ -18,7 +18,7 @@ class ResideInOneOfTheseNamespaces implements Expression
 
     public function __construct(string ...$namespaces)
     {
-        $this->namespaces = $namespaces;
+        $this->namespaces = array_unique($namespaces);
     }
 
     public function describe(ClassDescription $theClass, string $because): Description


### PR DESCRIPTION
When building expressions automatically, with a builder, it sometimes happens that a namespace is added more than once.

Besides being redundant to have and check the same namespace more than once, the tests also become more difficult to assert on their outcomes.