### PR TITLE
Fix documentation about class NotResideInTheseNamespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ $rules[] = Rule::allClasses()
 ```php
 $rules[] = Rule::allClasses()
     ->that(new Extend('App\Domain\Event'))
-    ->should(new NotResideInOneOfTheseNamespaces('App\Application', 'App\Infrastructure'))
+    ->should(new NotResideInTheseNamespaces('App\Application', 'App\Infrastructure'))
     ->because('we want to be sure that all events not reside in wrong layers');
 ```
 


### PR DESCRIPTION
This PR fix an error in the README file. In the README the class `NotResideInOneOfTheseNamespaces` does not exist. The correct one is `NotResideInTheseNamespaces`.