### PR TITLE
Fix fatal error on startup with Symfony 7.x due to changes in command naming

### DIFF
--- a/src/CLI/Command/DebugExpression.php
+++ b/src/CLI/Command/DebugExpression.php
@@ -17,9 +17,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DebugExpression extends Command
 {
     /** @var string|null */
-    public static $defaultName = 'debug:expression';
-
-    /** @var string|null */
     public static $defaultDescription = <<< 'EOT'
 Check which classes respect an expression
 EOT;
@@ -28,6 +25,11 @@ EOT;
     public static $help = <<< 'EOT'
 Check which classes respect an expression
 EOT;
+
+    public function __construct()
+    {
+        parent::__construct('debug:expression');
+    }
 
     protected function configure(): void
     {

--- a/src/CLI/Command/Init.php
+++ b/src/CLI/Command/Init.php
@@ -12,9 +12,6 @@ use Webmozart\Assert\Assert;
 class Init extends Command
 {
     /** @var string|null */
-    public static $defaultName = 'init';
-
-    /** @var string|null */
     public static $defaultDescription = <<< 'EOT'
 Creates a new phparkitect.php file
 EOT;
@@ -24,6 +21,11 @@ EOT;
 This command creates a new phparkitect.php in the current directory
 You can customize the directory where the file is created specifying <comment>-d /dest/path</comment>
 EOT;
+
+    public function __construct()
+    {
+        parent::__construct('init');
+    }
 
     protected function configure(): void
     {


### PR DESCRIPTION
Fixes #419 

Aligns with `Check` command which does:

```php
    public function __construct()
    {
        parent::__construct('check');
    }
```