### PR TITLE
Fix handling unordered baseline violations with ignore line numbers option

### DIFF
--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -116,7 +116,7 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
             $this->violations = array_values(array_udiff(
                 $this->violations,
                 $violations->violations,
-                [__CLASS__, 'compareViolations'],
+                [__CLASS__, 'compareViolations']
             ));
 
             return;

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -165,7 +165,7 @@ App\Controller\Foo has 1 violations
         ?string $useBaseline = null,
         $generateBaseline = false,
         bool $skipBaseline = false,
-        bool $ignoreBaselineNumbers = false,
+        bool $ignoreBaselineNumbers = false
     ): ApplicationTester {
         $input = ['check'];
         if (null !== $configFilePath) {

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -146,12 +146,26 @@ App\Controller\Foo has 1 violations
         $this->assertCheckHasErrors($cmdTester);
     }
 
+    public function test_baseline_line_numbers_can_be_ignored(): void
+    {
+        $configFilePath = __DIR__.'/../_fixtures/configIgnoreBaselineLineNumbers.php';
+
+        // No errors when ignoring baseline line numbers
+        $cmdTester = $this->runCheck($configFilePath, null, __DIR__.'/../_fixtures/line_numbers/baseline.json', false, false, true);
+        $this->assertCheckHasSuccess($cmdTester);
+
+        // Errors when not ignoring baseline line numbers
+        $cmdTester = $this->runCheck($configFilePath, null, __DIR__.'/../_fixtures/line_numbers/baseline.json');
+        $this->assertCheckHasErrors($cmdTester);
+    }
+
     protected function runCheck(
         $configFilePath = null,
         ?bool $stopOnFailure = null,
         ?string $useBaseline = null,
         $generateBaseline = false,
-        bool $skipBaseline = false
+        bool $skipBaseline = false,
+        bool $ignoreBaselineNumbers = false,
     ): ApplicationTester {
         $input = ['check'];
         if (null !== $configFilePath) {
@@ -165,6 +179,10 @@ App\Controller\Foo has 1 violations
         }
         if ($skipBaseline) {
             $input['--skip-baseline'] = true;
+        }
+
+        if ($ignoreBaselineNumbers) {
+            $input['--ignore-baseline-linenumbers'] = true;
         }
 
         // false = option not set, null = option set but without value, string = option with value

--- a/tests/E2E/_fixtures/configIgnoreBaselineLineNumbers.php
+++ b/tests/E2E/_fixtures/configIgnoreBaselineLineNumbers.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Arkitect\ClassSet;
+use Arkitect\CLI\Config;
+use Arkitect\Expression\ForClasses\DependsOnlyOnTheseNamespaces;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+
+return static function (Config $config): void {
+    $rootPath = realpath(__DIR__);
+    $classSet = ClassSet::fromDir("$rootPath/line_numbers");
+
+    $rules = [
+        Rule::allClasses()
+            ->that(new ResideInOneOfTheseNamespaces('App\Application'))
+            ->should(new DependsOnlyOnTheseNamespaces('App\Application'))
+            ->because('That is how I want it'),
+    ];
+
+    $config->add($classSet, ...$rules);
+};

--- a/tests/E2E/_fixtures/line_numbers/Application/Foo.php
+++ b/tests/E2E/_fixtures/line_numbers/Application/Foo.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application;
+
+final class Foo
+{
+    public function doSomething(\App\Ui\Baz $baz): void
+    {
+    }
+
+    public function doSomethingElse(\App\Ui\Bar $bar): void
+    {
+    }
+
+    public function doSomethingElseEvenMore(\App\Ui\Bar $bar): void
+    {
+    }
+}

--- a/tests/E2E/_fixtures/line_numbers/baseline.json
+++ b/tests/E2E/_fixtures/line_numbers/baseline.json
@@ -1,0 +1,20 @@
+{
+    "violations": [
+        {
+            "fqcn": "App\\Application\\Foo",
+            "line": 13,
+            "error": "depends on App\\Ui\\Bar, but should depend only on classes in one of these namespaces: App\\Application because That is how I want it"
+        },
+        {
+            "fqcn": "App\\Application\\Foo",
+            "line": 20,
+            "error": "depends on App\\Ui\\Baz, but should depend only on classes in one of these namespaces: App\\Application because That is how I want it"
+        },
+        {
+            "fqcn": "App\\Application\\Foo",
+            "line": 17,
+            "error": "depends on App\\Ui\\Bar, but should depend only on classes in one of these namespaces: App\\Application because That is how I want it"
+        }
+    ],
+    "stopOnFailure": false
+}

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -187,11 +187,19 @@ App\Controller\Foo has 1 violations
 
         $violation2 = new Violation(
             'App\Controller\Shop',
-            'should implement AbstractController'
+            'should implement AbstractController',
+            21,
         );
         $this->violationStore->add($violation2);
 
-        $this->assertCount(3, $this->violationStore->toArray());
+        $violation3 = new Violation(
+            'App\Controller\Shop',
+            'should have name end with Controller',
+            5
+        );
+        $this->violationStore->add($violation3);
+
+        $this->assertCount(4, $this->violationStore->toArray());
 
         $violationsBaseline = new Violations();
         $violationsBaseline->add(new Violation(
@@ -202,10 +210,11 @@ App\Controller\Foo has 1 violations
 
         $this->violationStore->remove($violationsBaseline, true);
 
-        $this->assertCount(2, $this->violationStore->toArray());
+        $this->assertCount(3, $this->violationStore->toArray());
         $this->assertEquals([
             $this->violation,
             $violation2,
+            $violation3,
         ], $this->violationStore->toArray());
     }
 }

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -188,7 +188,7 @@ App\Controller\Foo has 1 violations
         $violation2 = new Violation(
             'App\Controller\Shop',
             'should implement AbstractController',
-            21,
+            21
         );
         $this->violationStore->add($violation2);
 


### PR DESCRIPTION
Handles unordered baseline violations when ignoring baseline numbers.
This resolves #428.