### PR TITLE
Fix code style

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
       run: composer install --prefer-dist
 
     - name: Coding Standard Checks
+      if: ${{ matrix.php-versions >= '8.0' }}
       run: PHP_CS_FIXER_IGNORE_ENV=1 ./bin/php-cs-fixer fix --dry-run -v
 
     - name: Static Analysis

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,7 +24,7 @@ return (new PhpCsFixer\Config())
         'modernize_types_casting' => true, // Replaces intval, floatval, doubleval, strval and boolval function calls with according type casting operator.
         'multiline_whitespace_before_semicolons' => true, // Forbid multi-line whitespace before the closing semicolon or move the semicolon to the new line for chained calls.
         'no_unreachable_default_argument_value' => true, // In function arguments there must not be arguments with default values before non-default ones.
-	'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],// To avoid problems of compatibility with the old php-cs-fixer version used on PHP 7.3
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true], // To avoid problems of compatibility with the old php-cs-fixer version used on PHP 7.3
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_class_elements' => true, // Orders the elements of classes/interfaces/traits.
@@ -40,5 +40,8 @@ return (new PhpCsFixer\Config())
         'list_syntax' => ['syntax' => 'short'],
         'phpdoc_to_comment' => false,
         'php_unit_method_casing' => ['case' => 'snake_case'],
-        'function_to_constant' => false
+        'function_to_constant' => false,
+        'trailing_comma_in_multiline' => [
+            'elements' => ['array_destructuring', 'arrays'],
+        ],
     ]);

--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -44,7 +44,6 @@ class ClassDescription
     /**
      * @param list<ClassDependency>         $dependencies
      * @param list<FullyQualifiedClassName> $interfaces
-     * @param ?FullyQualifiedClassName      $extends
      * @param list<FullyQualifiedClassName> $attributes
      */
     public function __construct(

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -125,7 +125,7 @@ class Check extends Command
             $this->printHeadingLine($output);
 
             $rulesFilename = $this->getConfigFilename($input);
-            $output->writeln(sprintf("Config file: %s\n", $rulesFilename));
+            $output->writeln(\sprintf("Config file: %s\n", $rulesFilename));
 
             $config = new Config();
 
@@ -239,14 +239,14 @@ class Check extends Command
     private function printViolations(Violations $violations, OutputInterface $output): void
     {
         $output->writeln('<error>ERRORS!</error>');
-        $output->writeln(sprintf('%s', $violations->toString()));
-        $output->writeln(sprintf('<error>%s VIOLATIONS DETECTED!</error>', \count($violations)));
+        $output->writeln(\sprintf('%s', $violations->toString()));
+        $output->writeln(\sprintf('<error>%s VIOLATIONS DETECTED!</error>', \count($violations)));
     }
 
     private function printParsedErrors(ParsingErrors $parsingErrors, OutputInterface $output): void
     {
         $output->writeln('<error>ERROR ON PARSING THESE FILES:</error>');
-        $output->writeln(sprintf('%s', $parsingErrors->toString()));
+        $output->writeln(\sprintf('%s', $parsingErrors->toString()));
     }
 
     private function printNoViolationsDetectedMessage(OutputInterface $output): void

--- a/src/CLI/PhpArkitectApplication.php
+++ b/src/CLI/PhpArkitectApplication.php
@@ -28,6 +28,6 @@ EOD;
 
     public function getLongVersion(): string
     {
-        return sprintf("%s\n\n<info>%s</info> version <comment>%s</comment>", self::$logo, $this->getName(), $this->getVersion());
+        return \sprintf("%s\n\n<info>%s</info> version <comment>%s</comment>", self::$logo, $this->getName(), $this->getVersion());
     }
 }

--- a/src/Exceptions/IndexNotFoundException.php
+++ b/src/Exceptions/IndexNotFoundException.php
@@ -7,6 +7,6 @@ class IndexNotFoundException extends \Exception
 {
     public function __construct(int $index)
     {
-        parent::__construct(sprintf('Index not found %d', $index));
+        parent::__construct(\sprintf('Index not found %d', $index));
     }
 }

--- a/src/Exceptions/PhpVersionNotValidException.php
+++ b/src/Exceptions/PhpVersionNotValidException.php
@@ -7,6 +7,6 @@ class PhpVersionNotValidException extends \Exception
 {
     public function __construct(string $phpVersion)
     {
-        parent::__construct(sprintf('PHP version not valid for PHPArkitect parser %s', $phpVersion));
+        parent::__construct(\sprintf('PHP version not valid for PHPArkitect parser %s', $phpVersion));
     }
 }

--- a/tests/Unit/Rules/ConstraintsTest.php
+++ b/tests/Unit/Rules/ConstraintsTest.php
@@ -18,7 +18,7 @@ class ConstraintsTest extends TestCase
 {
     public function test_it_should_not_add_to_violation_if_constraint_is_not_violated(): void
     {
-        $trueExpression = new class() implements Expression {
+        $trueExpression = new class implements Expression {
             public function describe(ClassDescription $theClass, string $because): Description
             {
                 return new Description('', '');
@@ -48,7 +48,7 @@ class ConstraintsTest extends TestCase
 
     public function test_it_should_add_to_violation_store_if_constraint_is_violated(): void
     {
-        $falseExpression = new class() implements Expression {
+        $falseExpression = new class implements Expression {
             public function describe(ClassDescription $theClass, string $because): Description
             {
                 return new Description('bar', 'we want to add this rule');


### PR DESCRIPTION
Currently CI checks fail due to code style issues being reported by the latest version of CS fixer. This PR fixes these issues and also changes configuration for `trailing_comma_in_multiline` fixer not to add comma after parameters, because it's not allowed in PHP 7. 