### PR TITLE
fix: Add consideration of Node\Attribute to FileVisitor

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -224,6 +224,15 @@ class FileVisitor extends NodeVisitorAbstract
                     ->addDependency(new ClassDependency($returnType->toString(), $returnType->getLine()));
             }
         }
+
+        if ($node instanceof Node\Attribute) {
+            $nodeName = $node->name;
+
+            if ($nodeName instanceof Node\Name\FullyQualified) {
+                $this->classDescriptionBuilder
+                    ->addDependency(new ClassDependency(implode('\\', $nodeName->getParts()), $node->getLine()));
+            }
+        }
     }
 
     public function getClassDescriptions(): array

--- a/tests/E2E/PHPUnit/CheckAttributeDependencyTest.php
+++ b/tests/E2E/PHPUnit/CheckAttributeDependencyTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Arkitect\Tests\E2E\PHPUnit;
 
 use Arkitect\ClassSet;
-use Arkitect\Expression\ForClasses\Implement;
 use Arkitect\Expression\ForClasses\NotDependsOnTheseNamespaces;
 use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
 use Arkitect\Rules\Rule;

--- a/tests/E2E/PHPUnit/CheckAttributeDependencyTest.php
+++ b/tests/E2E/PHPUnit/CheckAttributeDependencyTest.php
@@ -22,9 +22,7 @@ class CheckAttributeDependencyTest extends TestCase
             ->should(new NotDependsOnTheseNamespaces('App\Service\Invalid'))
             ->because('i said so');
 
-        $expectedExceptionMessage = '
-App\Service\Foo has 1 violations
-  should not depend on these namespaces: App\Service\Invalid because i said so';
+        $expectedExceptionMessage = 'depends on App\Service\Invalid\Attr, but should not depend on these namespaces: App\Service\Invalid because i said so';
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);

--- a/tests/E2E/PHPUnit/CheckAttributeDependencyTest.php
+++ b/tests/E2E/PHPUnit/CheckAttributeDependencyTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\E2E\PHPUnit;
+
+use Arkitect\ClassSet;
+use Arkitect\Expression\ForClasses\Implement;
+use Arkitect\Expression\ForClasses\NotDependsOnTheseNamespaces;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+
+class CheckAttributeDependencyTest extends TestCase
+{
+    public function test_assertion_should_fail_on_invalid_dependency(): void
+    {
+        $set = ClassSet::fromDir(__DIR__.'/../_fixtures/attributes');
+
+        $rule = Rule::allClasses()
+            ->that(new ResideInOneOfTheseNamespaces('App\Service'))
+            ->should(new NotDependsOnTheseNamespaces('App\Service\Invalid'))
+            ->because('i said so');
+
+        $expectedExceptionMessage = '
+App\Service\Foo has 1 violations
+  should not depend on these namespaces: App\Service\Invalid because i said so';
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        ArchRuleTestCase::assertArchRule($rule, $set);
+    }
+}

--- a/tests/E2E/PHPUnit/CheckAttributeDependencyTest.php
+++ b/tests/E2E/PHPUnit/CheckAttributeDependencyTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 
 class CheckAttributeDependencyTest extends TestCase
 {
+    /**
+     * @requires PHP >= 8.0
+     */
     public function test_assertion_should_fail_on_invalid_dependency(): void
     {
         $set = ClassSet::fromDir(__DIR__.'/../_fixtures/attributes');

--- a/tests/E2E/_fixtures/attributes/Foo.php
+++ b/tests/E2E/_fixtures/attributes/Foo.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Service\Valid\Attr as ValidAttr;
+use App\Service\Invalid\Attr as InvalidAttr;
+
+#[ValidAttr, InvalidAttr]
+class Foo
+{
+
+}

--- a/tests/E2E/_fixtures/attributes/Foo.php
+++ b/tests/E2E/_fixtures/attributes/Foo.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace App\Service;
 
-use App\Service\Valid\Attr as ValidAttr;
 use App\Service\Invalid\Attr as InvalidAttr;
+use App\Service\Valid\Attr as ValidAttr;
 
 #[ValidAttr, InvalidAttr]
 class Foo
 {
-
 }

--- a/tests/E2E/_fixtures/attributes/Invalid/Attr.php
+++ b/tests/E2E/_fixtures/attributes/Invalid/Attr.php
@@ -9,5 +9,4 @@ use Attribute;
 #[Attribute]
 class Attr
 {
-
 }

--- a/tests/E2E/_fixtures/attributes/Invalid/Attr.php
+++ b/tests/E2E/_fixtures/attributes/Invalid/Attr.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Invalid;
+
+use Attribute;
+
+#[Attribute]
+class Attr
+{
+
+}

--- a/tests/E2E/_fixtures/attributes/Valid/Attr.php
+++ b/tests/E2E/_fixtures/attributes/Valid/Attr.php
@@ -9,5 +9,4 @@ use Attribute;
 #[Attribute]
 class Attr
 {
-
 }

--- a/tests/E2E/_fixtures/attributes/Valid/Attr.php
+++ b/tests/E2E/_fixtures/attributes/Valid/Attr.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Valid;
+
+use Attribute;
+
+#[Attribute]
+class Attr
+{
+
+}

--- a/tests/E2E/_fixtures/parse_error/Services/CartService.php
+++ b/tests/E2E/_fixtures/parse_error/Services/CartService.php
@@ -5,6 +5,6 @@ namespace App\Services;
 
 use ContainerAwareInterface;
 
-class Cart Service implements ContainerAwareInterface
+class CartService implements ContainerAwareInterface
 {
 }

--- a/tests/E2E/_fixtures/parse_error/Services/CartService.php
+++ b/tests/E2E/_fixtures/parse_error/Services/CartService.php
@@ -5,6 +5,6 @@ namespace App\Services;
 
 use ContainerAwareInterface;
 
-class CartService implements ContainerAwareInterface
+class Cart Service implements ContainerAwareInterface
 {
 }


### PR DESCRIPTION
At the moment imports of Attributes are ignored. This results in unreliable results. 

I've adjusted the code to take imports from attributes into account. 