### PR TITLE
Support php 8.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         coverage-driver: [ 'pcov' ]
 
     steps:
@@ -58,7 +58,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   phar:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: build
     steps:
       - uses: actions/checkout@v3
@@ -95,8 +95,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     strategy:
       matrix:
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
-
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     steps:
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,11 @@ jobs:
       run: composer install --prefer-dist
 
     - name: Coding Standard Checks
+      if: ${{ matrix.php-versions  == '7.4' }}
       run: PHP_CS_FIXER_IGNORE_ENV=1 ./bin/php-cs-fixer fix --dry-run -v
 
     - name: Static Analysis
+      if: ${{ matrix.php-versions  == '7.4' }}
       run: ./bin/psalm.phar
 
     - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Static Analysis
       if: ${{ matrix.php-versions  == '7.4' }}
-      run: ./bin/psalm.phar
+      run: ./bin/psalm.phar --no-cache
 
     - name: Test
       run: ./bin/phpunit -d memory_limit=-1 --coverage-clover clover.xml

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ psalm: ## it launches psalm
 build: ## it launches all the build
 	composer install
 	PHP_CS_FIXER_IGNORE_ENV=1 bin/php-cs-fixer fix -v
-	bin/psalm
+	bin/psalm.phar --no-cache
 	bin/phpunit
 
 sfbuild: ## it launches all the build

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ coverage: ## it launches coverage
 	phpdbg -qrr ./bin/phpunit --coverage-html build/coverage
 
 csfix: ## it launches cs fix
-	bin/php-cs-fixer fix -v
+	PHP_CS_FIXER_IGNORE_ENV=1 bin/php-cs-fixer fix -v
 
 psalm: ## it launches psalm
 	bin/psalm.phar

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/event-dispatcher": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "symfony/console": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "symfony/polyfill-php80": "^1.20",
-        "nikic/php-parser": "~4",
+        "nikic/php-parser": "~5",
         "webmozart/assert": "^1.9",
         "ext-json": "*",
         "phpstan/phpdoc-parser": "^1.2",

--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Arkitect\Analyzer;
@@ -6,9 +7,9 @@ namespace Arkitect\Analyzer;
 use Arkitect\CLI\TargetPhpVersion;
 use Arkitect\Rules\ParsingError;
 use PhpParser\ErrorHandler\Collecting;
-use PhpParser\Lexer\Emulative;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
 
 class FileParser implements Parser
 {
@@ -33,12 +34,7 @@ class FileParser implements Parser
         $this->fileVisitor = $fileVisitor;
         $this->parsingErrors = [];
 
-        $lexer = new Emulative([
-            'usedAttributes' => ['comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos'],
-            'phpVersion' => $targetPhpVersion->get() ?? phpversion(),
-        ]);
-
-        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
+        $this->parser = (new ParserFactory())->createForVersion(PhpVersion::fromString($targetPhpVersion->get() ?? phpversion()));
         $this->traverser = $traverser;
         $this->traverser->addVisitor($nameResolver);
         $this->traverser->addVisitor($this->fileVisitor);

--- a/src/Analyzer/NameResolver.php
+++ b/src/Analyzer/NameResolver.php
@@ -320,7 +320,12 @@ class NameResolver extends NodeVisitorAbstract
         }
     }
 
-    /** @param Stmt\Use_::TYPE_* $type */
+    /**
+     * @param Stmt\Use_::TYPE_* $type
+     * @param ?Name             $prefix
+     *
+     * @psalm-suppress PossiblyNullArgument
+     */
     private function addAlias(Node\UseItem $use, int $type, ?Name $prefix = null): void
     {
         // Add prefix for group uses
@@ -377,6 +382,7 @@ class NameResolver extends NodeVisitorAbstract
      * @psalm-suppress MissingParamType
      * @psalm-suppress PossiblyNullArgument
      * @psalm-suppress MissingReturnType
+     * @psalm-suppress InvalidReturnStatement
      *
      * @template T of Node\Identifier|Name|Node\ComplexType|null
      *

--- a/src/CLI/TargetPhpVersion.php
+++ b/src/CLI/TargetPhpVersion.php
@@ -14,6 +14,7 @@ class TargetPhpVersion
         '8.1',
         '8.2',
         '8.3',
+        '8.4',
     ];
 
     /** @var string|null */
@@ -23,7 +24,7 @@ class TargetPhpVersion
     {
         $versionNumbers = explode('.', $version);
         if (3 <= \count($versionNumbers)) {
-            $version = $versionNumbers[0].'.'.$versionNumbers[1];
+            $version = $versionNumbers[0] . '.' . $versionNumbers[1];
         }
 
         if (!\in_array($version, self::VALID_PHP_VERSIONS)) {

--- a/src/CLI/TargetPhpVersion.php
+++ b/src/CLI/TargetPhpVersion.php
@@ -24,7 +24,7 @@ class TargetPhpVersion
     {
         $versionNumbers = explode('.', $version);
         if (3 <= \count($versionNumbers)) {
-            $version = $versionNumbers[0] . '.' . $versionNumbers[1];
+            $version = $versionNumbers[0].'.'.$versionNumbers[1];
         }
 
         if (!\in_array($version, self::VALID_PHP_VERSIONS)) {

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -1343,4 +1343,38 @@ enum IntEnum: int
 EOF
         ];
     }
+
+    /**
+     * @requires PHP >= 8.4
+     */
+    public function test_it_parse_property_hooks(): void
+    {
+        $code = <<< 'EOF'
+<?php
+namespace App\Foo;
+
+class User {
+    private string $firstName;
+    private string $lastName;
+
+    public function __construct(string $firstName, string $lastName) {
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+    }
+
+    public string $fullName {
+        get => $this->firstName . ' ' . $this->lastName;
+        set {[$this->firstName, $this->lastName] = explode(' ', $value, 2);}
+    }
+}
+EOF;
+
+        /** @var FileParser $fp */
+        $fp = FileParserFactory::createFileParser(TargetPhpVersion::create('8.4'));
+        $fp->parse($code, 'relativePathName');
+
+        $cd = $fp->getClassDescriptions();
+
+        $this->assertInstanceOf(ClassDescription::class, $cd[0]);
+    }
 }


### PR DESCRIPTION
* added php 8.4 to the build matrix
* do static checks only on php 7.4 to avoid random results
* upgraded PHP Parser to version 5 to be able to parse php 8.4 code
* added a test to verify php 8.4 can be parsed
* updated our custom NameResolver (ugly, we should find a way to avoid that 😅) 