### PR TITLE
Refactor tests to use ClassDescriptionBuilder instead of new ClassDescription 

### DIFF
--- a/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\ContainDocBlockLike;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -16,19 +15,11 @@ class ContainDocBlockLikeTest extends TestCase
     {
         $expression = new ContainDocBlockLike('myDocBlock');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland\Myclass'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            ['/**  */myDocBlock with other information']
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland\Myclass')
+            ->addDocBlock('/**  */myDocBlock with other information')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($classDescription, $violations, $because);
@@ -40,50 +31,15 @@ class ContainDocBlockLikeTest extends TestCase
         );
     }
 
-    public function test_it_should_return_true_if_contains_doc_block_without_because(): void
-    {
-        $expression = new ContainDocBlockLike('myDocBlock');
-
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland\Myclass'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            ['/**  */myDocBlock with other information']
-        );
-        $violations = new Violations();
-        $expression->evaluate($classDescription, $violations, '');
-
-        self::assertEquals(0, $violations->count());
-        self::assertEquals(
-            'should have a doc block that contains myDocBlock',
-            $expression->describe($classDescription, '')->toString()
-        );
-    }
-
     public function test_it_should_return_false_if_not_contains_doc_block(): void
     {
         $expression = new ContainDocBlockLike('anotherDocBlock');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland\Myclass'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            ['/**  */myDocBlock with other information']
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland\Myclass')
+            ->addDocBlock('/**  */myDocBlock with other information')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($classDescription, $violations, $because);

--- a/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
@@ -17,6 +17,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
         $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $dependOnClasses->evaluate($classDescription, $violations, $because);

--- a/tests/Unit/Expressions/ForClasses/ExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/ExtendTest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Analyzer\ClassDescriptionBuilder;
-use Arkitect\Analyzer\FullyQualifiedClassName;
 use Arkitect\Expression\ForClasses\Extend;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -77,18 +75,9 @@ class ExtendTest extends TestCase
     {
         $extend = new Extend('My\BaseClass');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
 
         $because = 'we want to add this rule for our software';
         $violationError = $extend->describe($classDescription, $because)->toString();

--- a/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\HaveAttribute;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -16,20 +15,11 @@ class HaveAttributeTest extends TestCase
     {
         $expression = new HaveAttribute('myAttribute');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland\Myclass'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            [],
-            [FullyQualifiedClassName::fromString('myAttribute')]
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland\Myclass')
+            ->addAttribute('myAttribute', 1)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($classDescription, $violations, $because);
@@ -45,20 +35,11 @@ class HaveAttributeTest extends TestCase
     {
         $expression = new HaveAttribute('myAttribute');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland\Myclass'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            [],
-            [FullyQualifiedClassName::fromString('myAttribute')]
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland\Myclass')
+            ->addAttribute('myAttribute', 1)
+            ->build();
+
         $violations = new Violations();
         $expression->evaluate($classDescription, $violations, '');
 
@@ -73,20 +54,11 @@ class HaveAttributeTest extends TestCase
     {
         $expression = new HaveAttribute('anotherAttribute');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland\Myclass'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            [],
-            [FullyQualifiedClassName::fromString('myAttribute')]
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland\Myclass')
+            ->addAttribute('myAttribute', 1)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($classDescription, $violations, $because);

--- a/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
@@ -15,6 +15,7 @@ class HaveNameMatchingTest extends TestCase
         $expression = new HaveNameMatching('*Class');
 
         $goodClass = ClassDescription::getBuilder('\App\MyClass')->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($goodClass, $violations, $because);
@@ -26,6 +27,7 @@ class HaveNameMatchingTest extends TestCase
         $expression = new HaveNameMatching('*GoodName*');
 
         $badClass = ClassDescription::getBuilder('\App\BadNameClass')->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($badClass, $violations, $because);

--- a/tests/Unit/Expressions/ForClasses/ImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/ImplementTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\Implement;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -14,98 +13,67 @@ class ImplementTest extends TestCase
 {
     public function test_it_should_return_violation_error(): void
     {
-        $interface = 'interface';
+        $implementConstraint = new Implement('interface');
 
-        $implementConstraint = new Implement($interface);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
 
         $because = 'we want to add this rule for our software';
         $violationError = $implementConstraint->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('should implement '.$interface.' because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('should implement interface because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_not_depends_on_namespace(): void
     {
-        $interface = 'interface';
+        $implementConstraint = new Implement('interface');
 
-        $implementConstraint = new Implement($interface);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [FullyQualifiedClassName::fromString('foo')],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addInterface('Foo', 1)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, $because);
+
         self::assertNotEquals(0, $violations->count());
     }
 
     public function test_it_should_return_false_if_depends_on_namespace(): void
     {
-        $interface = 'interface';
+        $implementConstraint = new Implement('interface');
 
-        $implementConstraint = new Implement($interface);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [FullyQualifiedClassName::fromString('interface')],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addInterface('interface', 1)
+            ->build();
+
         $because = 'we want to add this rule for our software';
 
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 
     public function test_it_should_check_the_complete_fqcn(): void
     {
-        $interfaceName = '\Foo\Order';
+        $implementConstraint = new Implement('\Foo\Order');
 
-        $implementConstraint = new Implement($interfaceName);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [FullyQualifiedClassName::fromString('\Foo\Orderable')],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addInterface('\Foo\Orderable', 1)
+            ->build();
+
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, '');
+
         self::assertEquals(1, $violations->count());
     }
 
@@ -114,22 +82,17 @@ class ImplementTest extends TestCase
         $interface = 'interface';
 
         $implementConstraint = new Implement($interface);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            true,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setInterface(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
 
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsAbstract;
 use Arkitect\Expression\ForClasses\IsNotAbstract;
 use Arkitect\Rules\Violations;
@@ -16,46 +15,36 @@ class IsAbstractTest extends TestCase
     public function test_it_should_return_violation_error(): void
     {
         $isAbstract = new IsAbstract();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isAbstract->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $isAbstract->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should be abstract because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('HappyIsland should be abstract because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_abstract(): void
     {
         $isAbstract = new IsAbstract();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            true,
-            true,
-            true,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setFinal(true)
+            ->setReadonly(true)
+            ->setAbstract(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isAbstract->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 
@@ -63,18 +52,11 @@ class IsAbstractTest extends TestCase
     {
         $isAbstract = new IsAbstract();
         $isNotAbstract = new IsNotAbstract();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            true,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setInterface(true)
+            ->build();
 
         self::assertFalse($isAbstract->appliesTo($classDescription));
         self::assertFalse($isNotAbstract->appliesTo($classDescription));
@@ -85,18 +67,10 @@ class IsAbstractTest extends TestCase
         $isAbstract = new IsAbstract();
         $isNotAbstract = new IsNotAbstract();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            true,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setTrait(true)
+            ->build();
 
         self::assertFalse($isAbstract->appliesTo($classDescription));
         self::assertFalse($isNotAbstract->appliesTo($classDescription));
@@ -107,18 +81,10 @@ class IsAbstractTest extends TestCase
         $isAbstract = new IsAbstract();
         $isNotAbstract = new IsNotAbstract();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setEnum(true)
+            ->build();
 
         self::assertFalse($isAbstract->appliesTo($classDescription));
         self::assertFalse($isNotAbstract->appliesTo($classDescription));
@@ -129,18 +95,10 @@ class IsAbstractTest extends TestCase
         $isAbstract = new IsAbstract();
         $isNotAbstract = new IsNotAbstract();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            true,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setFinal(true)
+            ->build();
 
         self::assertFalse($isAbstract->appliesTo($classDescription));
         self::assertFalse($isNotAbstract->appliesTo($classDescription));

--- a/tests/Unit/Expressions/ForClasses/IsEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsEnumTest.php
@@ -3,8 +3,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsEnum;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -14,46 +13,34 @@ class IsEnumTest extends TestCase
     public function test_it_should_return_violation_error(): void
     {
         $isEnum = new IsEnum();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isEnum->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $isEnum->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should be an enum because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('HappyIsland should be an enum because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_enum(): void
     {
         $isEnum = new IsEnum();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setEnum(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isEnum->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/IsFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsFinalTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsFinal;
 use Arkitect\Expression\ForClasses\IsNotFinal;
 use Arkitect\Rules\Violations;
@@ -16,39 +15,26 @@ class IsFinalTest extends TestCase
     public function test_it_should_return_error_description(): void
     {
         $isFinal = new IsFinal();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isFinal->describe($classDescription, $because)->toString();
 
-        $this->assertEquals('HappyIsland should be final because we want to add this rule for our software', $violationError);
+        self::assertEquals('HappyIsland should be final because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_final(): void
     {
         $isFinal = new IsFinal();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            true,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setFinal(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
 
@@ -57,23 +43,15 @@ class IsFinalTest extends TestCase
         self::assertEquals(0, $violations->count());
     }
 
-    public function test_final_classes_can_not_be_abstract_and_should_be_ignored(): void
+    public function test_abstract_classes_can_not_be_final_and_should_be_ignored(): void
     {
         $isFinal = new IsFinal();
         $isNotFinal = new IsNotFinal();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            true,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setAbstract(true)
+            ->build();
 
         self::assertFalse($isFinal->appliesTo($classDescription));
         self::assertFalse($isNotFinal->appliesTo($classDescription));
@@ -84,18 +62,10 @@ class IsFinalTest extends TestCase
         $isFinal = new IsFinal();
         $isNotFinal = new IsNotFinal();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            true,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setInterface(true)
+            ->build();
 
         self::assertFalse($isFinal->appliesTo($classDescription));
         self::assertFalse($isNotFinal->appliesTo($classDescription));
@@ -106,18 +76,10 @@ class IsFinalTest extends TestCase
         $isFinal = new IsFinal();
         $isNotFinal = new IsNotFinal();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            true,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setTrait(true)
+            ->build();
 
         self::assertFalse($isFinal->appliesTo($classDescription));
         self::assertFalse($isNotFinal->appliesTo($classDescription));
@@ -128,18 +90,10 @@ class IsFinalTest extends TestCase
         $isFinal = new IsFinal();
         $isNotFinal = new IsNotFinal();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setEnum(true)
+            ->build();
 
         self::assertFalse($isFinal->appliesTo($classDescription));
         self::assertFalse($isNotFinal->appliesTo($classDescription));

--- a/tests/Unit/Expressions/ForClasses/IsInterfaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsInterfaceTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsInterface;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -15,46 +14,34 @@ class IsInterfaceTest extends TestCase
     public function test_it_should_return_violation_error(): void
     {
         $isFinal = new IsInterface();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isFinal->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $isFinal->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should be an interface because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('HappyIsland should be an interface because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_interface(): void
     {
         $isFinal = new IsInterface();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            true,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setInterface(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isFinal->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsNotAbstract;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -15,46 +14,34 @@ class IsNotAbstractTest extends TestCase
     public function test_it_should_return_violation_error(): void
     {
         $isAbstract = new IsNotAbstract();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            true,
-            false,
-            true,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setAbstract(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isAbstract->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $isAbstract->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should not be abstract because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('HappyIsland should not be abstract because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_abstract(): void
     {
         $isAbstract = new IsNotAbstract();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isAbstract->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
@@ -3,8 +3,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsNotEnum;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -14,46 +13,35 @@ class IsNotEnumTest extends TestCase
     public function test_it_should_return_violation_error(): void
     {
         $isEnum = new IsNotEnum();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setEnum(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isEnum->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $isEnum->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should not be an enum because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('HappyIsland should not be an enum because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_not_enum(): void
     {
         $isEnum = new IsNotEnum();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setEnum(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isEnum->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
@@ -35,7 +35,6 @@ class IsNotEnumTest extends TestCase
 
         $classDescription = (new ClassDescriptionBuilder())
             ->setClassName('HappyIsland')
-            ->setEnum(true)
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsNotFinal;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -15,18 +14,12 @@ class IsNotFinalTest extends TestCase
     public function test_it_should_return_violation_if_is_final(): void
     {
         $isFinal = new IsNotFinal();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            true,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setFinal(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
 

--- a/tests/Unit/Expressions/ForClasses/IsNotInterfaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotInterfaceTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsNotInterface;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -15,46 +14,34 @@ class IsNotInterfaceTest extends TestCase
     public function test_it_should_return_violation_error(): void
     {
         $isFinal = new IsNotInterface();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            true,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setInterface(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isFinal->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $isFinal->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should not be an interface because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('HappyIsland should not be an interface because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_not_interface(): void
     {
         $isFinal = new IsNotInterface();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isFinal->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/IsNotReadonlyTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotReadonlyTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsNotReadonly;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -16,47 +15,33 @@ class IsNotReadonlyTest extends TestCase
     {
         $isNotReadonly = new IsNotReadonly();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            true,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setReadonly(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isNotReadonly->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $isNotReadonly->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should not be readonly because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('HappyIsland should not be readonly because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_not_readonly(): void
     {
         $isNotReadonly = new IsNotReadonly();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isNotReadonly->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/IsNotTraitTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotTraitTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsNotTrait;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -15,46 +14,34 @@ class IsNotTraitTest extends TestCase
     public function test_it_should_return_violation_error(): void
     {
         $isFinal = new IsNotTrait();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            true,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setTrait(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isFinal->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $isFinal->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should not be trait because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('HappyIsland should not be trait because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_not_trait(): void
     {
         $isFinal = new IsNotTrait();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isFinal->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/IsReadonlyTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsReadonlyTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsNotReadonly;
 use Arkitect\Expression\ForClasses\IsReadonly;
 use Arkitect\Rules\Violations;
@@ -17,18 +16,10 @@ class IsReadonlyTest extends TestCase
     {
         $isReadonly = new IsReadonly();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isReadonly->describe($classDescription, $because)->toString();
 
@@ -39,18 +30,11 @@ class IsReadonlyTest extends TestCase
     {
         $isReadonly = new IsReadonly();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            true,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setReadonly(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isReadonly->evaluate($classDescription, $violations, $because);
@@ -62,18 +46,11 @@ class IsReadonlyTest extends TestCase
     {
         $isReadonly = new IsReadonly();
         $isNotReadonly = new IsNotReadonly();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            true,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setInterface(true)
+            ->build();
 
         self::assertFalse($isReadonly->appliesTo($classDescription));
         self::assertFalse($isNotReadonly->appliesTo($classDescription));
@@ -84,18 +61,10 @@ class IsReadonlyTest extends TestCase
         $isReadonly = new IsReadonly();
         $isNotReadonly = new IsNotReadonly();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            true,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setTrait(true)
+            ->build();
 
         self::assertFalse($isReadonly->appliesTo($classDescription));
         self::assertFalse($isNotReadonly->appliesTo($classDescription));
@@ -106,18 +75,10 @@ class IsReadonlyTest extends TestCase
         $isReadonly = new IsReadonly();
         $isNotReadonly = new IsNotReadonly();
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setEnum(true)
+            ->build();
 
         self::assertFalse($isReadonly->appliesTo($classDescription));
         self::assertFalse($isNotReadonly->appliesTo($classDescription));

--- a/tests/Unit/Expressions/ForClasses/IsTraitTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsTraitTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\IsTrait;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -15,46 +14,34 @@ class IsTraitTest extends TestCase
     public function test_it_should_return_violation_error(): void
     {
         $isFinal = new IsTrait();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $isFinal->describe($classDescription, $because)->toString();
 
         $violations = new Violations();
         $isFinal->evaluate($classDescription, $violations, $because);
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals('HappyIsland should be trait because we want to add this rule for our software', $violationError);
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals('HappyIsland should be trait because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_trait(): void
     {
         $isFinal = new IsTrait();
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            true,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setTrait(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $isFinal->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/MatchOneOfTheseNamesTest.php
+++ b/tests/Unit/Expressions/ForClasses/MatchOneOfTheseNamesTest.php
@@ -15,9 +15,11 @@ class MatchOneOfTheseNamesTest extends TestCase
         $expression = new MatchOneOfTheseNames(['*BadNameClass', '*Class']);
 
         $goodClass = ClassDescription::getBuilder('\App\MyClass')->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($goodClass, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 
@@ -26,11 +28,13 @@ class MatchOneOfTheseNamesTest extends TestCase
         $expression = new MatchOneOfTheseNames(['*BetterName*', '*GoodName*']);
 
         $badClass = ClassDescription::getBuilder('\App\BadNameClass')->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($badClass, $violations, $because);
+
         self::assertNotEquals(0, $violations->count());
-        $this->assertEquals(
+        self::assertEquals(
             'should have a name that matches *BetterName*, *GoodName* because we want to add this rule for our software',
             $expression->describe($badClass, $because)->toString()
         );

--- a/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\NotContainDocBlockLike;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -16,19 +15,11 @@ class NotContainDocBlockLikeTest extends TestCase
     {
         $expression = new NotContainDocBlockLike('anotherDocBlock');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland\Myclass'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            ['/**  */myDocBlock with other information']
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addDocBlock('/**  */myDocBlock with other information')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($classDescription, $violations, $because);
@@ -44,19 +35,11 @@ class NotContainDocBlockLikeTest extends TestCase
     {
         $expression = new NotContainDocBlockLike('anotherDocBlock');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland\Myclass'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            ['/**  */myDocBlock with other information']
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addDocBlock('/**  */myDocBlock with other information')
+            ->build();
+
         $violations = new Violations();
         $expression->evaluate($classDescription, $violations, '');
 
@@ -71,19 +54,11 @@ class NotContainDocBlockLikeTest extends TestCase
     {
         $expression = new NotContainDocBlockLike('myDocBlock');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland\Myclass'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            ['/**  */myDocBlock with other information']
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addDocBlock('/**  */myDocBlock with other information')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($classDescription, $violations, $because);

--- a/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
@@ -38,7 +38,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
         $notDependOnClasses->evaluate($classDescription, $violations, $because);
 
         self::assertEquals(1, $violations->count());
-        $this->assertEquals(
+        self::assertEquals(
             'depends on myNamespace\Banana, but should not depend on these namespaces: myNamespace because we want to add this rule for our software',
             $violations->get(0)->getError()
         );
@@ -59,7 +59,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
         $notDependOnClasses->evaluate($classDescription, $violations, $because);
 
         self::assertCount(1, $violations);
-        $this->assertEquals(
+        self::assertEquals(
             'depends on myNamespace\Banana, but should not depend on these namespaces: myNamespace because we want to add this rule for our software',
             $violations->get(0)->getError()
         );
@@ -79,7 +79,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
         $notDependOnClasses->evaluate($classDescription, $violations, $because);
 
         self::assertEquals(2, $violations->count());
-        $this->assertEquals(
+        self::assertEquals(
             'depends on myNamespace\Banana, but should not depend on these namespaces: myNamespace because we want to add this rule for our software',
             $violations->get(0)->getError()
         );

--- a/tests/Unit/Expressions/ForClasses/NotExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotExtendTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\NotExtend;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -16,22 +15,15 @@ class NotExtendTest extends TestCase
     {
         $notExtend = new NotExtend('My\BaseClass');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            FullyQualifiedClassName::fromString('My\BaseClass'),
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setExtends('My\BaseClass', 1)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $notExtend->describe($classDescription, $because)->toString();
-
         $violations = new Violations();
+
         $notExtend->evaluate($classDescription, $violations, $because);
 
         self::assertEquals(1, $violations->count());
@@ -42,22 +34,14 @@ class NotExtendTest extends TestCase
     {
         $notExtend = new NotExtend('My\BaseClass');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            FullyQualifiedClassName::fromString('My\AnotherClass'),
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
-        $because = 'we want to add this rule for our software';
-        $violationError = $notExtend->describe($classDescription, $because)->toString();
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setExtends('My\AnotherClass', 1)
+            ->build();
 
+        $because = 'we want to add this rule for our software';
         $violations = new Violations();
+
         $notExtend->evaluate($classDescription, $violations, $because);
 
         self::assertEquals(0, $violations->count());
@@ -67,22 +51,15 @@ class NotExtendTest extends TestCase
     {
         $notExtend = new NotExtend('My\FirstExtend', 'My\SecondExtend');
 
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            FullyQualifiedClassName::fromString('My\SecondExtend'),
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setExtends('My\SecondExtend', 1)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $notExtend->describe($classDescription, $because)->toString();
-
         $violations = new Violations();
+
         $notExtend->evaluate($classDescription, $violations, $because);
 
         self::assertEquals(1, $violations->count());

--- a/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
 use Arkitect\Analyzer\ClassDependency;
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\NotHaveDependencyOutsideNamespace;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -17,22 +16,15 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
     {
         $namespace = 'myNamespace';
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace($namespace);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violationError = $notHaveDependencyOutsideNamespace->describe($classDescription, $because)->toString();
 
-        $this->assertEquals(
+        self::assertEquals(
             'should not depend on classes outside namespace '.$namespace.' because we want to add this rule for our software',
             $violationError
         );
@@ -41,88 +33,66 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
     public function test_it_should_return_true_if_not_depends_on_namespace(): void
     {
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace');
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [new ClassDependency('myNamespace', 100)],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addDependency(new ClassDependency('myNamespace', 100))
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $notHaveDependencyOutsideNamespace->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 
     public function test_it_should_return_false_if_depends_on_namespace(): void
     {
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace');
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [
-                new ClassDependency('myNamespace', 100),
-                new ClassDependency('another\class', 200),
-                new ClassDependency('\DateTime', 300),
-            ],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addDependency(new ClassDependency('myNamespace', 100))
+            ->addDependency(new ClassDependency('another\class', 200))
+            ->addDependency(new ClassDependency('\DateTime', 300))
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $notHaveDependencyOutsideNamespace->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(2, $violations->count());
     }
 
     public function test_it_should_not_return_violation_error_if_dependency_excluded(): void
     {
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace', ['foo']);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [new ClassDependency('foo', 100)],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addDependency(new ClassDependency('foo', 100))
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $notHaveDependencyOutsideNamespace->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 
     public function test_it_should_not_return_violation_error_if_core_dependency_excluded(): void
     {
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace', [], true);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [new ClassDependency('\DateTime', 100)],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addDependency(new ClassDependency('\DateTime', 100))
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $notHaveDependencyOutsideNamespace->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/NotHaveNameMatchingTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveNameMatchingTest.php
@@ -19,8 +19,9 @@ class NotHaveNameMatchingTest extends TestCase
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
         $expression->evaluate($myClass, $violations, $because);
+
         self::assertEquals(1, $violations->count());
-        $this->assertEquals(
+        self::assertEquals(
             'should not have a name that matches *Class because we want to add this rule for our software',
             $expression->describe($myClass, $because)->toString()
         );
@@ -35,6 +36,7 @@ class NotHaveNameMatchingTest extends TestCase
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $expression->evaluate($badClass, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/NotImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotImplementTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Expressions\ForClasses;
 
-use Arkitect\Analyzer\ClassDescription;
-use Arkitect\Analyzer\FullyQualifiedClassName;
+use Arkitect\Analyzer\ClassDescriptionBuilder;
 use Arkitect\Expression\ForClasses\NotImplement;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -14,105 +13,70 @@ class NotImplementTest extends TestCase
 {
     public function test_it_should_return_violation_error(): void
     {
-        $interface = 'interface';
+        $implementConstraint = new NotImplement('interface');
 
-        $implementConstraint = new NotImplement($interface);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->build();
 
         $because = 'we want to add this rule for our software';
-        $violationError = $implementConstraint->describe($classDescription, $because)->toString();
-
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 
     public function test_it_should_return_true_if_not_depends_on_namespace(): void
     {
-        $interface = 'interface';
+        $implementConstraint = new NotImplement('interface');
 
-        $implementConstraint = new NotImplement($interface);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [FullyQualifiedClassName::fromString('foo')],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setExtends('foo', 1)
+            ->build();
+
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 
     public function test_it_should_return_false_if_depends_on_namespace(): void
     {
-        $interface = 'interface';
+        $implementConstraint = new NotImplement('interface');
 
-        $implementConstraint = new NotImplement($interface);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [FullyQualifiedClassName::fromString('interface')],
-            null,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->addInterface('interface', 1)
+            ->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, $because);
 
         $violationError = $implementConstraint->describe($classDescription, $because)->toString();
-        self::assertNotEquals(0, $violations->count());
 
-        $this->assertEquals(
-            'should not implement '.$interface.' because we want to add this rule for our software',
+        self::assertNotEquals(0, $violations->count());
+        self::assertEquals(
+            'should not implement interface because we want to add this rule for our software',
             $violationError
         );
     }
 
     public function test_it_should_return_if_is_an_interface(): void
     {
-        $interface = 'interface';
+        $implementConstraint = new NotImplement('interface');
 
-        $implementConstraint = new NotImplement($interface);
-        $classDescription = new ClassDescription(
-            FullyQualifiedClassName::fromString('HappyIsland'),
-            [],
-            [],
-            null,
-            false,
-            false,
-            false,
-            true,
-            false,
-            false
-        );
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setClassName('HappyIsland')
+            ->setInterface(true)
+            ->build();
+
         $because = 'we want to add this rule for our software';
-
         $violations = new Violations();
         $implementConstraint->evaluate($classDescription, $violations, $because);
+
         self::assertEquals(0, $violations->count());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/NotResideInTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotResideInTheseNamespacesTest.php
@@ -34,7 +34,7 @@ class NotResideInTheseNamespacesTest extends TestCase
         $haveNameMatching->evaluate($classDesc, $violations, $because);
 
         self::assertEquals(1, $violations->count());
-        $this->assertEquals(
+        self::assertEquals(
             'should not reside in one of these namespaces: '.$namespace.' because we want to add this rule for our software',
             $haveNameMatching->describe($classDesc, $because)->toString()
         );


### PR DESCRIPTION
Using the builder is more coincise and readable and allows to evolve ClassDescription constructor without changing tests