### PR TITLE
Allow using phpdoc-parser v1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "nikic/php-parser": "~5",
         "webmozart/assert": "^1.9",
         "ext-json": "*",
-        "phpstan/phpdoc-parser": "^2.0",
+        "phpstan/phpdoc-parser": "^1.2|^2.0",
         "ondram/ci-detector": "^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
Version 1.2 is still used (for instance in the symfony demo project, so I am re-adding it 