### PR TITLE
Support multiple output formats for violation reporting

### DIFF
--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -26,6 +26,7 @@ class Check extends Command
     private const USE_BASELINE_PARAM = 'use-baseline';
     private const SKIP_BASELINE_PARAM = 'skip-baseline';
     private const IGNORE_BASELINE_LINENUMBERS_PARAM = 'ignore-baseline-linenumbers';
+    private const FORMAT_PARAM = 'format';
 
     private const GENERATE_BASELINE_PARAM = 'generate-baseline';
     private const DEFAULT_RULES_FILENAME = 'phparkitect.php';
@@ -87,6 +88,13 @@ class Check extends Command
                 'i',
                 InputOption::VALUE_NONE,
                 'Ignore line numbers when checking the baseline'
+            )
+            ->addOption(
+                self::FORMAT_PARAM,
+                'f',
+                InputOption::VALUE_OPTIONAL,
+                'Output format: json or text (default)',
+                'text'
             );
     }
 
@@ -102,6 +110,7 @@ class Check extends Command
             $useBaseline = (string) $input->getOption(self::USE_BASELINE_PARAM);
             $skipBaseline = (bool) $input->getOption(self::SKIP_BASELINE_PARAM);
             $ignoreBaselineLinenumbers = (bool) $input->getOption(self::IGNORE_BASELINE_LINENUMBERS_PARAM);
+            $format = $input->getOption(self::FORMAT_PARAM);
 
             if (true !== $skipBaseline && !$useBaseline && file_exists(self::DEFAULT_BASELINE_FILENAME)) {
                 $useBaseline = self::DEFAULT_BASELINE_FILENAME;
@@ -158,7 +167,7 @@ class Check extends Command
             }
 
             if ($violations->count() > 0) {
-                $this->printViolations($violations, $output);
+                $this->printViolations($violations, $output, $format);
                 $this->printExecutionTime($output, $startTime);
 
                 return self::ERROR_CODE;
@@ -236,10 +245,10 @@ class Check extends Command
         return $filename;
     }
 
-    private function printViolations(Violations $violations, OutputInterface $output): void
+    private function printViolations(Violations $violations, OutputInterface $output, string $format): void
     {
         $output->writeln('<error>ERRORS!</error>');
-        $output->writeln(sprintf('%s', $violations->toString()));
+        $output->writeln(sprintf('%s', $violations->toString($format)));
         $output->writeln(sprintf('<error>%s VIOLATIONS DETECTED!</error>', \count($violations)));
     }
 

--- a/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
+++ b/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
@@ -11,6 +11,7 @@ use Arkitect\ClassSetRules;
 use Arkitect\CLI\Progress\VoidProgress;
 use Arkitect\CLI\Runner;
 use Arkitect\CLI\TargetPhpVersion;
+use Arkitect\Printer\Printer;
 use Arkitect\Rules\ParsingErrors;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\Constraint\Constraint;
@@ -78,6 +79,6 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
             return "\n".$this->parsingErrors->toString();
         }
 
-        return "\n".$this->violations->toString();
+        return "\n".$this->violations->toString(Printer::FORMAT_TEXT);
     }
 }

--- a/src/Printer/JsonPrinter.php
+++ b/src/Printer/JsonPrinter.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Printer;
+
+use Arkitect\Rules\Violation;
+
+class JsonPrinter implements Printer
+{
+    public function print(array $violationsCollection): string
+    {
+        $totalViolations = 0;
+        $details = [];
+
+        /**
+         * @var string      $key
+         * @var Violation[] $violationsByFqcn
+         */
+        foreach ($violationsCollection as $key => $violationsByFqcn) {
+            $violationForThisFqcn = \count($violationsByFqcn);
+            $totalViolations += $violationForThisFqcn;
+
+            $details[$key] = [];
+
+            foreach ($violationsByFqcn as $kv => $violation) {
+                $details[$key][$kv]['error'] = $violation->getError();
+
+                if (null !== $violation->getLine()) {
+                    $details[$key][$kv]['line'] = $violation->getLine();
+                }
+            }
+        }
+
+        $errors = [
+            'totalViolations' => $totalViolations,
+            'details' => $details,
+        ];
+
+        return json_encode($errors);
+    }
+}

--- a/src/Printer/Printer.php
+++ b/src/Printer/Printer.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Printer;
+
+interface Printer
+{
+    public const FORMAT_TEXT = 'text';
+
+    public const FORMAT_JSON = 'json';
+
+    public function print(array $violationsCollection): string;
+}

--- a/src/Printer/PrinterFactory.php
+++ b/src/Printer/PrinterFactory.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Printer;
+
+final class PrinterFactory
+{
+    public function create(string $format): Printer
+    {
+        switch ($format) {
+            case 'json':
+                return new JsonPrinter();
+            default:
+                return new TextPrinter();
+        }
+    }
+}

--- a/src/Printer/TextPrinter.php
+++ b/src/Printer/TextPrinter.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Printer;
+
+use Arkitect\Rules\Violation;
+
+class TextPrinter implements Printer
+{
+    public function print(array $violationsCollection): string
+    {
+        $errors = '';
+
+        /**
+         * @var string      $key
+         * @var Violation[] $violationsByFqcn
+         */
+        foreach ($violationsCollection as $key => $violationsByFqcn) {
+            $violationForThisFqcn = \count($violationsByFqcn);
+            $errors .= "\n$key has {$violationForThisFqcn} violations";
+
+            foreach ($violationsByFqcn as $violation) {
+                $errors .= "\n  ".$violation->getError();
+
+                if (null !== $violation->getLine()) {
+                    $errors .= ' (on line '.$violation->getLine().')';
+                }
+            }
+            $errors .= "\n";
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -6,6 +6,7 @@ namespace Arkitect\Rules;
 
 use Arkitect\Exceptions\FailOnFirstViolationException;
 use Arkitect\Exceptions\IndexNotFoundException;
+use Arkitect\Printer\PrinterFactory;
 
 /**
  * @template-implements \IteratorAggregate<Violation>
@@ -79,30 +80,11 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
         }, []);
     }
 
-    public function toString(): string
+    public function toString(string $format): string
     {
-        $errors = '';
-        $violationsCollection = $this->groupedByFqcn();
+        $printer = (new PrinterFactory())->create($format);
 
-        /**
-         * @var string      $key
-         * @var Violation[] $violationsByFqcn
-         */
-        foreach ($violationsCollection as $key => $violationsByFqcn) {
-            $violationForThisFqcn = \count($violationsByFqcn);
-            $errors .= "\n$key has {$violationForThisFqcn} violations";
-
-            foreach ($violationsByFqcn as $violation) {
-                $errors .= "\n  ".$violation->getError();
-
-                if (null !== $violation->getLine()) {
-                    $errors .= ' (on line '.$violation->getLine().')';
-                }
-            }
-            $errors .= "\n";
-        }
-
-        return $errors;
+        return $printer->print($this->groupedByFqcn());
     }
 
     public function toArray(): array

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -14,6 +14,7 @@ use Arkitect\Expression\ForClasses\DependsOnlyOnTheseNamespaces;
 use Arkitect\Expression\ForClasses\Implement;
 use Arkitect\Expression\ForClasses\NotContainDocBlockLike;
 use Arkitect\Expression\ForClasses\NotHaveDependencyOutsideNamespace;
+use Arkitect\Printer\Printer;
 use Arkitect\Rules\ParsingError;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -823,7 +824,7 @@ EOF;
         $implement = new Implement('Foo\Order');
         $implement->evaluate($cd, $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations, $violations->toString());
+        $this->assertCount(0, $violations, $violations->toString(Printer::FORMAT_TEXT));
     }
 
     public function test_it_parse_dependencies_in_docblocks_with_alias(): void

--- a/tests/Unit/Printer/JsonPrinterTest.php
+++ b/tests/Unit/Printer/JsonPrinterTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Printer;
+
+use Arkitect\Printer\JsonPrinter;
+use Arkitect\Rules\Violation;
+use PHPUnit\Framework\TestCase;
+
+class JsonPrinterTest extends TestCase
+{
+    /**
+     * Test that print method returns correct JSON for an empty violations collection.
+     */
+    public function test_print_returns_correct_json_for_empty_violations(): void
+    {
+        $printer = new JsonPrinter();
+        $result = $printer->print([]);
+
+        $expected = json_encode([
+            'totalViolations' => 0,
+            'details' => [],
+        ]);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test that print method returns correct JSON for a single violation.
+     */
+    public function test_print_returns_correct_json_for_single_violation(): void
+    {
+        $violation = $this->createMock(Violation::class);
+        $violation->method('getError')->willReturn('Error message');
+        $violation->method('getLine')->willReturn(42);
+
+        $violationsCollection = [
+            'Some\\Class' => [$violation],
+        ];
+
+        $printer = new JsonPrinter();
+        $result = $printer->print($violationsCollection);
+
+        $expected = json_encode([
+            'totalViolations' => 1,
+            'details' => [
+                'Some\\Class' => [
+                    [
+                        'error' => 'Error message',
+                        'line' => 42,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test that print method returns correct JSON for multiple violations.
+     */
+    public function test_print_returns_correct_json_for_multiple_violations(): void
+    {
+        $violation1 = $this->createMock(Violation::class);
+        $violation1->method('getError')->willReturn('First error');
+        $violation1->method('getLine')->willReturn(10);
+
+        $violation2 = $this->createMock(Violation::class);
+        $violation2->method('getError')->willReturn('Second error');
+
+        $violationsCollection = [
+            'ClassA' => [$violation1],
+            'ClassB' => [$violation2],
+        ];
+
+        $printer = new JsonPrinter();
+        $result = $printer->print($violationsCollection);
+
+        $expected = json_encode([
+            'totalViolations' => 2,
+            'details' => [
+                'ClassA' => [
+                    [
+                        'error' => 'First error',
+                        'line' => 10,
+                    ],
+                ],
+                'ClassB' => [
+                    [
+                        'error' => 'Second error',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/tests/Unit/Printer/PrinterFactoryTest.php
+++ b/tests/Unit/Printer/PrinterFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Printer;
+
+use Arkitect\Printer\JsonPrinter;
+use Arkitect\Printer\PrinterFactory;
+use Arkitect\Printer\TextPrinter;
+use PHPUnit\Framework\TestCase;
+
+class PrinterFactoryTest extends TestCase
+{
+    /**
+     * Test if the create method returns a JsonPrinter when the format is 'json'.
+     */
+    public function test_create_returns_json_printer_for_json_format(): void
+    {
+        $factory = new PrinterFactory();
+
+        $printer = $factory->create('json');
+
+        $this->assertInstanceOf(JsonPrinter::class, $printer);
+    }
+
+    /**
+     * Test if the create method returns a TextPrinter when the format is not 'json'.
+     */
+    public function test_create_returns_text_printer_for_non_json_format(): void
+    {
+        $factory = new PrinterFactory();
+
+        $printer = $factory->create('text');
+
+        $this->assertInstanceOf(TextPrinter::class, $printer);
+    }
+}

--- a/tests/Unit/Printer/TextPrinterTest.php
+++ b/tests/Unit/Printer/TextPrinterTest.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Printer;
+
+use Arkitect\Printer\TextPrinter;
+use Arkitect\Rules\Violation;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Arkitect\Printer\TextPrinter
+ */
+class TextPrinterTest extends TestCase
+{
+    public function test_prints_violation_without_line(): void
+    {
+        $violations = [
+            'ExampleClass' => [
+                new Violation('ExampleClass', 'Error message'),
+            ],
+        ];
+
+        $printer = new TextPrinter();
+        $result = $printer->print($violations);
+
+        $expectedOutput = "\nExampleClass has 1 violations\n  Error message\n";
+
+        $this->assertSame($expectedOutput, $result);
+    }
+
+    public function test_prints_violation_with_line(): void
+    {
+        $violations = [
+            'ExampleClass' => [
+                new Violation('ExampleClass', 'Error message', 42),
+            ],
+        ];
+
+        $printer = new TextPrinter();
+        $result = $printer->print($violations);
+
+        $expectedOutput = "\nExampleClass has 1 violations\n  Error message (on line 42)\n";
+
+        $this->assertSame($expectedOutput, $result);
+    }
+
+    public function test_prints_multiple_violations_grouped_by_fqcn(): void
+    {
+        $violations = [
+            'ExampleClass' => [
+                new Violation('ExampleClass', 'First error'),
+                new Violation('ExampleClass', 'Second error', 10),
+            ],
+            'AnotherClass' => [
+                new Violation('AnotherClass', 'Another error', 15),
+            ],
+        ];
+
+        $printer = new TextPrinter();
+        $result = $printer->print($violations);
+
+        $expectedOutput = "\nExampleClass has 2 violations\n  First error\n  Second error (on line 10)\n\nAnotherClass has 1 violations\n  Another error (on line 15)\n";
+
+        $this->assertSame($expectedOutput, $result);
+    }
+}

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Arkitect\Tests\Unit\Rules;
 
 use Arkitect\Exceptions\IndexNotFoundException;
+use Arkitect\Printer\Printer;
 use Arkitect\Rules\Violation;
 use Arkitect\Rules\Violations;
 use PHPUnit\Framework\TestCase;
@@ -65,7 +66,7 @@ App\Controller\Foo has 1 violations
   should have name end with Controller
 ';
 
-        $this->assertEquals($expected, $this->violationStore->toString());
+        $this->assertEquals($expected, $this->violationStore->toString(Printer::FORMAT_TEXT));
     }
 
     public function test_get_iterable(): void


### PR DESCRIPTION
Added support for violation reporting in both text and JSON formats by introducing a `Printer` interface and implementing `TextPrinter` and `JsonPrinter` classes. Refactored relevant methods to utilize the new `Printer` system and updated CLI options to allow format selection. Included comprehensive unit tests for the new functionality.