### PR TITLE
feat: Add GitLab output format support to CLI.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     "autoload-dev": {
         "psr-4": {
             "Arkitect\\Tests\\": "tests/"
-        }
+        },
+        "classmap": ["tests/E2E/_fixtures/"]
     },
     "config": {
         "bin-dir": "bin",

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,7 @@
     "autoload-dev": {
         "psr-4": {
             "Arkitect\\Tests\\": "tests/"
-        },
-        "classmap": ["tests/E2E/_fixtures/"]
+        }
     },
     "config": {
         "bin-dir": "bin",

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -285,7 +285,7 @@ class Check extends Command
     {
         if (!$onlyErrors) {
             $output->writeln('<info>NO VIOLATIONS DETECTED!</info>');
-        } elseif (Printer::FORMAT_JSON === $format) {
+        } elseif (Printer::FORMAT_JSON === $format || Printer::FORMAT_GITLAB === $format) {
             $output->writeln('<info>[]</info>');
         }
     }

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -94,7 +94,7 @@ class Check extends Command
                 self::FORMAT_PARAM,
                 'f',
                 InputOption::VALUE_OPTIONAL,
-                'Output format: json or text (default)',
+                'Output format: text (default), json, gitlab',
                 'text'
             );
     }
@@ -112,7 +112,7 @@ class Check extends Command
             $skipBaseline = (bool) $input->getOption(self::SKIP_BASELINE_PARAM);
             $ignoreBaselineLinenumbers = (bool) $input->getOption(self::IGNORE_BASELINE_LINENUMBERS_PARAM);
             $format = $input->getOption(self::FORMAT_PARAM);
-            $onlyErrors = Printer::FORMAT_JSON === $format;
+            $onlyErrors = Printer::FORMAT_JSON === $format || Printer::FORMAT_GITLAB === $format;
 
             if (true !== $skipBaseline && !$useBaseline && file_exists(self::DEFAULT_BASELINE_FILENAME)) {
                 $useBaseline = self::DEFAULT_BASELINE_FILENAME;

--- a/src/CLI/Printer/GitlabPrinter.php
+++ b/src/CLI/Printer/GitlabPrinter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Arkitect\CLI\Printer;
 
 use Arkitect\Rules\Violation;
+use Symfony\Component\Filesystem\Path;
 
 class GitlabPrinter implements Printer
 {
@@ -25,7 +26,7 @@ class GitlabPrinter implements Printer
                 $errorClassGrouped[$class][$key]['check_name'] = $class.'.'.$this->toKebabCase($violation->getError());
                 $errorClassGrouped[$class][$key]['fingerprint'] = hash('sha256', $errorClassGrouped[$class][$key]['check_name']);
                 $errorClassGrouped[$class][$key]['severity'] = 'major'; // Todo enable severity on violation
-                $errorClassGrouped[$class][$key]['location']['path'] = $this->getPathFromFqcn($fqcn);
+                $errorClassGrouped[$class][$key]['location']['path'] = Path::makeRelative($this->getPathFromFqcn($fqcn), getcwd());
 
                 if (null !== $violation->getLine()) {
                     $errorClassGrouped[$class][$key]['lines']['begin'] = $violation->getLine();

--- a/src/CLI/Printer/GitlabPrinter.php
+++ b/src/CLI/Printer/GitlabPrinter.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\CLI\Printer;
+
+use Arkitect\Rules\Violation;
+
+class GitlabPrinter implements Printer
+{
+    public function print(array $violationsCollection): string
+    {
+        $details = [];
+        $errorClassGrouped = [];
+
+        /**
+         * @var string      $key
+         * @var Violation[] $violationsByFqcn
+         */
+        foreach ($violationsCollection as $class => $violationsByFqcn) {
+            foreach ($violationsByFqcn as $key => $violation) {
+                /** @var class-string $fqcn */
+                $fqcn = $violation->getFqcn();
+
+                $errorClassGrouped[$class][$key]['description'] = $violation->getError();
+                $errorClassGrouped[$class][$key]['check_name'] = $class.'.'.$this->toKebabCase($violation->getError());
+                $errorClassGrouped[$class][$key]['fingerprint'] = hash('sha256', $errorClassGrouped[$class][$key]['check_name']);
+                $errorClassGrouped[$class][$key]['severity'] = 'major'; // Todo enable severity on violation
+                $errorClassGrouped[$class][$key]['location']['path'] = $this->getPathFromFqcn($fqcn);
+
+                if (null !== $violation->getLine()) {
+                    $errorClassGrouped[$class][$key]['lines']['begin'] = $violation->getLine();
+                } else {
+                    $errorClassGrouped[$class][$key]['lines']['begin'] = 1;
+                }
+            }
+        }
+
+        return json_encode(array_merge($details, ...array_values($errorClassGrouped)));
+    }
+
+    /**
+     * @param class-string $fqcn
+     */
+    private function getPathFromFqcn(string $fqcn): string
+    {
+        return (new \ReflectionClass($fqcn))->getFileName();
+    }
+
+    private function toKebabCase(string $string): string
+    {
+        $string = preg_replace('/[^a-zA-Z0-9]+/', ' ', $string);
+        $string = preg_replace('/\s+/', ' ', $string);
+        $string = strtolower(trim($string));
+        $string = str_replace(' ', '-', $string);
+
+        return $string;
+    }
+}

--- a/src/CLI/Printer/Printer.php
+++ b/src/CLI/Printer/Printer.php
@@ -9,5 +9,7 @@ interface Printer
 
     public const FORMAT_JSON = 'json';
 
+    public const FORMAT_GITLAB = 'gitlab';
+
     public function print(array $violationsCollection): string;
 }

--- a/src/CLI/Printer/PrinterFactory.php
+++ b/src/CLI/Printer/PrinterFactory.php
@@ -8,6 +8,8 @@ final class PrinterFactory
     public function create(string $format): Printer
     {
         switch ($format) {
+            case 'gitlab':
+                return new GitlabPrinter();
             case 'json':
                 return new JsonPrinter();
             default:

--- a/src/CLI/Printer/PrinterFactory.php
+++ b/src/CLI/Printer/PrinterFactory.php
@@ -8,9 +8,9 @@ final class PrinterFactory
     public function create(string $format): Printer
     {
         switch ($format) {
-            case 'gitlab':
+            case Printer::FORMAT_GITLAB:
                 return new GitlabPrinter();
-            case 'json':
+            case Printer::FORMAT_JSON:
                 return new JsonPrinter();
             default:
                 return new TextPrinter();

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -207,18 +207,10 @@ App\Controller\Foo has 1 violations
 
         $this->assertJson($display);
 
-        $decodedResult = json_decode($display, true);
+        self::assertSame(<<<JSON
+        [{"description":"should have a name that matches *Controller because all controllers should be end name with Controller","check_name":"App\\\\Controller\\\\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller","fingerprint":"1e960c3f49b5ec63ece40321072ef2bd0bc33ad11b7be326f304255d277dc860","severity":"major","location":{"path":"tests\/E2E\/_fixtures\/mvc\/Controller\/Foo.php"},"lines":{"begin":1}}]
 
-        $this->assertIsString($display, 'Result should be a string');
-        $this->assertJson($display, 'Result should be a valid JSON string');
-        $this->assertCount(1, $decodedResult, 'Result should contain two violations');
-
-        $this->assertSame('should have a name that matches *Controller because all controllers should be end name with Controller', $decodedResult[0]['description']);
-        $this->assertSame('App\Controller\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller', $decodedResult[0]['check_name']);
-        $this->assertSame(hash('sha256', 'App\Controller\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller'), $decodedResult[0]['fingerprint']);
-        $this->assertSame('major', $decodedResult[0]['severity']);
-        $this->assertSame(getcwd().'/tests/E2E/_fixtures/mvc/Controller/Foo.php', $decodedResult[0]['location']['path']);
-        $this->assertSame(1, $decodedResult[0]['lines']['begin']);
+        JSON, $display);
     }
 
     public function test_gitlab_format_output_no_errors(): void

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -208,7 +208,7 @@ App\Controller\Foo has 1 violations
         $this->assertJson($display);
 
         self::assertSame(<<<JSON
-        [{"description":"should have a name that matches *Controller because all controllers should be end name with Controller","check_name":"App\\\\Controller\\\\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller","fingerprint":"1e960c3f49b5ec63ece40321072ef2bd0bc33ad11b7be326f304255d277dc860","severity":"major","location":{"path":"Controller\/Foo.php"},"lines":{"begin":1}}]
+        [{"description":"should have a name that matches *Controller because all controllers should be end name with Controller","check_name":"App\\\\Controller\\\\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller","fingerprint":"1e960c3f49b5ec63ece40321072ef2bd0bc33ad11b7be326f304255d277dc860","severity":"major","location":{"path":"Controller\/Foo.php","lines":{"begin":1}}}]
 
         JSON, $display);
     }

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -221,6 +221,22 @@ App\Controller\Foo has 1 violations
         $this->assertSame(1, $decodedResult[0]['lines']['begin']);
     }
 
+    public function test_gitlab_format_output_no_errors(): void
+    {
+        $configFilePath = __DIR__.'/../_fixtures/configMvcWithoutErrors.php';
+
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, false, 'gitlab');
+
+        $this->assertCheckHasSuccess($cmdTester);
+
+        $display = $cmdTester->getDisplay();
+
+        $this->assertJson($display);
+
+        $json = json_decode($display, true);
+        $this->assertCount(0, $json);
+    }
+
     protected function runCheck(
         $configFilePath = null,
         ?bool $stopOnFailure = null,

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -195,6 +195,32 @@ App\Controller\Foo has 1 violations
         $this->assertCount(0, $json);
     }
 
+    public function test_gitlab_format_output(): void
+    {
+        $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
+
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, false, 'gitlab');
+
+        $this->assertCheckHasErrors($cmdTester);
+
+        $display = $cmdTester->getDisplay();
+
+        $this->assertJson($display);
+
+        $decodedResult = json_decode($display, true);
+
+        $this->assertIsString($display, 'Result should be a string');
+        $this->assertJson($display, 'Result should be a valid JSON string');
+        $this->assertCount(1, $decodedResult, 'Result should contain two violations');
+
+        $this->assertSame('should have a name that matches *Controller because all controllers should be end name with Controller', $decodedResult[0]['description']);
+        $this->assertSame('App\Controller\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller', $decodedResult[0]['check_name']);
+        $this->assertSame(hash('sha256', 'App\Controller\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller'), $decodedResult[0]['fingerprint']);
+        $this->assertSame('major', $decodedResult[0]['severity']);
+        $this->assertSame(getcwd().'/tests/E2E/_fixtures/mvc/Controller/Foo.php', $decodedResult[0]['location']['path']);
+        $this->assertSame(1, $decodedResult[0]['lines']['begin']);
+    }
+
     protected function runCheck(
         $configFilePath = null,
         ?bool $stopOnFailure = null,

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -208,7 +208,7 @@ App\Controller\Foo has 1 violations
         $this->assertJson($display);
 
         self::assertSame(<<<JSON
-        [{"description":"should have a name that matches *Controller because all controllers should be end name with Controller","check_name":"App\\\\Controller\\\\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller","fingerprint":"1e960c3f49b5ec63ece40321072ef2bd0bc33ad11b7be326f304255d277dc860","severity":"major","location":{"path":"tests\/E2E\/_fixtures\/mvc\/Controller\/Foo.php"},"lines":{"begin":1}}]
+        [{"description":"should have a name that matches *Controller because all controllers should be end name with Controller","check_name":"App\\\\Controller\\\\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller","fingerprint":"1e960c3f49b5ec63ece40321072ef2bd0bc33ad11b7be326f304255d277dc860","severity":"major","location":{"path":"Controller\/Foo.php"},"lines":{"begin":1}}]
 
         JSON, $display);
     }

--- a/tests/Unit/CLI/Printer/GitlabPrinterTest.php
+++ b/tests/Unit/CLI/Printer/GitlabPrinterTest.php
@@ -17,8 +17,8 @@ class GitlabPrinterTest extends TestCase
      */
     public function test_print_with_violations(): void
     {
-        $violation1 = new Violation(ExampleClass::class, 'Some error message', 42);
-        $violation2 = new Violation(AnotherExampleClass::class, 'Another error message', null);
+        $violation1 = new Violation(ExampleClass::class, 'Some error message', 42, 'tests/Unit/CLI/Printer/GitlabPrinterTest.php');
+        $violation2 = new Violation(AnotherExampleClass::class, 'Another error message', null, 'tests/Unit/CLI/Printer/GitlabPrinterTest.php');
 
         $violationsCollection = [
             'RuleA' => [$violation1],

--- a/tests/Unit/CLI/Printer/GitlabPrinterTest.php
+++ b/tests/Unit/CLI/Printer/GitlabPrinterTest.php
@@ -6,8 +6,6 @@ namespace Arkitect\Tests\Unit\CLI\Printer;
 use Arkitect\CLI\Printer\GitlabPrinter;
 use Arkitect\Rules\Violation;
 use PHPUnit\Framework\TestCase;
-use Some\AnotherExampleClass;
-use Some\ExampleClass;
 
 class GitlabPrinterTest extends TestCase
 {
@@ -17,8 +15,8 @@ class GitlabPrinterTest extends TestCase
      */
     public function test_print_with_violations(): void
     {
-        $violation1 = new Violation(ExampleClass::class, 'Some error message', 42, 'tests/Unit/CLI/Printer/GitlabPrinterTest.php');
-        $violation2 = new Violation(AnotherExampleClass::class, 'Another error message', null, 'tests/Unit/CLI/Printer/GitlabPrinterTest.php');
+        $violation1 = new Violation('App\\ExampleClass', 'Some error message', 42, 'tests/Unit/CLI/Printer/GitlabPrinterTest.php');
+        $violation2 = new Violation('App\\AnotherExampleClass', 'Another error message', null, 'tests/Unit/CLI/Printer/GitlabPrinterTest.php');
 
         $violationsCollection = [
             'RuleA' => [$violation1],
@@ -30,7 +28,7 @@ class GitlabPrinterTest extends TestCase
         $result = $printer->print($violationsCollection);
 
         self::assertSame(<<<JSON
-        [{"description":"Some error message","check_name":"RuleA.some-error-message","fingerprint":"7ddcfd42f5f2af3d00864ef959a0327f508cb5227aedca96d919d681a5dcde4a","severity":"major","location":{"path":"tests\/Unit\/CLI\/Printer\/GitlabPrinterTest.php"},"lines":{"begin":42}},{"description":"Another error message","check_name":"RuleB.another-error-message","fingerprint":"800c2ceafbf4023e401200186ecabdfe59891c5d6670e86571e3c50339df07dc","severity":"major","location":{"path":"tests\/Unit\/CLI\/Printer\/GitlabPrinterTest.php"},"lines":{"begin":1}}]
+        [{"description":"Some error message","check_name":"RuleA.some-error-message","fingerprint":"7ddcfd42f5f2af3d00864ef959a0327f508cb5227aedca96d919d681a5dcde4a","severity":"major","location":{"path":"tests\/Unit\/CLI\/Printer\/GitlabPrinterTest.php","lines":{"begin":42}}},{"description":"Another error message","check_name":"RuleB.another-error-message","fingerprint":"800c2ceafbf4023e401200186ecabdfe59891c5d6670e86571e3c50339df07dc","severity":"major","location":{"path":"tests\/Unit\/CLI\/Printer\/GitlabPrinterTest.php","lines":{"begin":1}}}]
         JSON, $result);
     }
 
@@ -52,14 +50,4 @@ class GitlabPrinterTest extends TestCase
         $decodedResult = json_decode($result, true);
         $this->assertEmpty($decodedResult, 'Result should be an empty array');
     }
-}
-
-namespace Some;
-
-class ExampleClass
-{
-}
-
-class AnotherExampleClass
-{
 }

--- a/tests/Unit/CLI/Printer/GitlabPrinterTest.php
+++ b/tests/Unit/CLI/Printer/GitlabPrinterTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\CLI\Printer;
+
+use Arkitect\CLI\Printer\GitlabPrinter;
+use Arkitect\Rules\Violation;
+use PHPUnit\Framework\TestCase;
+
+class GitlabPrinterTest extends TestCase
+{
+    /**
+     * Test the `print` method returns a valid JSON string
+     * with violations details when violations exist.
+     */
+    public function test_print_with_violations(): void
+    {
+        $violation1 = $this->createMock(Violation::class);
+        $violation1->method('getFqcn')->willReturn('Some\\ExampleClass');
+        $violation1->method('getError')->willReturn('Some error message');
+        $violation1->method('getLine')->willReturn(42);
+
+        $violation2 = $this->createMock(Violation::class);
+        $violation2->method('getFqcn')->willReturn('Another\\ExampleClass');
+        $violation2->method('getError')->willReturn('Another error message');
+        $violation2->method('getLine')->willReturn(null);
+
+        $violationsCollection = [
+            'RuleA' => [$violation1],
+            'RuleB' => [$violation2],
+        ];
+
+        $printer = new GitlabPrinter();
+
+        $result = $printer->print($violationsCollection);
+        $decodedResult = json_decode($result, true);
+
+        $this->assertIsString($result, 'Result should be a string');
+        $this->assertJson($result, 'Result should be a valid JSON string');
+        $this->assertCount(2, $decodedResult, 'Result should contain two violations');
+
+        $this->assertSame('Some error message', $decodedResult[0]['description']);
+        $this->assertSame('RuleA.some-error-message', $decodedResult[0]['check_name']);
+        $this->assertSame(hash('sha256', 'RuleA.some-error-message'), $decodedResult[0]['fingerprint']);
+        $this->assertSame('major', $decodedResult[0]['severity']);
+        $this->assertSame(__DIR__.'/GitlabPrinterTest.php', $decodedResult[0]['location']['path']);
+        $this->assertSame(42, $decodedResult[0]['lines']['begin']);
+
+        $this->assertSame('Another error message', $decodedResult[1]['description']);
+        $this->assertSame('RuleB.another-error-message', $decodedResult[1]['check_name']);
+        $this->assertSame(hash('sha256', 'RuleB.another-error-message'), $decodedResult[1]['fingerprint']);
+        $this->assertSame('major', $decodedResult[1]['severity']);
+        $this->assertSame(__DIR__.'/GitlabPrinterTest.php', $decodedResult[1]['location']['path']);
+        $this->assertSame(1, $decodedResult[1]['lines']['begin']);
+    }
+
+    /**
+     * Test the `print` method returns an empty JSON array
+     * when no violations are provided.
+     */
+    public function test_print_with_no_violations(): void
+    {
+        $violationsCollection = [];
+
+        $printer = new GitlabPrinter();
+
+        $result = $printer->print($violationsCollection);
+
+        $this->assertIsString($result, 'Result should be a string');
+        $this->assertJson($result, 'Result should be a valid JSON string');
+
+        $decodedResult = json_decode($result, true);
+        $this->assertEmpty($decodedResult, 'Result should be an empty array');
+    }
+}
+
+namespace Some;
+
+class ExampleClass
+{
+}
+
+namespace Another;
+
+class ExampleClass
+{
+}

--- a/tests/Unit/CLI/Printer/JsonPrinterTest.php
+++ b/tests/Unit/CLI/Printer/JsonPrinterTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Arkitect\Tests\Unit\Printer;
+namespace Arkitect\Tests\Unit\CLI\Printer;
 
 use Arkitect\CLI\Printer\JsonPrinter;
 use Arkitect\Rules\Violation;

--- a/tests/Unit/CLI/Printer/PrinterFactoryTest.php
+++ b/tests/Unit/CLI/Printer/PrinterFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Arkitect\Tests\Unit\Printer;
+namespace Arkitect\Tests\Unit\CLI\Printer;
 
 use Arkitect\CLI\Printer\JsonPrinter;
 use Arkitect\CLI\Printer\PrinterFactory;

--- a/tests/Unit/CLI/Printer/TextPrinterTest.php
+++ b/tests/Unit/CLI/Printer/TextPrinterTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Arkitect\Tests\Unit\Printer;
+namespace Arkitect\Tests\Unit\CLI\Printer;
 
 use Arkitect\CLI\Printer\TextPrinter;
 use Arkitect\Rules\Violation;


### PR DESCRIPTION
Introduced the "gitlab" format for CLI output, alongside existing "text" and "json" formats. This includes a new `GitlabPrinter` implementation, updates to the `PrinterFactory` and output option handling, as well as corresponding unit and E2E tests. The change enhances integration options, particularly for GitLab CI.

gitlab code quality format must have particular json format

see gitlab docs: https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format

this PR depends on #475