### PR TITLE
Add relative file path to classdescription

### DIFF
--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -74,11 +74,11 @@ class ClassDescription
         $this->enum = $enum;
     }
 
-    public static function getBuilder(string $FQCN, string $relativeFilePath): ClassDescriptionBuilder
+    public static function getBuilder(string $FQCN, string $filePath): ClassDescriptionBuilder
     {
         $cb = new ClassDescriptionBuilder();
         $cb->setClassName($FQCN);
-        $cb->setFilePath($relativeFilePath);
+        $cb->setFilePath($filePath);
 
         return $cb;
     }

--- a/src/Analyzer/ClassDescription.php
+++ b/src/Analyzer/ClassDescription.php
@@ -8,6 +8,8 @@ class ClassDescription
 {
     private FullyQualifiedClassName $FQCN;
 
+    private string $filePath;
+
     /** @var list<ClassDependency> */
     private array $dependencies;
 
@@ -53,10 +55,12 @@ class ClassDescription
         bool $interface,
         bool $trait,
         bool $enum,
-        array $docBlock = [],
-        array $attributes = []
+        array $docBlock,
+        array $attributes,
+        string $filePath
     ) {
         $this->FQCN = $FQCN;
+        $this->filePath = $filePath;
         $this->dependencies = $dependencies;
         $this->interfaces = $interfaces;
         $this->extends = $extends;
@@ -70,10 +74,11 @@ class ClassDescription
         $this->enum = $enum;
     }
 
-    public static function getBuilder(string $FQCN): ClassDescriptionBuilder
+    public static function getBuilder(string $FQCN, string $relativeFilePath): ClassDescriptionBuilder
     {
         $cb = new ClassDescriptionBuilder();
         $cb->setClassName($FQCN);
+        $cb->setFilePath($relativeFilePath);
 
         return $cb;
     }
@@ -86,6 +91,11 @@ class ClassDescription
     public function getFQCN(): string
     {
         return $this->FQCN->toString();
+    }
+
+    public function getFilePath(): string
+    {
+        return $this->filePath;
     }
 
     public function namespaceMatches(string $pattern): bool

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -36,6 +36,8 @@ class ClassDescriptionBuilder
 
     private bool $enum = false;
 
+    private ?string $filePath = null;
+
     public function clear(): void
     {
         $this->FQCN = null;
@@ -50,6 +52,13 @@ class ClassDescriptionBuilder
         $this->interface = false;
         $this->trait = false;
         $this->enum = false;
+    }
+
+    public function setFilePath(?string $filePath): self
+    {
+        $this->filePath = $filePath;
+
+        return $this;
     }
 
     public function setClassName(string $FQCN): self
@@ -142,6 +151,7 @@ class ClassDescriptionBuilder
     public function build(): ClassDescription
     {
         Assert::notNull($this->FQCN, 'You must set an FQCN');
+        Assert::notNull($this->filePath, 'You must set a file path');
 
         return new ClassDescription(
             $this->FQCN,
@@ -155,7 +165,8 @@ class ClassDescriptionBuilder
             $this->trait,
             $this->enum,
             $this->docBlock,
-            $this->attributes
+            $this->attributes,
+            $this->filePath
         );
     }
 }

--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -50,6 +50,7 @@ class FileParser implements Parser
         $this->parsingErrors = [];
         try {
             $this->fileVisitor->clearParsedClassDescriptions();
+            $this->fileVisitor->setFilePath($filename);
 
             $errorHandler = new Collecting();
             $stmts = $this->parser->parse($fileContent, $errorHandler);

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -21,6 +21,11 @@ class FileVisitor extends NodeVisitorAbstract
         $this->classDescriptionBuilder = $classDescriptionBuilder;
     }
 
+    public function setFilePath(string $filePath): void
+    {
+        $this->classDescriptionBuilder->setFilePath($filePath);
+    }
+
     public function enterNode(Node $node): void
     {
         if ($node instanceof Node\Stmt\Class_) {
@@ -224,6 +229,7 @@ class FileVisitor extends NodeVisitorAbstract
     public function clearParsedClassDescriptions(): void
     {
         $this->classDescriptions = [];
+        $this->classDescriptionBuilder->setFilePath(null);
         $this->classDescriptionBuilder->clear();
     }
 

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -15,14 +15,13 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_builder_with_dependency_and_interface(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
             ->addDependency(new ClassDependency('DepClass', 10))
-            ->addInterface('InterfaceClass', 10);
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->addInterface('InterfaceClass', 10)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -33,13 +32,12 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_final_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
-            ->setFinal(true);
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->setFinal(true)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -49,13 +47,12 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_not_final_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
-            ->setFinal(false);
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->setFinal(false)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -65,13 +62,12 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_abstract_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
-            ->setAbstract(true);
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->setAbstract(true)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -81,13 +77,12 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_not_abstract_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
-            ->setAbstract(false);
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->setAbstract(false)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
 
@@ -97,36 +92,32 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_annotated_class(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $docBlock = <<< 'EOT'
+        /**
+         * @psalm-immutable
+         */
+        EOT;
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
-            ->addDocBlock('/**
- * @psalm-immutable
- */');
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->addDocBlock($docBlock)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
-
-        $this->assertEquals(
-            ['/**
- * @psalm-immutable
- */'],
-            $classDescription->getDocBlock()
-        );
+        $this->assertEquals([$docBlock], $classDescription->getDocBlock());
     }
 
     public function test_it_should_add_attributes(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
-            ->addAttribute('AttrClass', 27);
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->addAttribute('AttrClass', 27)
+            ->build();
 
         self::assertEquals(
             [FullyQualifiedClassName::fromString('AttrClass')],
@@ -137,63 +128,56 @@ class ClassDescriptionBuilderTest extends TestCase
     public function test_it_should_create_interface(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
-            ->setInterface(true);
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->setInterface(true)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
-
         $this->assertTrue($classDescription->isInterface());
     }
 
     public function test_it_should_create_not_interface(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
-            ->setInterface(false);
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->setInterface(false)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
-
         $this->assertFalse($classDescription->isInterface());
     }
 
     public function test_it_should_create_trait(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder
+
+        $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName($FQCN)
-            ->setTrait(true);
-
-        $classDescription = $classDescriptionBuilder->build();
+            ->setTrait(true)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
-
         $this->assertTrue($classDescription->isTrait());
     }
 
     public function test_it_should_create_not_trait(): void
     {
         $FQCN = 'HappyIsland';
-        $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN)
-            ->setTrait(false);
 
-        $classDescription = $classDescriptionBuilder->build();
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->setTrait(false)
+            ->build();
 
         $this->assertInstanceOf(ClassDescription::class, $classDescription);
-
         $this->assertFalse($classDescription->isTrait());
     }
 }

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -16,13 +16,11 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-
-        $classDependency = new ClassDependency('DepClass', 10);
-
-        $classDescriptionBuilder->addDependency($classDependency);
-        $classDescriptionBuilder->addInterface('InterfaceClass', 10);
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->addDependency(new ClassDependency('DepClass', 10))
+            ->addInterface('InterfaceClass', 10);
 
         $classDescription = $classDescriptionBuilder->build();
 
@@ -36,9 +34,10 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->setFinal(true);
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->setFinal(true);
 
         $classDescription = $classDescriptionBuilder->build();
 
@@ -51,9 +50,10 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->setFinal(false);
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->setFinal(false);
 
         $classDescription = $classDescriptionBuilder->build();
 
@@ -66,9 +66,10 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->setAbstract(true);
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->setAbstract(true);
 
         $classDescription = $classDescriptionBuilder->build();
 
@@ -81,9 +82,10 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->setAbstract(false);
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->setAbstract(false);
 
         $classDescription = $classDescriptionBuilder->build();
 
@@ -96,9 +98,10 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->addDocBlock('/**
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->addDocBlock('/**
  * @psalm-immutable
  */');
 
@@ -118,9 +121,10 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->addAttribute('AttrClass', 27);
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->addAttribute('AttrClass', 27);
 
         $classDescription = $classDescriptionBuilder->build();
 
@@ -134,9 +138,10 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->setInterface(true);
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->setInterface(true);
 
         $classDescription = $classDescriptionBuilder->build();
 
@@ -149,9 +154,10 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->setInterface(false);
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->setInterface(false);
 
         $classDescription = $classDescriptionBuilder->build();
 
@@ -164,9 +170,10 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->setTrait(true);
+        $classDescriptionBuilder
+            ->setFilePath('src/Foo.php')
+            ->setClassName($FQCN)
+            ->setTrait(true);
 
         $classDescription = $classDescriptionBuilder->build();
 
@@ -180,8 +187,8 @@ class ClassDescriptionBuilderTest extends TestCase
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
         $classDescriptionBuilder->setFilePath('src/Foo.php')
-            ->setClassName($FQCN);
-        $classDescriptionBuilder->setTrait(false);
+            ->setClassName($FQCN)
+            ->setTrait(false);
 
         $classDescription = $classDescriptionBuilder->build();
 

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -16,7 +16,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
 
         $classDependency = new ClassDependency('DepClass', 10);
 
@@ -35,7 +35,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->setFinal(true);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -49,7 +49,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->setFinal(false);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -63,7 +63,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->setAbstract(true);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -77,7 +77,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->setAbstract(false);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -91,7 +91,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->addDocBlock('/**
  * @psalm-immutable
  */');
@@ -112,7 +112,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->addAttribute('AttrClass', 27);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -127,7 +127,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->setInterface(true);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -141,7 +141,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->setInterface(false);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -155,7 +155,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->setTrait(true);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -169,7 +169,7 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
         $classDescriptionBuilder->setTrait(false);
 
         $classDescription = $classDescriptionBuilder->build();

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -16,7 +16,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
 
         $classDependency = new ClassDependency('DepClass', 10);
 
@@ -35,7 +36,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->setFinal(true);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -49,7 +51,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->setFinal(false);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -63,7 +66,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->setAbstract(true);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -77,7 +81,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->setAbstract(false);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -91,7 +96,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->addDocBlock('/**
  * @psalm-immutable
  */');
@@ -112,7 +118,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->addAttribute('AttrClass', 27);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -127,7 +134,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->setInterface(true);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -141,7 +149,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->setInterface(false);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -155,7 +164,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->setTrait(true);
 
         $classDescription = $classDescriptionBuilder->build();
@@ -169,7 +179,8 @@ class ClassDescriptionBuilderTest extends TestCase
     {
         $FQCN = 'HappyIsland';
         $classDescriptionBuilder = new ClassDescriptionBuilder();
-        $classDescriptionBuilder->setFilePath('src/Foo.php')->setClassName($FQCN);
+        $classDescriptionBuilder->setFilePath('src/Foo.php')
+            ->setClassName($FQCN);
         $classDescriptionBuilder->setTrait(false);
 
         $classDescription = $classDescriptionBuilder->build();

--- a/tests/Unit/Analyzer/ClassDescriptionTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionTest.php
@@ -15,7 +15,7 @@ class ClassDescriptionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->builder = ClassDescription::getBuilder('Fruit\Banana');
+        $this->builder = ClassDescription::getBuilder('Fruit\Banana', 'src/Foo.php');
     }
 
     public function test_should_return_true_if_there_class_is_in_namespace(): void

--- a/tests/Unit/Analyzer/ClassDescriptionTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionTest.php
@@ -10,12 +10,18 @@ use PHPUnit\Framework\TestCase;
 
 class ClassDescriptionTest extends TestCase
 {
-    /** @var ClassDescriptionBuilder */
-    private $builder;
+    private ClassDescriptionBuilder $builder;
 
     protected function setUp(): void
     {
         $this->builder = ClassDescription::getBuilder('Fruit\Banana', 'src/Foo.php');
+    }
+
+    public function test_should_return_file_path(): void
+    {
+        $cd = $this->builder->build();
+
+        $this->assertEquals('src/Foo.php', $cd->getFilePath());
     }
 
     public function test_should_return_true_if_there_class_is_in_namespace(): void

--- a/tests/Unit/Analyzer/FileParserTest.php
+++ b/tests/Unit/Analyzer/FileParserTest.php
@@ -26,6 +26,7 @@ class FileParserTest extends TestCase
         $traverser->addVisitor($nameResolver);
         $traverser->addVisitor($fileVisitor);
 
+        $fileVisitor->setFilePath('foo')->shouldBeCalled();
         $fileVisitor->clearParsedClassDescriptions()->shouldBeCalled();
 
         $fileParser = new FileParser(
@@ -52,6 +53,7 @@ class FileParserTest extends TestCase
         $traverser->addVisitor($nameResolver);
         $traverser->addVisitor($fileVisitor);
 
+        $fileVisitor->setFilePath('foo')->shouldBeCalled();
         $fileVisitor->clearParsedClassDescriptions()->shouldBeCalled();
 
         $fileParser = new FileParser(

--- a/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
@@ -16,7 +16,7 @@ class ContainDocBlockLikeTest extends TestCase
         $expression = new ContainDocBlockLike('myDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 
@@ -36,7 +36,7 @@ class ContainDocBlockLikeTest extends TestCase
         $expression = new ContainDocBlockLike('anotherDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/ContainDocBlockLikeTest.php
@@ -16,7 +16,8 @@ class ContainDocBlockLikeTest extends TestCase
         $expression = new ContainDocBlockLike('myDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland\Myclass')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 
@@ -36,7 +37,8 @@ class ContainDocBlockLikeTest extends TestCase
         $expression = new ContainDocBlockLike('anotherDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland\Myclass')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/DependsOnlyOnTheseNamespacesTest.php
@@ -16,7 +16,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')->build();
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass', 'src/Foo.php')->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
@@ -33,7 +33,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass', 'src/Foo.php')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('anotherNamespace\Banana', 1))
             ->build();
@@ -53,7 +53,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass', 'src/Foo.php')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('\anotherNamespace\Banana', 1))
             ->addDependency(new ClassDependency('\DateTime', 10))
@@ -71,7 +71,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass', 'src/Foo.php')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('myNamespace\Mango', 10))
             ->build();
@@ -87,7 +87,7 @@ class DependsOnlyOnTheseNamespacesTest extends TestCase
     {
         $dependOnClasses = new DependsOnlyOnTheseNamespaces();
 
-        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass', 'src/Foo.php')
             ->addDependency(new ClassDependency('HappyIsland\Banana', 0))
             ->addDependency(new ClassDependency('myNamespace\Mango', 10))
             ->build();

--- a/tests/Unit/Expressions/ForClasses/ExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/ExtendTest.php
@@ -16,7 +16,8 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('My\Class')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('My\Class')
             ->addExtends('My\BaseClass', 10)
             ->build();
 
@@ -31,7 +32,8 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\B14*');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('My\Class')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('My\Class')
             ->addExtends('My\B14Class', 10)
             ->build();
 
@@ -46,7 +48,8 @@ class ExtendTest extends TestCase
         $extend = new Extend('App\Providers\(Auth|Event|Route|Horizon)ServiceProvider');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('My\Class')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('My\Class')
             ->addExtends('My\BaseClass', 10)
             ->build();
 
@@ -60,7 +63,8 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addExtends('My\AnotherClass', 10)
             ->build();
 
@@ -76,7 +80,8 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -94,7 +99,8 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\FirstExtend', 'My\SecondExtend');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('My\Class')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('My\Class')
             ->addExtends('My\SecondExtend', 10)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/ExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/ExtendTest.php
@@ -16,7 +16,7 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('My\Class')
+            ->setFilePath('src/Foo.php')->setClassName('My\Class')
             ->addExtends('My\BaseClass', 10)
             ->build();
 
@@ -31,7 +31,7 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\B14*');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('My\Class')
+            ->setFilePath('src/Foo.php')->setClassName('My\Class')
             ->addExtends('My\B14Class', 10)
             ->build();
 
@@ -46,7 +46,7 @@ class ExtendTest extends TestCase
         $extend = new Extend('App\Providers\(Auth|Event|Route|Horizon)ServiceProvider');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('My\Class')
+            ->setFilePath('src/Foo.php')->setClassName('My\Class')
             ->addExtends('My\BaseClass', 10)
             ->build();
 
@@ -60,7 +60,7 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addExtends('My\AnotherClass', 10)
             ->build();
 
@@ -76,7 +76,7 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -94,7 +94,7 @@ class ExtendTest extends TestCase
         $extend = new Extend('My\FirstExtend', 'My\SecondExtend');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('My\Class')
+            ->setFilePath('src/Foo.php')->setClassName('My\Class')
             ->addExtends('My\SecondExtend', 10)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
@@ -16,7 +16,8 @@ class HaveAttributeTest extends TestCase
         $expression = new HaveAttribute('myAttribute');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland\Myclass')
             ->addAttribute('myAttribute', 1)
             ->build();
 
@@ -36,7 +37,8 @@ class HaveAttributeTest extends TestCase
         $expression = new HaveAttribute('myAttribute');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland\Myclass')
             ->addAttribute('myAttribute', 1)
             ->build();
 
@@ -55,7 +57,8 @@ class HaveAttributeTest extends TestCase
         $expression = new HaveAttribute('anotherAttribute');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland\Myclass')
             ->addAttribute('myAttribute', 1)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveAttributeTest.php
@@ -16,7 +16,7 @@ class HaveAttributeTest extends TestCase
         $expression = new HaveAttribute('myAttribute');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
             ->addAttribute('myAttribute', 1)
             ->build();
 
@@ -36,7 +36,7 @@ class HaveAttributeTest extends TestCase
         $expression = new HaveAttribute('myAttribute');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
             ->addAttribute('myAttribute', 1)
             ->build();
 
@@ -55,7 +55,7 @@ class HaveAttributeTest extends TestCase
         $expression = new HaveAttribute('anotherAttribute');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland\Myclass')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland\Myclass')
             ->addAttribute('myAttribute', 1)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
@@ -14,7 +14,7 @@ class HaveNameMatchingTest extends TestCase
     {
         $expression = new HaveNameMatching('*Class');
 
-        $goodClass = ClassDescription::getBuilder('\App\MyClass')->build();
+        $goodClass = ClassDescription::getBuilder('\App\MyClass', 'src/Foo.php')->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
@@ -26,7 +26,7 @@ class HaveNameMatchingTest extends TestCase
     {
         $expression = new HaveNameMatching('*GoodName*');
 
-        $badClass = ClassDescription::getBuilder('\App\BadNameClass')->build();
+        $badClass = ClassDescription::getBuilder('\App\BadNameClass', 'src/Foo.php')->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();

--- a/tests/Unit/Expressions/ForClasses/ImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/ImplementTest.php
@@ -16,7 +16,8 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -34,7 +35,8 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addInterface('Foo', 1)
             ->build();
 
@@ -50,7 +52,8 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addInterface('interface', 1)
             ->build();
 
@@ -67,7 +70,8 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement('\Foo\Order');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addInterface('\Foo\Orderable', 1)
             ->build();
 
@@ -84,7 +88,8 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement($interface);
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/ImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/ImplementTest.php
@@ -16,7 +16,7 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -34,7 +34,7 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addInterface('Foo', 1)
             ->build();
 
@@ -50,7 +50,7 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addInterface('interface', 1)
             ->build();
 
@@ -67,7 +67,7 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement('\Foo\Order');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addInterface('\Foo\Orderable', 1)
             ->build();
 
@@ -84,7 +84,7 @@ class ImplementTest extends TestCase
         $implementConstraint = new Implement($interface);
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
@@ -17,7 +17,7 @@ class IsAbstractTest extends TestCase
         $isAbstract = new IsAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -35,7 +35,7 @@ class IsAbstractTest extends TestCase
         $isAbstract = new IsAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setFinal(true)
             ->setReadonly(true)
             ->setAbstract(true)
@@ -54,7 +54,7 @@ class IsAbstractTest extends TestCase
         $isNotAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 
@@ -68,7 +68,7 @@ class IsAbstractTest extends TestCase
         $isNotAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 
@@ -82,7 +82,7 @@ class IsAbstractTest extends TestCase
         $isNotAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 
@@ -96,7 +96,7 @@ class IsAbstractTest extends TestCase
         $isNotAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setFinal(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
@@ -17,7 +17,8 @@ class IsAbstractTest extends TestCase
         $isAbstract = new IsAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -35,7 +36,8 @@ class IsAbstractTest extends TestCase
         $isAbstract = new IsAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setFinal(true)
             ->setReadonly(true)
             ->setAbstract(true)
@@ -54,7 +56,8 @@ class IsAbstractTest extends TestCase
         $isNotAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 
@@ -68,7 +71,8 @@ class IsAbstractTest extends TestCase
         $isNotAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 
@@ -82,7 +86,8 @@ class IsAbstractTest extends TestCase
         $isNotAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 
@@ -96,7 +101,8 @@ class IsAbstractTest extends TestCase
         $isNotAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setFinal(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsEnumTest.php
@@ -15,7 +15,7 @@ class IsEnumTest extends TestCase
         $isEnum = new IsEnum();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -33,7 +33,7 @@ class IsEnumTest extends TestCase
         $isEnum = new IsEnum();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsEnumTest.php
@@ -15,7 +15,8 @@ class IsEnumTest extends TestCase
         $isEnum = new IsEnum();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -33,7 +34,8 @@ class IsEnumTest extends TestCase
         $isEnum = new IsEnum();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsFinalTest.php
@@ -17,7 +17,8 @@ class IsFinalTest extends TestCase
         $isFinal = new IsFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -31,7 +32,8 @@ class IsFinalTest extends TestCase
         $isFinal = new IsFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setFinal(true)
             ->build();
 
@@ -49,7 +51,8 @@ class IsFinalTest extends TestCase
         $isNotFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setAbstract(true)
             ->build();
 
@@ -63,7 +66,8 @@ class IsFinalTest extends TestCase
         $isNotFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 
@@ -77,7 +81,8 @@ class IsFinalTest extends TestCase
         $isNotFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 
@@ -91,7 +96,8 @@ class IsFinalTest extends TestCase
         $isNotFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsFinalTest.php
@@ -17,7 +17,7 @@ class IsFinalTest extends TestCase
         $isFinal = new IsFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -31,7 +31,7 @@ class IsFinalTest extends TestCase
         $isFinal = new IsFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setFinal(true)
             ->build();
 
@@ -49,7 +49,7 @@ class IsFinalTest extends TestCase
         $isNotFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setAbstract(true)
             ->build();
 
@@ -63,7 +63,7 @@ class IsFinalTest extends TestCase
         $isNotFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 
@@ -77,7 +77,7 @@ class IsFinalTest extends TestCase
         $isNotFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 
@@ -91,7 +91,7 @@ class IsFinalTest extends TestCase
         $isNotFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsInterfaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsInterfaceTest.php
@@ -16,7 +16,7 @@ class IsInterfaceTest extends TestCase
         $isFinal = new IsInterface();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -34,7 +34,7 @@ class IsInterfaceTest extends TestCase
         $isFinal = new IsInterface();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsInterfaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsInterfaceTest.php
@@ -16,7 +16,8 @@ class IsInterfaceTest extends TestCase
         $isFinal = new IsInterface();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -34,7 +35,8 @@ class IsInterfaceTest extends TestCase
         $isFinal = new IsInterface();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
@@ -16,7 +16,8 @@ class IsNotAbstractTest extends TestCase
         $isAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setAbstract(true)
             ->build();
 
@@ -35,7 +36,8 @@ class IsNotAbstractTest extends TestCase
         $isAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotAbstractTest.php
@@ -16,7 +16,7 @@ class IsNotAbstractTest extends TestCase
         $isAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setAbstract(true)
             ->build();
 
@@ -35,7 +35,7 @@ class IsNotAbstractTest extends TestCase
         $isAbstract = new IsNotAbstract();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
@@ -15,7 +15,7 @@ class IsNotEnumTest extends TestCase
         $isEnum = new IsNotEnum();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 
@@ -34,7 +34,7 @@ class IsNotEnumTest extends TestCase
         $isEnum = new IsNotEnum();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotEnumTest.php
@@ -15,7 +15,8 @@ class IsNotEnumTest extends TestCase
         $isEnum = new IsNotEnum();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 
@@ -34,7 +35,8 @@ class IsNotEnumTest extends TestCase
         $isEnum = new IsNotEnum();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
@@ -16,7 +16,8 @@ class IsNotFinalTest extends TestCase
         $isFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setFinal(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotFinalTest.php
@@ -16,7 +16,7 @@ class IsNotFinalTest extends TestCase
         $isFinal = new IsNotFinal();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setFinal(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsNotInterfaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotInterfaceTest.php
@@ -16,7 +16,7 @@ class IsNotInterfaceTest extends TestCase
         $isFinal = new IsNotInterface();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 
@@ -35,7 +35,7 @@ class IsNotInterfaceTest extends TestCase
         $isFinal = new IsNotInterface();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotInterfaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotInterfaceTest.php
@@ -16,7 +16,8 @@ class IsNotInterfaceTest extends TestCase
         $isFinal = new IsNotInterface();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 
@@ -35,7 +36,8 @@ class IsNotInterfaceTest extends TestCase
         $isFinal = new IsNotInterface();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotReadonlyTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotReadonlyTest.php
@@ -16,7 +16,7 @@ class IsNotReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setReadonly(true)
             ->build();
 
@@ -35,7 +35,7 @@ class IsNotReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotReadonlyTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotReadonlyTest.php
@@ -16,7 +16,8 @@ class IsNotReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setReadonly(true)
             ->build();
 
@@ -35,7 +36,8 @@ class IsNotReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotTraitTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotTraitTest.php
@@ -16,7 +16,7 @@ class IsNotTraitTest extends TestCase
         $isFinal = new IsNotTrait();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 
@@ -35,7 +35,7 @@ class IsNotTraitTest extends TestCase
         $isFinal = new IsNotTrait();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsNotTraitTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotTraitTest.php
@@ -16,7 +16,8 @@ class IsNotTraitTest extends TestCase
         $isFinal = new IsNotTrait();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 
@@ -35,7 +36,8 @@ class IsNotTraitTest extends TestCase
         $isFinal = new IsNotTrait();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';

--- a/tests/Unit/Expressions/ForClasses/IsReadonlyTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsReadonlyTest.php
@@ -17,7 +17,8 @@ class IsReadonlyTest extends TestCase
         $isReadonly = new IsReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -31,7 +32,8 @@ class IsReadonlyTest extends TestCase
         $isReadonly = new IsReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setReadonly(true)
             ->build();
 
@@ -48,7 +50,8 @@ class IsReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 
@@ -62,7 +65,8 @@ class IsReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 
@@ -76,7 +80,8 @@ class IsReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsReadonlyTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsReadonlyTest.php
@@ -17,7 +17,7 @@ class IsReadonlyTest extends TestCase
         $isReadonly = new IsReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -31,7 +31,7 @@ class IsReadonlyTest extends TestCase
         $isReadonly = new IsReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setReadonly(true)
             ->build();
 
@@ -48,7 +48,7 @@ class IsReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 
@@ -62,7 +62,7 @@ class IsReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 
@@ -76,7 +76,7 @@ class IsReadonlyTest extends TestCase
         $isNotReadonly = new IsNotReadonly();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setEnum(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsTraitTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsTraitTest.php
@@ -16,7 +16,7 @@ class IsTraitTest extends TestCase
         $isFinal = new IsTrait();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -34,7 +34,7 @@ class IsTraitTest extends TestCase
         $isFinal = new IsTrait();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/IsTraitTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsTraitTest.php
@@ -16,7 +16,8 @@ class IsTraitTest extends TestCase
         $isFinal = new IsTrait();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -34,7 +35,8 @@ class IsTraitTest extends TestCase
         $isFinal = new IsTrait();
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setTrait(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/MatchOneOfTheseNamesTest.php
+++ b/tests/Unit/Expressions/ForClasses/MatchOneOfTheseNamesTest.php
@@ -14,7 +14,7 @@ class MatchOneOfTheseNamesTest extends TestCase
     {
         $expression = new MatchOneOfTheseNames(['*BadNameClass', '*Class']);
 
-        $goodClass = ClassDescription::getBuilder('\App\MyClass')->build();
+        $goodClass = ClassDescription::getBuilder('\App\MyClass', 'src/Foo.php')->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
@@ -27,7 +27,7 @@ class MatchOneOfTheseNamesTest extends TestCase
     {
         $expression = new MatchOneOfTheseNames(['*BetterName*', '*GoodName*']);
 
-        $badClass = ClassDescription::getBuilder('\App\BadNameClass')->build();
+        $badClass = ClassDescription::getBuilder('\App\BadNameClass', 'src/Foo.php')->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();

--- a/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
@@ -16,7 +16,8 @@ class NotContainDocBlockLikeTest extends TestCase
         $expression = new NotContainDocBlockLike('anotherDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 
@@ -36,7 +37,8 @@ class NotContainDocBlockLikeTest extends TestCase
         $expression = new NotContainDocBlockLike('anotherDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 
@@ -55,7 +57,8 @@ class NotContainDocBlockLikeTest extends TestCase
         $expression = new NotContainDocBlockLike('myDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotContainDocBlockLikeTest.php
@@ -16,7 +16,7 @@ class NotContainDocBlockLikeTest extends TestCase
         $expression = new NotContainDocBlockLike('anotherDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 
@@ -36,7 +36,7 @@ class NotContainDocBlockLikeTest extends TestCase
         $expression = new NotContainDocBlockLike('anotherDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 
@@ -55,7 +55,7 @@ class NotContainDocBlockLikeTest extends TestCase
         $expression = new NotContainDocBlockLike('myDocBlock');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addDocBlock('/**  */myDocBlock with other information')
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotDependsOnTheseNamespacesTest.php
@@ -16,7 +16,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
     {
         $notDependOnClasses = new NotDependsOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')->build();
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass', 'src/Foo.php')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $notDependOnClasses->evaluate($classDescription, $violations, $because);
@@ -28,7 +28,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
     {
         $notDependOnClasses = new NotDependsOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass', 'src/Foo.php')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('anotherNamespace\Banana', 1))
             ->build();
@@ -48,7 +48,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
     {
         $notDependOnClasses = new NotDependsOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass', 'src/Foo.php')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('\anotherNamespace\Banana', 1))
             ->addDependency(new ClassDependency('\DateTime', 10))
@@ -69,7 +69,7 @@ class NotDependsOnTheseNamespacesTest extends TestCase
     {
         $notDependOnClasses = new NotDependsOnTheseNamespaces('myNamespace');
 
-        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass')
+        $classDescription = ClassDescription::getBuilder('HappyIsland\Myclass', 'src/Foo.php')
             ->addDependency(new ClassDependency('myNamespace\Banana', 0))
             ->addDependency(new ClassDependency('myNamespace\Mango', 10))
             ->build();

--- a/tests/Unit/Expressions/ForClasses/NotExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotExtendTest.php
@@ -16,7 +16,8 @@ class NotExtendTest extends TestCase
         $notExtend = new NotExtend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addExtends('My\BaseClass', 1)
             ->build();
 
@@ -35,7 +36,8 @@ class NotExtendTest extends TestCase
         $notExtend = new NotExtend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addExtends('My\AnotherClass', 1)
             ->build();
 
@@ -52,7 +54,8 @@ class NotExtendTest extends TestCase
         $notExtend = new NotExtend('My\FirstExtend', 'My\SecondExtend');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addExtends('My\SecondExtend', 1)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/NotExtendTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotExtendTest.php
@@ -16,7 +16,7 @@ class NotExtendTest extends TestCase
         $notExtend = new NotExtend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addExtends('My\BaseClass', 1)
             ->build();
 
@@ -35,7 +35,7 @@ class NotExtendTest extends TestCase
         $notExtend = new NotExtend('My\BaseClass');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addExtends('My\AnotherClass', 1)
             ->build();
 
@@ -52,7 +52,7 @@ class NotExtendTest extends TestCase
         $notExtend = new NotExtend('My\FirstExtend', 'My\SecondExtend');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addExtends('My\SecondExtend', 1)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
@@ -18,7 +18,8 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace($namespace);
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -35,7 +36,8 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addDependency(new ClassDependency('myNamespace', 100))
             ->build();
 
@@ -51,7 +53,8 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addDependency(new ClassDependency('myNamespace', 100))
             ->addDependency(new ClassDependency('another\class', 200))
             ->addDependency(new ClassDependency('\DateTime', 300))
@@ -69,7 +72,8 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace', ['foo']);
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addDependency(new ClassDependency('foo', 100))
             ->build();
 
@@ -85,7 +89,8 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace', [], true);
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addDependency(new ClassDependency('\DateTime', 100))
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveDependencyOutsideNamespaceTest.php
@@ -18,7 +18,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace($namespace);
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -35,7 +35,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addDependency(new ClassDependency('myNamespace', 100))
             ->build();
 
@@ -51,7 +51,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addDependency(new ClassDependency('myNamespace', 100))
             ->addDependency(new ClassDependency('another\class', 200))
             ->addDependency(new ClassDependency('\DateTime', 300))
@@ -69,7 +69,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace', ['foo']);
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addDependency(new ClassDependency('foo', 100))
             ->build();
 
@@ -85,7 +85,7 @@ class NotHaveDependencyOutsideNamespaceTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('myNamespace', [], true);
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addDependency(new ClassDependency('\DateTime', 100))
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/NotHaveNameMatchingTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveNameMatchingTest.php
@@ -14,7 +14,7 @@ class NotHaveNameMatchingTest extends TestCase
     {
         $expression = new NotHaveNameMatching('*Class');
 
-        $myClass = ClassDescription::getBuilder('\App\MyClass')->build();
+        $myClass = ClassDescription::getBuilder('\App\MyClass', 'src/Foo.php')->build();
 
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
@@ -31,7 +31,7 @@ class NotHaveNameMatchingTest extends TestCase
     {
         $expression = new NotHaveNameMatching('*GoodName*');
 
-        $badClass = ClassDescription::getBuilder('\App\BadNameClass')->build();
+        $badClass = ClassDescription::getBuilder('\App\BadNameClass', 'src/Foo.php')->build();
 
         $because = 'we want to add this rule for our software';
         $violations = new Violations();

--- a/tests/Unit/Expressions/ForClasses/NotImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotImplementTest.php
@@ -16,7 +16,7 @@ class NotImplementTest extends TestCase
         $implementConstraint = new NotImplement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -31,7 +31,7 @@ class NotImplementTest extends TestCase
         $implementConstraint = new NotImplement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addExtends('foo', 1)
             ->build();
 
@@ -47,7 +47,7 @@ class NotImplementTest extends TestCase
         $implementConstraint = new NotImplement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->addInterface('interface', 1)
             ->build();
 
@@ -69,7 +69,7 @@ class NotImplementTest extends TestCase
         $implementConstraint = new NotImplement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/NotImplementTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotImplementTest.php
@@ -16,7 +16,8 @@ class NotImplementTest extends TestCase
         $implementConstraint = new NotImplement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->build();
 
         $because = 'we want to add this rule for our software';
@@ -31,7 +32,8 @@ class NotImplementTest extends TestCase
         $implementConstraint = new NotImplement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addExtends('foo', 1)
             ->build();
 
@@ -47,7 +49,8 @@ class NotImplementTest extends TestCase
         $implementConstraint = new NotImplement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->addInterface('interface', 1)
             ->build();
 
@@ -69,7 +72,8 @@ class NotImplementTest extends TestCase
         $implementConstraint = new NotImplement('interface');
 
         $classDescription = (new ClassDescriptionBuilder())
-            ->setFilePath('src/Foo.php')->setClassName('HappyIsland')
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland')
             ->setInterface(true)
             ->build();
 

--- a/tests/Unit/Expressions/ForClasses/NotResideInTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotResideInTheseNamespacesTest.php
@@ -15,7 +15,7 @@ class NotResideInTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new NotResideInTheseNamespaces('MyNamespace');
 
-        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland', 'src/Foo.php')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -28,7 +28,7 @@ class NotResideInTheseNamespacesTest extends TestCase
         $namespace = 'MyNamespace';
         $haveNameMatching = new NotResideInTheseNamespaces($namespace);
 
-        $classDesc = ClassDescription::getBuilder('MyNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('MyNamespace\HappyIsland', 'src/Foo.php')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -44,18 +44,18 @@ class NotResideInTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new NotResideInTheseNamespaces('AnotherNamespace', 'ASecondNamespace', 'AThirdNamespace');
 
-        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland', 'src/Foo.php')->build();
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(1, $violations->count());
 
-        $classDesc = ClassDescription::getBuilder('MyNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('MyNamespace\HappyIsland', 'src/Foo.php')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::getBuilder('AThirdNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AThirdNamespace\HappyIsland', 'src/Foo.php')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(1, $violations->count());

--- a/tests/Unit/Expressions/ForClasses/ResideInOneOfTheseNamespacesTest.php
+++ b/tests/Unit/Expressions/ForClasses/ResideInOneOfTheseNamespacesTest.php
@@ -39,7 +39,7 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new ResideInOneOfTheseNamespaces($expectedNamespace);
 
-        $classDesc = ClassDescription::getBuilder($actualFQCN)->build();
+        $classDesc = ClassDescription::getBuilder($actualFQCN, 'src/Foo.php')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -51,7 +51,7 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new ResideInOneOfTheseNamespaces('MyNamespace');
 
-        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland', 'src/Foo.php')->build();
         $because = 'we want to add this rule for our software';
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
@@ -63,23 +63,23 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
     {
         $haveNameMatching = new ResideInOneOfTheseNamespaces('MyNamespace', 'AnotherNamespace', 'AThirdNamespace');
 
-        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AnotherNamespace\HappyIsland', 'src/Foo.php')->build();
         $violations = new Violations();
         $because = 'we want to add this rule for our software';
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::getBuilder('MyNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('MyNamespace\HappyIsland', 'src/Foo.php')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::getBuilder('AThirdNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('AThirdNamespace\HappyIsland', 'src/Foo.php')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertEquals(0, $violations->count());
 
-        $classDesc = ClassDescription::getBuilder('NopeNamespace\HappyIsland')->build();
+        $classDesc = ClassDescription::getBuilder('NopeNamespace\HappyIsland', 'src/Foo.php')->build();
         $violations = new Violations();
         $haveNameMatching->evaluate($classDesc, $violations, $because);
         self::assertNotEquals(0, $violations->count());
@@ -91,7 +91,7 @@ class ResideInOneOfTheseNamespacesTest extends TestCase
 
         self::assertSame(
             'should reside in one of these namespaces: A, B, C, D because rave',
-            $expression->describe(ClassDescription::getBuilder('Marko')->build(), 'rave')->toString()
+            $expression->describe(ClassDescription::getBuilder('Marko', 'src/Foo.php')->build(), 'rave')->toString()
         );
     }
 }

--- a/tests/Unit/Rules/ConstraintsTest.php
+++ b/tests/Unit/Rules/ConstraintsTest.php
@@ -35,7 +35,7 @@ class ConstraintsTest extends TestCase
         $because = 'we want to add this rule for our software';
 
         $cb = new ClassDescriptionBuilder();
-        $cb->setClassName('Banana');
+        $cb->setFilePath('src/Foo.php')->setClassName('Banana');
 
         $expressionStore->checkAll(
             $cb->build(),
@@ -71,7 +71,7 @@ class ConstraintsTest extends TestCase
         $because = 'we want to add this rule for our software';
 
         $cb = new ClassDescriptionBuilder();
-        $cb->setClassName('Banana');
+        $cb->setFilePath('src/Foo.php')->setClassName('Banana');
 
         $expressionStore->checkAll(
             $cb->build(),

--- a/tests/Unit/Rules/ConstraintsTest.php
+++ b/tests/Unit/Rules/ConstraintsTest.php
@@ -35,7 +35,8 @@ class ConstraintsTest extends TestCase
         $because = 'we want to add this rule for our software';
 
         $cb = new ClassDescriptionBuilder();
-        $cb->setFilePath('src/Foo.php')->setClassName('Banana');
+        $cb->setFilePath('src/Foo.php')
+            ->setClassName('Banana');
 
         $expressionStore->checkAll(
             $cb->build(),
@@ -71,7 +72,8 @@ class ConstraintsTest extends TestCase
         $because = 'we want to add this rule for our software';
 
         $cb = new ClassDescriptionBuilder();
-        $cb->setFilePath('src/Foo.php')->setClassName('Banana');
+        $cb->setFilePath('src/Foo.php')
+            ->setClassName('Banana');
 
         $expressionStore->checkAll(
             $cb->build(),

--- a/tests/Unit/Rules/RuleCheckerTest.php
+++ b/tests/Unit/Rules/RuleCheckerTest.php
@@ -89,7 +89,7 @@ class FakeParser implements Parser
 
     public function getClassDescriptions(): array
     {
-        return [ClassDescription::getBuilder('uno')->build()];
+        return [ClassDescription::getBuilder('uno', 'src/Foo.php')->build()];
     }
 
     public function getParsingErrors(): array

--- a/tests/Unit/Rules/SpecsTest.php
+++ b/tests/Unit/Rules/SpecsTest.php
@@ -17,7 +17,7 @@ class SpecsTest extends TestCase
         $specStore = new Specs();
         $specStore->add(new HaveNameMatching('Foo'));
 
-        $classDescription = ClassDescription::getBuilder('MyNamespace\HappyIsland')->build();
+        $classDescription = ClassDescription::getBuilder('MyNamespace\HappyIsland', 'src/Foo.php')->build();
         $because = 'we want to add this rule for our software';
 
         $this->assertFalse($specStore->allSpecsAreMatchedBy($classDescription, $because));
@@ -28,7 +28,7 @@ class SpecsTest extends TestCase
         $specStore = new Specs();
         $specStore->add(new HaveNameMatching('Happy*'));
 
-        $classDescription = ClassDescription::getBuilder('MyNamespace\HappyIsland')
+        $classDescription = ClassDescription::getBuilder('MyNamespace\HappyIsland', 'src/Foo.php')
             ->addDependency(new ClassDependency('Foo', 100))
             ->build();
         $because = 'we want to add this rule for our software';


### PR DESCRIPTION
This depends on #476. Here a `$filePath` attribute is added to `ClassDescription` and is populated during the parsing process. That should enable adding the information relative to the file path when building a violation (needed in #474) 