### PR TITLE
Violation can now contain a reference to the file path

### DIFF
--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -19,8 +19,8 @@ class FileParser implements Parser
 
     private FileVisitor $fileVisitor;
 
-    /** @var array */
-    private $parsingErrors;
+    /** @var ParsingError[] */
+    private array $parsingErrors;
 
     public function __construct(
         NodeTraverser $traverser,

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -13,7 +13,7 @@ class FileVisitor extends NodeVisitorAbstract
 {
     private ClassDescriptionBuilder $classDescriptionBuilder;
 
-    /** @var array<ClassDescription> */
+    /** @var ClassDescription[] */
     private array $classDescriptions = [];
 
     public function __construct(ClassDescriptionBuilder $classDescriptionBuilder)
@@ -21,7 +21,7 @@ class FileVisitor extends NodeVisitorAbstract
         $this->classDescriptionBuilder = $classDescriptionBuilder;
     }
 
-    public function setFilePath(string $filePath): void
+    public function setFilePath(?string $filePath): void
     {
         $this->classDescriptionBuilder->setFilePath($filePath);
     }

--- a/src/Expression/ForClasses/ContainDocBlockLike.php
+++ b/src/Expression/ForClasses/ContainDocBlockLike.php
@@ -31,7 +31,8 @@ class ContainDocBlockLike implements Expression
         if (!$theClass->containsDocBlock($this->docBlock)) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/DependsOnlyOnTheseNamespaces.php
+++ b/src/Expression/ForClasses/DependsOnlyOnTheseNamespaces.php
@@ -15,7 +15,7 @@ use Arkitect\Rules\Violations;
 class DependsOnlyOnTheseNamespaces implements Expression
 {
     /** @var string[] */
-    private $namespaces;
+    private array $namespaces;
 
     public function __construct(string ...$namespace)
     {
@@ -49,7 +49,8 @@ class DependsOnlyOnTheseNamespaces implements Expression
                         $this->describe($theClass, $because),
                         "depends on {$dependency->getFQCN()->toString()}"
                     ),
-                    $dependency->getLine()
+                    $dependency->getLine(),
+                    $theClass->getFilePath()
                 );
 
                 $violations->add($violation);

--- a/src/Expression/ForClasses/Extend.php
+++ b/src/Expression/ForClasses/Extend.php
@@ -43,7 +43,8 @@ class Extend implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/HaveAttribute.php
+++ b/src/Expression/ForClasses/HaveAttribute.php
@@ -34,7 +34,8 @@ final class HaveAttribute implements Expression
         $violations->add(
             Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             )
         );
     }

--- a/src/Expression/ForClasses/HaveNameMatching.php
+++ b/src/Expression/ForClasses/HaveNameMatching.php
@@ -33,7 +33,8 @@ class HaveNameMatching implements Expression
         if (!$fqcn->classMatches($this->name)) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/Implement.php
+++ b/src/Expression/ForClasses/Implement.php
@@ -47,7 +47,8 @@ class Implement implements Expression
         if (0 === \count(array_filter($interfaces, $implements))) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/IsAbstract.php
+++ b/src/Expression/ForClasses/IsAbstract.php
@@ -31,7 +31,8 @@ class IsAbstract implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsEnum.php
+++ b/src/Expression/ForClasses/IsEnum.php
@@ -26,7 +26,8 @@ class IsEnum implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsFinal.php
+++ b/src/Expression/ForClasses/IsFinal.php
@@ -31,7 +31,8 @@ class IsFinal implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsInterface.php
+++ b/src/Expression/ForClasses/IsInterface.php
@@ -26,7 +26,8 @@ class IsInterface implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsNotAbstract.php
+++ b/src/Expression/ForClasses/IsNotAbstract.php
@@ -31,7 +31,8 @@ class IsNotAbstract implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsNotEnum.php
+++ b/src/Expression/ForClasses/IsNotEnum.php
@@ -26,7 +26,8 @@ class IsNotEnum implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsNotFinal.php
+++ b/src/Expression/ForClasses/IsNotFinal.php
@@ -31,7 +31,8 @@ class IsNotFinal implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsNotInterface.php
+++ b/src/Expression/ForClasses/IsNotInterface.php
@@ -26,7 +26,8 @@ class IsNotInterface implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsNotReadonly.php
+++ b/src/Expression/ForClasses/IsNotReadonly.php
@@ -31,7 +31,8 @@ class IsNotReadonly implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsNotTrait.php
+++ b/src/Expression/ForClasses/IsNotTrait.php
@@ -26,7 +26,8 @@ class IsNotTrait implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsReadonly.php
+++ b/src/Expression/ForClasses/IsReadonly.php
@@ -31,7 +31,8 @@ class IsReadonly implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/IsTrait.php
+++ b/src/Expression/ForClasses/IsTrait.php
@@ -26,7 +26,8 @@ class IsTrait implements Expression
 
         $violation = Violation::create(
             $theClass->getFQCN(),
-            ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+            ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+            $theClass->getFilePath()
         );
 
         $violations->add($violation);

--- a/src/Expression/ForClasses/MatchOneOfTheseNames.php
+++ b/src/Expression/ForClasses/MatchOneOfTheseNames.php
@@ -40,7 +40,8 @@ class MatchOneOfTheseNames implements Expression
         if (!$matches) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/NotContainDocBlockLike.php
+++ b/src/Expression/ForClasses/NotContainDocBlockLike.php
@@ -31,7 +31,8 @@ class NotContainDocBlockLike implements Expression
         if ($theClass->containsDocBlock($this->docBlock)) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/NotDependsOnTheseNamespaces.php
+++ b/src/Expression/ForClasses/NotDependsOnTheseNamespaces.php
@@ -15,7 +15,7 @@ use Arkitect\Rules\Violations;
 class NotDependsOnTheseNamespaces implements Expression
 {
     /** @var string[] */
-    private $namespaces;
+    private array $namespaces;
 
     public function __construct(string ...$namespace)
     {
@@ -46,7 +46,8 @@ class NotDependsOnTheseNamespaces implements Expression
                         $this->describe($theClass, $because),
                         "depends on {$dependency->getFQCN()->toString()}"
                     ),
-                    $dependency->getLine()
+                    $dependency->getLine(),
+                    $theClass->getFilePath()
                 );
 
                 $violations->add($violation);

--- a/src/Expression/ForClasses/NotExtend.php
+++ b/src/Expression/ForClasses/NotExtend.php
@@ -38,7 +38,8 @@ class NotExtend implements Expression
                 if ($extend->matches($className)) {
                     $violation = Violation::create(
                         $theClass->getFQCN(),
-                        ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                        ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                        $theClass->getFilePath()
                     );
 
                     $violations->add($violation);

--- a/src/Expression/ForClasses/NotHaveDependencyOutsideNamespace.php
+++ b/src/Expression/ForClasses/NotHaveDependencyOutsideNamespace.php
@@ -14,12 +14,12 @@ use Arkitect\Rules\Violations;
 
 class NotHaveDependencyOutsideNamespace implements Expression
 {
-    /** @var string */
-    private $namespace;
-    /** @var array */
-    private $externalDependenciesToExclude;
-    /** @var bool */
-    private $excludeCoreNamespace;
+    private string $namespace;
+
+    /** @var string[] */
+    private array $externalDependenciesToExclude;
+
+    private bool $excludeCoreNamespace;
 
     public function __construct(string $namespace, array $externalDependenciesToExclude = [], bool $excludeCoreNamespace = false)
     {
@@ -59,7 +59,8 @@ class NotHaveDependencyOutsideNamespace implements Expression
                     $this->describe($theClass, $because),
                     "depends on {$externalDep->getFQCN()->toString()}"
                 ),
-                $externalDep->getLine()
+                $externalDep->getLine(),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/NotHaveNameMatching.php
+++ b/src/Expression/ForClasses/NotHaveNameMatching.php
@@ -33,7 +33,8 @@ class NotHaveNameMatching implements Expression
         if ($fqcn->classMatches($this->name)) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/NotImplement.php
+++ b/src/Expression/ForClasses/NotImplement.php
@@ -47,7 +47,8 @@ class NotImplement implements Expression
         if (\count(array_filter($interfaces, $implements)) > 0) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/NotResideInTheseNamespaces.php
+++ b/src/Expression/ForClasses/NotResideInTheseNamespaces.php
@@ -40,7 +40,8 @@ class NotResideInTheseNamespaces implements Expression
         if ($resideInNamespace) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
+++ b/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
@@ -40,7 +40,8 @@ class ResideInOneOfTheseNamespaces implements Expression
         if (!$resideInNamespace) {
             $violation = Violation::create(
                 $theClass->getFQCN(),
-                ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
             );
             $violations->add($violation);
         }

--- a/src/Rules/Violation.php
+++ b/src/Rules/Violation.php
@@ -22,9 +22,9 @@ class Violation implements \JsonSerializable
         $this->filePath = $filePath;
     }
 
-    public static function create(string $fqcn, ViolationMessage $error): self
+    public static function create(string $fqcn, ViolationMessage $error, string $filePath): self
     {
-        return new self($fqcn, $error->toString());
+        return new self($fqcn, $error->toString(), null, $filePath);
     }
 
     public static function createWithErrorLine(string $fqcn, ViolationMessage $error, int $line, string $filePath): self

--- a/src/Rules/Violation.php
+++ b/src/Rules/Violation.php
@@ -10,13 +10,16 @@ class Violation implements \JsonSerializable
 
     private ?int $line;
 
+    private ?string $filePath;
+
     private string $error;
 
-    public function __construct(string $fqcn, string $error, ?int $line = null)
+    public function __construct(string $fqcn, string $error, ?int $line = null, ?string $filePath = null)
     {
         $this->fqcn = $fqcn;
         $this->error = $error;
         $this->line = $line;
+        $this->filePath = $filePath;
     }
 
     public static function create(string $fqcn, ViolationMessage $error): self
@@ -24,9 +27,9 @@ class Violation implements \JsonSerializable
         return new self($fqcn, $error->toString());
     }
 
-    public static function createWithErrorLine(string $fqcn, ViolationMessage $error, int $line): self
+    public static function createWithErrorLine(string $fqcn, ViolationMessage $error, int $line, string $filePath): self
     {
-        return new self($fqcn, $error->toString(), $line);
+        return new self($fqcn, $error->toString(), $line, $filePath);
     }
 
     public function getFqcn(): string
@@ -44,6 +47,11 @@ class Violation implements \JsonSerializable
         return $this->line;
     }
 
+    public function getFilePath(): ?string
+    {
+        return $this->filePath;
+    }
+
     public function jsonSerialize(): array
     {
         return get_object_vars($this);
@@ -51,6 +59,6 @@ class Violation implements \JsonSerializable
 
     public static function fromJson(array $json): self
     {
-        return new self($json['fqcn'], $json['error'], $json['line']);
+        return new self($json['fqcn'], $json['error'], $json['line'], $json['filePath'] ?? null);
     }
 }

--- a/tests/Unit/Rules/ConstraintsTest.php
+++ b/tests/Unit/Rules/ConstraintsTest.php
@@ -59,7 +59,8 @@ class ConstraintsTest extends TestCase
             {
                 $violation = Violation::create(
                     $theClass->getFQCN(),
-                    ViolationMessage::selfExplanatory($this->describe($theClass, $because))
+                    ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                    $theClass->getFilePath()
                 );
 
                 $violations->add($violation);


### PR DESCRIPTION
This is the last step to unblock https://github.com/phparkitect/arkitect/pull/474. 
Now all rules populate the field `$filePath`, which can be used when generating the output. 