### PR TITLE
Bump csfixer to version 3.75.0 and tweak configuration

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,6 +9,7 @@ return (new PhpCsFixer\Config())
     ->setFinder($finder)
     ->setRiskyAllowed(true)
     ->setRules([
+        '@PER-CS' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
         '@PHP71Migration:risky' => true,
@@ -39,5 +40,8 @@ return (new PhpCsFixer\Config())
         'list_syntax' => ['syntax' => 'short'],
         'phpdoc_to_comment' => false,
         'php_unit_method_casing' => ['case' => 'snake_case'],
-        'function_to_constant' => false
+        'function_to_constant' => false,
+        'php_unit_data_provider_static' => true ,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'phpdoc_array_type' => true
     ]);

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,13 @@
         "ondram/ci-detector": "^4.1"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master",
-        "symfony/var-dumper": "^3.0|^4.0|^5.0|^6.0|^7.0",
-        "phpunit/phpunit": "^7.5|^9.0|^10.0",
+        "friendsofphp/php-cs-fixer": "^3.75",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy": "^1.10",
-        "friendsofphp/php-cs-fixer": "3.4.0",
-        "phpspec/prophecy-phpunit": "^2.3"
+        "phpspec/prophecy-phpunit": "^2.3",
+        "phpunit/phpunit": "^7.5|^9.0|^10.0",
+        "roave/security-advisories": "dev-master",
+        "symfony/var-dumper": "^3.0|^4.0|^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -19,7 +19,7 @@ class FileParser implements Parser
 
     private FileVisitor $fileVisitor;
 
-    /** @var ParsingError[] */
+    /** @var array<ParsingError> */
     private array $parsingErrors;
 
     public function __construct(
@@ -38,7 +38,7 @@ class FileParser implements Parser
     }
 
     /**
-     * @return ClassDescription[]
+     * @return array<ClassDescription>
      */
     public function getClassDescriptions(): array
     {

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -13,7 +13,7 @@ class FileVisitor extends NodeVisitorAbstract
 {
     private ClassDescriptionBuilder $classDescriptionBuilder;
 
-    /** @var ClassDescription[] */
+    /** @var array<ClassDescription> */
     private array $classDescriptions = [];
 
     public function __construct(ClassDescriptionBuilder $classDescriptionBuilder)

--- a/src/Analyzer/NameResolver.php
+++ b/src/Analyzer/NameResolver.php
@@ -329,7 +329,6 @@ class NameResolver extends NodeVisitorAbstract
 
     /**
      * @param Stmt\Use_::TYPE_* $type
-     * @param ?Name             $prefix
      *
      * @psalm-suppress PossiblyNullArgument
      */

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -142,7 +142,7 @@ class Check extends Command
 
             $rulesFilename = $this->getConfigFilename($input);
             if (!$onlyErrors) {
-                $output->writeln(sprintf("Config file: %s\n", $rulesFilename));
+                $output->writeln(\sprintf("Config file: %s\n", $rulesFilename));
             }
 
             $config = new Config();
@@ -267,9 +267,9 @@ class Check extends Command
             $output->writeln('<error>ERRORS!</error>');
         }
 
-        $output->writeln(sprintf('%s', $violations->toString($format)));
+        $output->writeln(\sprintf('%s', $violations->toString($format)));
         if (!$onlyErrors) {
-            $output->writeln(sprintf('<error>%s VIOLATIONS DETECTED!</error>', \count($violations)));
+            $output->writeln(\sprintf('<error>%s VIOLATIONS DETECTED!</error>', \count($violations)));
         }
     }
 
@@ -278,7 +278,7 @@ class Check extends Command
         if (!$onlyErrors) {
             $output->writeln('<error>ERROR ON PARSING THESE FILES:</error>');
         }
-        $output->writeln(sprintf('%s', $parsingErrors->toString()));
+        $output->writeln(\sprintf('%s', $parsingErrors->toString()));
     }
 
     private function printNoViolationsDetectedMessage(OutputInterface $output, bool $onlyErrors = false, string $format = Printer::FORMAT_TEXT): void

--- a/src/CLI/PhpArkitectApplication.php
+++ b/src/CLI/PhpArkitectApplication.php
@@ -29,6 +29,6 @@ EOD;
 
     public function getLongVersion(): string
     {
-        return sprintf("%s\n\n<info>%s</info> version <comment>%s</comment>", self::$logo, $this->getName(), $this->getVersion());
+        return \sprintf("%s\n\n<info>%s</info> version <comment>%s</comment>", self::$logo, $this->getName(), $this->getVersion());
     }
 }

--- a/src/CLI/PhpArkitectApplication.php
+++ b/src/CLI/PhpArkitectApplication.php
@@ -10,14 +10,13 @@ use Arkitect\CLI\Command\Init;
 
 class PhpArkitectApplication extends \Symfony\Component\Console\Application
 {
-    /** @var string */
-    private static $logo = <<< 'EOD'
-  ____  _   _ ____   _         _    _ _            _
- |  _ \| | | |  _ \ / \   _ __| | _(_) |_ ___  ___| |_
- | |_) | |_| | |_) / _ \ | '__| |/ / | __/ _ \/ __| __|
- |  __/|  _  |  __/ ___ \| |  |   <| | ||  __/ (__| |_
- |_|   |_| |_|_| /_/   \_\_|  |_|\_\_|\__\___|\___|\__|
-EOD;
+    private static string $logo = <<< 'EOD'
+     ____  _   _ ____   _         _    _ _            _
+    |  _ \| | | |  _ \ / \   _ __| | _(_) |_ ___  ___| |_
+    | |_) | |_| | |_) / _ \ | '__| |/ / | __/ _ \/ __| __|
+    |  __/|  _  |  __/ ___ \| |  |   <| | ||  __/ (__| |_
+    |_|   |_| |_|_| /_/   \_\_|  |_|\_\_|\__\___|\___|\__|
+    EOD;
 
     public function __construct()
     {

--- a/src/CLI/Printer/GitlabPrinter.php
+++ b/src/CLI/Printer/GitlabPrinter.php
@@ -12,8 +12,8 @@ class GitlabPrinter implements Printer
         $allErrors = [];
 
         /**
-         * @var string      $key
-         * @var Violation[] $violationsByFqcn
+         * @var string           $key
+         * @var array<Violation> $violationsByFqcn
          */
         foreach ($violationsCollection as $class => $violationsByFqcn) {
             foreach ($violationsByFqcn as $violation) {

--- a/src/CLI/Printer/JsonPrinter.php
+++ b/src/CLI/Printer/JsonPrinter.php
@@ -13,8 +13,8 @@ class JsonPrinter implements Printer
         $details = [];
 
         /**
-         * @var string      $key
-         * @var Violation[] $violationsByFqcn
+         * @var string           $key
+         * @var array<Violation> $violationsByFqcn
          */
         foreach ($violationsCollection as $class => $violationsByFqcn) {
             $violationForThisFqcn = \count($violationsByFqcn);

--- a/src/CLI/Printer/TextPrinter.php
+++ b/src/CLI/Printer/TextPrinter.php
@@ -12,8 +12,8 @@ class TextPrinter implements Printer
         $errors = '';
 
         /**
-         * @var string      $key
-         * @var Violation[] $violationsByFqcn
+         * @var string           $key
+         * @var array<Violation> $violationsByFqcn
          */
         foreach ($violationsCollection as $key => $violationsByFqcn) {
             $violationForThisFqcn = \count($violationsByFqcn);

--- a/src/ClassSet.php
+++ b/src/ClassSet.php
@@ -11,7 +11,7 @@ use Symfony\Component\Finder\Finder;
  */
 class ClassSet implements \IteratorAggregate
 {
-    /** @var string[] */
+    /** @var array<string> */
     private array $directoryList;
 
     private array $exclude;

--- a/src/ClassSetRules.php
+++ b/src/ClassSetRules.php
@@ -10,7 +10,7 @@ class ClassSetRules
 {
     private ClassSet $classSet;
 
-    /** @var ArchRule[] */
+    /** @var array<ArchRule> */
     private array $rules;
 
     private function __construct(ClassSet $classSet, ArchRule ...$rules)

--- a/src/Exceptions/IndexNotFoundException.php
+++ b/src/Exceptions/IndexNotFoundException.php
@@ -7,6 +7,6 @@ class IndexNotFoundException extends \Exception
 {
     public function __construct(int $index)
     {
-        parent::__construct(sprintf('Index not found %d', $index));
+        parent::__construct(\sprintf('Index not found %d', $index));
     }
 }

--- a/src/Exceptions/PhpVersionNotValidException.php
+++ b/src/Exceptions/PhpVersionNotValidException.php
@@ -7,6 +7,6 @@ class PhpVersionNotValidException extends \Exception
 {
     public function __construct(string $phpVersion)
     {
-        parent::__construct(sprintf('PHP version not valid for PHPArkitect parser %s', $phpVersion));
+        parent::__construct(\sprintf('PHP version not valid for PHPArkitect parser %s', $phpVersion));
     }
 }

--- a/src/Expression/Expression.php
+++ b/src/Expression/Expression.php
@@ -29,7 +29,7 @@ interface Expression
      *
      * Not included directly in the interface to allow incremental implementation of it in the rules.
      */
-    //public function appliesTo(ClassDescription $theClass): bool;
+    // public function appliesTo(ClassDescription $theClass): bool;
 
     /**
      * Evaluates the expression for the class passed as parameter.

--- a/src/Expression/ForClasses/DependsOnlyOnTheseNamespaces.php
+++ b/src/Expression/ForClasses/DependsOnlyOnTheseNamespaces.php
@@ -14,7 +14,7 @@ use Arkitect\Rules\Violations;
 
 class DependsOnlyOnTheseNamespaces implements Expression
 {
-    /** @var string[] */
+    /** @var array<string> */
     private array $namespaces;
 
     public function __construct(string ...$namespace)

--- a/src/Expression/ForClasses/Extend.php
+++ b/src/Expression/ForClasses/Extend.php
@@ -13,7 +13,7 @@ use Arkitect\Rules\Violations;
 
 class Extend implements Expression
 {
-    /** @var string[] */
+    /** @var array<string> */
     private array $classNames;
 
     public function __construct(string ...$classNames)

--- a/src/Expression/ForClasses/NotDependsOnTheseNamespaces.php
+++ b/src/Expression/ForClasses/NotDependsOnTheseNamespaces.php
@@ -14,7 +14,7 @@ use Arkitect\Rules\Violations;
 
 class NotDependsOnTheseNamespaces implements Expression
 {
-    /** @var string[] */
+    /** @var array<string> */
     private array $namespaces;
 
     public function __construct(string ...$namespace)

--- a/src/Expression/ForClasses/NotExtend.php
+++ b/src/Expression/ForClasses/NotExtend.php
@@ -13,7 +13,7 @@ use Arkitect\Rules\Violations;
 
 class NotExtend implements Expression
 {
-    /** @var string[] */
+    /** @var array<string> */
     private array $classNames;
 
     public function __construct(string ...$classNames)

--- a/src/Expression/ForClasses/NotHaveDependencyOutsideNamespace.php
+++ b/src/Expression/ForClasses/NotHaveDependencyOutsideNamespace.php
@@ -16,7 +16,7 @@ class NotHaveDependencyOutsideNamespace implements Expression
 {
     private string $namespace;
 
-    /** @var string[] */
+    /** @var array<string> */
     private array $externalDependenciesToExclude;
 
     private bool $excludeCoreNamespace;

--- a/src/Expression/ForClasses/NotResideInTheseNamespaces.php
+++ b/src/Expression/ForClasses/NotResideInTheseNamespaces.php
@@ -13,7 +13,7 @@ use Arkitect\Rules\Violations;
 
 class NotResideInTheseNamespaces implements Expression
 {
-    /** @var string[] */
+    /** @var array<string> */
     private $namespaces;
 
     public function __construct(string ...$namespaces)

--- a/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
+++ b/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
@@ -13,7 +13,7 @@ use Arkitect\Rules\Violations;
 
 class ResideInOneOfTheseNamespaces implements Expression
 {
-    /** @var string[] */
+    /** @var array<string> */
     private $namespaces;
 
     public function __construct(string ...$namespaces)

--- a/src/RuleBuilders/Architecture/Architecture.php
+++ b/src/RuleBuilders/Architecture/Architecture.php
@@ -14,9 +14,9 @@ class Architecture implements Component, DefinedBy, Where, MayDependOnComponents
     private $componentName;
     /** @var array<string, string> */
     private $componentSelectors;
-    /** @var array<string, string[]> */
+    /** @var array<string, array<string>> */
     private $allowedDependencies;
-    /** @var array<string, string[]> */
+    /** @var array<string, array<string>> */
     private $componentDependsOnlyOnTheseNamespaces;
 
     private function __construct()

--- a/src/RuleBuilders/Architecture/MayDependOnComponents.php
+++ b/src/RuleBuilders/Architecture/MayDependOnComponents.php
@@ -8,7 +8,7 @@ interface MayDependOnComponents
     /**
      * May depend on the specified components, plus itself.
      *
-     * @param string[] $componentNames
+     * @param array<string> $componentNames
      *
      * @return Where&Rules
      */

--- a/src/RuleBuilders/Architecture/ShouldOnlyDependOnComponents.php
+++ b/src/RuleBuilders/Architecture/ShouldOnlyDependOnComponents.php
@@ -8,7 +8,7 @@ interface ShouldOnlyDependOnComponents
     /**
      * May depend ONLY on the specified components, thus it can only depend on itself if itself is specified.
      *
-     * @param string[] $componentNames
+     * @param array<string> $componentNames
      *
      * @return Where&Rules
      */

--- a/src/Rules/ParsingErrors.php
+++ b/src/Rules/ParsingErrors.php
@@ -12,7 +12,7 @@ use Arkitect\Exceptions\IndexNotFoundException;
 class ParsingErrors implements \IteratorAggregate, \Countable
 {
     /**
-     * @var ParsingError[]
+     * @var array<ParsingError>
      */
     private $parsingErrors;
 

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -13,7 +13,7 @@ use Arkitect\Exceptions\IndexNotFoundException;
 class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
 {
     /**
-     * @var Violation[]
+     * @var array<Violation>
      */
     private array $violations;
 

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -205,7 +205,7 @@ App\Controller\Foo has 1 violations
 
         $display = $cmdTester->getDisplay();
 
-        $this->assertJson($display);
+        self::assertJson($display);
 
         self::assertSame(<<<JSON
         [{"description":"should have a name that matches *Controller because all controllers should be end name with Controller","check_name":"App\\\\Controller\\\\Foo.should-have-a-name-that-matches-controller-because-all-controllers-should-be-end-name-with-controller","fingerprint":"1e960c3f49b5ec63ece40321072ef2bd0bc33ad11b7be326f304255d277dc860","severity":"major","location":{"path":"Controller\/Foo.php","lines":{"begin":1}}}]
@@ -223,10 +223,10 @@ App\Controller\Foo has 1 violations
 
         $display = $cmdTester->getDisplay();
 
-        $this->assertJson($display);
+        self::assertJson($display);
 
         $json = json_decode($display, true);
-        $this->assertCount(0, $json);
+        self::assertCount(0, $json);
     }
 
     protected function runCheck(

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -176,7 +176,7 @@ App\Controller\Foo has 1 violations
 
         $display = $cmdTester->getDisplay();
 
-        $this->assertJson($display);
+        self::assertJson($display);
     }
 
     public function test_json_format_output_no_errors(): void
@@ -189,10 +189,10 @@ App\Controller\Foo has 1 violations
 
         $display = $cmdTester->getDisplay();
 
-        $this->assertJson($display);
+        self::assertJson($display);
 
         $json = json_decode($display, true);
-        $this->assertCount(0, $json);
+        self::assertCount(0, $json);
     }
 
     public function test_gitlab_format_output(): void
@@ -274,27 +274,27 @@ App\Controller\Foo has 1 violations
 
     protected function assertCheckHasErrors(ApplicationTester $applicationTester, ?string $expectedOutput = null): void
     {
-        $this->assertEquals(self::ERROR_CODE, $applicationTester->getStatusCode());
+        self::assertEquals(self::ERROR_CODE, $applicationTester->getStatusCode());
         if (null != $expectedOutput) {
             $actualOutput = str_replace(["\r", "\n"], '', $applicationTester->getDisplay());
             $expectedOutput = str_replace(["\r", "\n"], '', $expectedOutput);
-            $this->assertStringContainsString($expectedOutput, $actualOutput);
+            self::assertStringContainsString($expectedOutput, $actualOutput);
         }
     }
 
     protected function assertCheckHasNoErrorsLike(ApplicationTester $applicationTester, ?string $expectedOutput = null): void
     {
-        $this->assertEquals(self::ERROR_CODE, $applicationTester->getStatusCode());
+        self::assertEquals(self::ERROR_CODE, $applicationTester->getStatusCode());
         if (null != $expectedOutput) {
             $actualOutput = str_replace(["\r", "\n"], '', $applicationTester->getDisplay());
             $expectedOutput = str_replace(["\r", "\n"], '', $expectedOutput);
-            $this->assertStringNotContainsString($expectedOutput, $actualOutput);
+            self::assertStringNotContainsString($expectedOutput, $actualOutput);
         }
     }
 
     protected function assertCheckHasSuccess(ApplicationTester $applicationTester): void
     {
-        $this->assertEquals(self::SUCCESS_CODE, $applicationTester->getStatusCode(), 'Command failed: '.$applicationTester->getDisplay());
-        $this->assertStringNotContainsString('ERRORS!', $applicationTester->getDisplay(), 'Error message not expected in successful execution');
+        self::assertEquals(self::SUCCESS_CODE, $applicationTester->getStatusCode(), 'Command failed: '.$applicationTester->getDisplay());
+        self::assertStringNotContainsString('ERRORS!', $applicationTester->getDisplay(), 'Error message not expected in successful execution');
     }
 }

--- a/tests/E2E/Cli/DebugExpressionCommandTest.php
+++ b/tests/E2E/Cli/DebugExpressionCommandTest.php
@@ -14,55 +14,55 @@ class DebugExpressionCommandTest extends TestCase
     {
         $appTester = $this->createAppTester();
         $appTester->run(['debug:expression']);
-        $this->assertEquals(1, $appTester->getStatusCode());
+        self::assertEquals(1, $appTester->getStatusCode());
     }
 
     public function test_zero_results(): void
     {
         $appTester = $this->createAppTester();
         $appTester->run(['debug:expression', 'expression' => 'Extend', 'arguments' => ['NotFound'], '--from-dir' => __DIR__]);
-        $this->assertEquals('', $appTester->getDisplay());
-        $this->assertEquals(0, $appTester->getStatusCode());
+        self::assertEquals('', $appTester->getDisplay());
+        self::assertEquals(0, $appTester->getStatusCode());
     }
 
     public function test_some_classes_found(): void
     {
         $appTester = $this->createAppTester();
         $appTester->run(['debug:expression', 'expression' => 'NotExtend', 'arguments' => ['NotFound'], '--from-dir' => __DIR__.'/../_fixtures/mvc/Domain']);
-        $this->assertEquals("App\Domain\Model\n", $appTester->getDisplay());
-        $this->assertEquals(0, $appTester->getStatusCode());
+        self::assertEquals("App\Domain\Model\n", $appTester->getDisplay());
+        self::assertEquals(0, $appTester->getStatusCode());
     }
 
     public function test_meaningful_errors_for_too_few_arguments_for_the_expression(): void
     {
         $appTester = $this->createAppTester();
         $appTester->run(['debug:expression', 'expression' => 'NotImplement', 'arguments' => [], '--from-dir' => __DIR__.'/../_fixtures/mvc/Domain']);
-        $this->assertEquals("Error: Too few arguments for 'NotImplement'.\n", $appTester->getDisplay());
-        $this->assertEquals(2, $appTester->getStatusCode());
+        self::assertEquals("Error: Too few arguments for 'NotImplement'.\n", $appTester->getDisplay());
+        self::assertEquals(2, $appTester->getStatusCode());
     }
 
     public function test_meaningful_errors_for_too_many_arguments_for_the_expression(): void
     {
         $appTester = $this->createAppTester();
         $appTester->run(['debug:expression', 'expression' => 'NotImplement', 'arguments' => ['First', 'Second'], '--from-dir' => __DIR__.'/../_fixtures/mvc/Domain']);
-        $this->assertEquals("Error: Too many arguments for 'NotImplement'.\n", $appTester->getDisplay());
-        $this->assertEquals(2, $appTester->getStatusCode());
+        self::assertEquals("Error: Too many arguments for 'NotImplement'.\n", $appTester->getDisplay());
+        self::assertEquals(2, $appTester->getStatusCode());
     }
 
     public function test_optional_argument_for_expression_can_be_avoided(): void
     {
         $appTester = $this->createAppTester();
         $appTester->run(['debug:expression', 'expression' => 'NotHaveDependencyOutsideNamespace', 'arguments' => ['NotFound'], '--from-dir' => __DIR__]);
-        $this->assertEquals('', $appTester->getDisplay());
-        $this->assertEquals(0, $appTester->getStatusCode());
+        self::assertEquals('', $appTester->getDisplay());
+        self::assertEquals(0, $appTester->getStatusCode());
     }
 
     public function test_expression_not_found(): void
     {
         $appTester = $this->createAppTester();
         $appTester->run(['debug:expression', 'expression' => 'blabla', 'arguments' => ['NotFound'], '--from-dir' => __DIR__]);
-        $this->assertEquals("Error: Expression 'blabla' not found.\n", $appTester->getDisplay());
-        $this->assertEquals(2, $appTester->getStatusCode());
+        self::assertEquals("Error: Expression 'blabla' not found.\n", $appTester->getDisplay());
+        self::assertEquals(2, $appTester->getStatusCode());
     }
 
     public function test_parse_error_dont_stop_execution(): void
@@ -77,8 +77,8 @@ WARNING: Some files could not be parsed for these errors:
 App\Services\UserService
 
 END;
-        $this->assertEquals($errorMessage, $appTester->getDisplay());
-        $this->assertEquals(0, $appTester->getStatusCode());
+        self::assertEquals($errorMessage, $appTester->getDisplay());
+        self::assertEquals(0, $appTester->getStatusCode());
     }
 
     private function createAppTester(): ApplicationTester

--- a/tests/E2E/Cli/InitCommandTest.php
+++ b/tests/E2E/Cli/InitCommandTest.php
@@ -19,9 +19,9 @@ class InitCommandTest extends TestCase
 
         $output = $appTester->getDisplay();
 
-        $this->assertFileExists($fs.'/phparkitect.php');
-        $this->assertStringContainsString('Creating phparkitect.php file...', $output);
-        $this->assertStringContainsString('customize it and run with php bin/phparkitect check', $output);
+        self::assertFileExists($fs.'/phparkitect.php');
+        self::assertStringContainsString('Creating phparkitect.php file...', $output);
+        self::assertStringContainsString('customize it and run with php bin/phparkitect check', $output);
     }
 
     public function test_it_creates_a_file_in_a_custom_dir(): void
@@ -38,9 +38,9 @@ class InitCommandTest extends TestCase
 
         $output = $appTester->getDisplay();
 
-        $this->assertFileExists($fs.'/nested/path/phparkitect.php');
-        $this->assertStringContainsString('Creating phparkitect.php file...', $output);
-        $this->assertStringContainsString('customize it and run with php bin/phparkitect check', $output);
+        self::assertFileExists($fs.'/nested/path/phparkitect.php');
+        self::assertStringContainsString('Creating phparkitect.php file...', $output);
+        self::assertStringContainsString('customize it and run with php bin/phparkitect check', $output);
     }
 
     public function test_do_nothing_if_file_exists(): void
@@ -57,7 +57,7 @@ class InitCommandTest extends TestCase
 
         $appTester = $this->runInit($fs.'/nested/path');
 
-        $this->assertStringContainsString(
+        self::assertStringContainsString(
             'File phparkitect.php found in current directory, nothing to do',
             $appTester->getDisplay()
         );
@@ -69,7 +69,7 @@ class InitCommandTest extends TestCase
 
         $appTester = $this->runInit($fs);
 
-        $this->assertStringContainsString(
+        self::assertStringContainsString(
             'Ops, it seems I cannot create the file in vfs://root',
             $appTester->getDisplay()
         );

--- a/tests/E2E/Cli/VersionCommandTest.php
+++ b/tests/E2E/Cli/VersionCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\E2E\Cli;
+
+use Arkitect\CLI\PhpArkitectApplication;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+class VersionCommandTest extends TestCase
+{
+    const SUCCESS_CODE = 0;
+
+    const ERROR_CODE = 1;
+
+    public function test_app_returns_version(): void
+    {
+        $input = ['--version'];
+        $app = new PhpArkitectApplication();
+        $app->setAutoExit(false);
+
+        $appTester = new ApplicationTester($app);
+        $appTester->run($input);
+
+        self::assertStringContainsString('PHPArkitect version', $appTester->getDisplay());
+    }
+}

--- a/tests/E2E/PHPUnit/ArchRuleTestCase.php
+++ b/tests/E2E/PHPUnit/ArchRuleTestCase.php
@@ -15,6 +15,6 @@ class ArchRuleTestCase extends TestCase
     {
         $constraint = new ArchRuleCheckerConstraintAdapter($set);
 
-        static::assertThat($rule, $constraint);
+        self::assertThat($rule, $constraint);
     }
 }

--- a/tests/E2E/Smoke/RunArkitectBinTest.php
+++ b/tests/E2E/Smoke/RunArkitectBinTest.php
@@ -39,8 +39,8 @@ App\Domain\Model has 2 violations
   depends on App\Services\UserService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
   depends on App\Services\CartService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
 
-        $this->assertEquals(self::ERROR_CODE, $process->getExitCode());
-        $this->assertStringContainsString($expectedErrors, $process->getOutput());
+        self::assertEquals(self::ERROR_CODE, $process->getExitCode());
+        self::assertStringContainsString($expectedErrors, $process->getOutput());
     }
 
     public function test_returns_error_with_multiple_violations_without_passing_config_file(): void
@@ -66,23 +66,23 @@ App\Domain\Model has 2 violations
   depends on App\Services\UserService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 14)
   depends on App\Services\CartService, but should not depend on classes outside namespace App\Domain because we want protect our domain (on line 15)';
 
-        $this->assertStringContainsString($expectedErrors, $process->getOutput());
-        $this->assertEquals(self::ERROR_CODE, $process->getExitCode());
+        self::assertStringContainsString($expectedErrors, $process->getOutput());
+        self::assertEquals(self::ERROR_CODE, $process->getExitCode());
     }
 
     public function test_does_not_explode_if_an_exception_is_thrown(): void
     {
         $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/../_fixtures/configThrowsException.php');
 
-        $this->assertEquals(self::ERROR_CODE, $process->getExitCode());
+        self::assertEquals(self::ERROR_CODE, $process->getExitCode());
     }
 
     public function test_run_command_with_success(): void
     {
         $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/../_fixtures/configMvcWithoutErrors.php');
 
-        $this->assertEquals(self::SUCCESS_CODE, $process->getExitCode());
-        $this->assertStringNotContainsString('ERRORS!', $process->getOutput());
+        self::assertEquals(self::SUCCESS_CODE, $process->getExitCode());
+        self::assertStringNotContainsString('ERRORS!', $process->getOutput());
     }
 
     public function test_bug_yield(): void
@@ -94,8 +94,8 @@ App\Domain\Model has 2 violations
 App\Controller\Foo has 1 violations
   should have a name that matches *Controller';
 
-        $this->assertEquals(self::ERROR_CODE, $process->getExitCode());
-        $this->assertStringContainsString($expectedErrors, $process->getOutput());
+        self::assertEquals(self::ERROR_CODE, $process->getExitCode());
+        self::assertStringContainsString($expectedErrors, $process->getOutput());
     }
 
     protected function runArkitectPassingConfigFilePath($configFilePath): Process

--- a/tests/Integration/CheckAttributeDependencyTest.php
+++ b/tests/Integration/CheckAttributeDependencyTest.php
@@ -26,10 +26,10 @@ class CheckAttributeDependencyTest extends TestCase
 
         $runner->run($dir, $rule);
 
-        $this->assertCount(1, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(1, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertStringContainsString('depends on App\Invalid\Attr, but should not depend on these namespaces: App\Invalid', $runner->getViolations()->get(0)->getError());
+        self::assertStringContainsString('depends on App\Invalid\Attr, but should not depend on these namespaces: App\Invalid', $runner->getViolations()->get(0)->getError());
     }
 
     public function createDirStructureWithAttributes(): array

--- a/tests/Integration/CheckClassHaveAttributeTest.php
+++ b/tests/Integration/CheckClassHaveAttributeTest.php
@@ -27,8 +27,8 @@ final class CheckClassHaveAttributeTest extends TestCase
 
         $runner->run($dir, $rule);
 
-        $this->assertCount(1, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(1, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
     }
 
     public function test_controllers_should_have_name_ending_in_controller(): void
@@ -44,10 +44,10 @@ final class CheckClassHaveAttributeTest extends TestCase
 
         $runner->run($dir, $rule);
 
-        $this->assertCount(1, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(1, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertEquals('App\Controller\Foo', $runner->getViolations()->get(0)->getFqcn());
+        self::assertEquals('App\Controller\Foo', $runner->getViolations()->get(0)->getFqcn());
     }
 
     public function test_controllers_should_have_controller_attribute(): void
@@ -63,8 +63,8 @@ final class CheckClassHaveAttributeTest extends TestCase
 
         $runner->run($dir, $rule);
 
-        $this->assertCount(0, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(0, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
     }
 
     public function createDirStructure(): array

--- a/tests/Integration/CheckClassNamingTest.php
+++ b/tests/Integration/CheckClassNamingTest.php
@@ -25,8 +25,8 @@ class CheckClassNamingTest extends TestCase
 
         $runner->run($dir, $rule);
 
-        $this->assertCount(0, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(0, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
     }
 
     public function createDummyProject(): array
@@ -47,7 +47,7 @@ class CheckClassNamingTest extends TestCase
                             $this->happy = $happy;
                         }
                     }
-                    EOF
+                    EOF,
             ],
             'OtherBadCode' => [
                 'OtherBadCode.php' => <<<'EOF'
@@ -64,7 +64,7 @@ class CheckClassNamingTest extends TestCase
                             $this->happy = $happy;
                         }
                     }
-                    EOF
+                    EOF,
             ],
 
             'HappyIsland' => [

--- a/tests/Integration/CheckEnumTest.php
+++ b/tests/Integration/CheckEnumTest.php
@@ -34,11 +34,11 @@ class CheckEnumTest extends TestCase
 
         $runner->run($dir, ...$rules);
 
-        $this->assertCount(2, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(2, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertStringContainsString('should have a name that matches *Enum because', $runner->getViolations()->get(0)->getError());
-        $this->assertStringContainsString('Aclass should be an enum because Enums should be enums', $runner->getViolations()->get(1)->getError());
+        self::assertStringContainsString('should have a name that matches *Enum because', $runner->getViolations()->get(0)->getError());
+        self::assertStringContainsString('Aclass should be an enum because Enums should be enums', $runner->getViolations()->get(1)->getError());
     }
 
     public function createDirStructure(): array

--- a/tests/Integration/ExtendsThrowableTest.php
+++ b/tests/Integration/ExtendsThrowableTest.php
@@ -26,10 +26,10 @@ class ExtendsThrowableTest extends TestCase
 
         $runner->run($dir, $rule);
 
-        $this->assertCount(1, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(1, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertStringContainsString('should have a name that matches *Exception because', $runner->getViolations()->get(0)->getError());
+        self::assertStringContainsString('should have a name that matches *Exception because', $runner->getViolations()->get(0)->getError());
     }
 
     public function createDirStructure(): array

--- a/tests/Integration/ImplementsTest.php
+++ b/tests/Integration/ImplementsTest.php
@@ -26,14 +26,14 @@ class ImplementsTest extends TestCase
 
         $runner->run($dir, $rule);
 
-        $this->assertCount(0, $runner->getParsingErrors());
-        $this->assertCount(2, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
+        self::assertCount(2, $runner->getViolations());
 
-        $this->assertEquals('App\AClass', $runner->getViolations()->get(0)->getFqcn());
-        $this->assertStringContainsString('should have a name that matches An* because reasons', $runner->getViolations()->get(0)->getError());
+        self::assertEquals('App\AClass', $runner->getViolations()->get(0)->getFqcn());
+        self::assertStringContainsString('should have a name that matches An* because reasons', $runner->getViolations()->get(0)->getError());
 
-        $this->assertEquals('App\AEnum', $runner->getViolations()->get(1)->getFqcn());
-        $this->assertStringContainsString('should have a name that matches An* because reasons', $runner->getViolations()->get(1)->getError());
+        self::assertEquals('App\AEnum', $runner->getViolations()->get(1)->getFqcn());
+        self::assertStringContainsString('should have a name that matches An* because reasons', $runner->getViolations()->get(1)->getError());
     }
 
     public function createDirStructure(): array

--- a/tests/Integration/IsAbstractTest.php
+++ b/tests/Integration/IsAbstractTest.php
@@ -31,8 +31,8 @@ class IsAbstractTest extends TestCase
 
         $runner->run($this->createClasses(), $rule);
 
-        $this->assertCount(0, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(0, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
     }
 
     public function test_is_abstract_in_should_should_consider_final_traits_enums_interfaces(): void
@@ -46,13 +46,13 @@ class IsAbstractTest extends TestCase
 
         $runner->run($this->createClasses(), $rule);
 
-        $this->assertCount(4, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(4, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertEquals('App\MyEnum', $runner->getViolations()->get(0)->getFqcn());
-        $this->assertEquals('App\MyFinal', $runner->getViolations()->get(1)->getFqcn());
-        $this->assertEquals('App\MyInterface', $runner->getViolations()->get(2)->getFqcn());
-        $this->assertEquals('App\MyTrait', $runner->getViolations()->get(3)->getFqcn());
+        self::assertEquals('App\MyEnum', $runner->getViolations()->get(0)->getFqcn());
+        self::assertEquals('App\MyFinal', $runner->getViolations()->get(1)->getFqcn());
+        self::assertEquals('App\MyInterface', $runner->getViolations()->get(2)->getFqcn());
+        self::assertEquals('App\MyTrait', $runner->getViolations()->get(3)->getFqcn());
     }
 
     public function test_is_not_abstract_in_should_should_consider_final_traits_enums_interfaces(): void
@@ -66,10 +66,10 @@ class IsAbstractTest extends TestCase
 
         $runner->run($this->createClasses(), $rule);
 
-        $this->assertCount(1, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(1, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertEquals('App\MyAbstract', $runner->getViolations()->get(0)->getFqcn());
+        self::assertEquals('App\MyAbstract', $runner->getViolations()->get(0)->getFqcn());
     }
 
     public function test_it_can_check_multiple_class_properties(): void
@@ -152,8 +152,8 @@ class IsAbstractTest extends TestCase
 
         $runner->run(vfsStream::setup('root', null, $structure)->url(), $rule);
 
-        $this->assertCount(0, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(0, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
     }
 
     protected function createClasses(): string

--- a/tests/Integration/IsFinalTest.php
+++ b/tests/Integration/IsFinalTest.php
@@ -25,8 +25,8 @@ class IsFinalTest extends TestCase
 
         $runner->run($this->createClasses(), $rule);
 
-        $this->assertCount(0, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(0, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
     }
 
     public function test_is_final_in_should_should_consider_final_traits_enums_interfaces(): void
@@ -40,13 +40,13 @@ class IsFinalTest extends TestCase
 
         $runner->run($this->createClasses(), $rule);
 
-        $this->assertCount(4, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(4, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertEquals('App\MyAbstract', $runner->getViolations()->get(0)->getFqcn());
-        $this->assertEquals('App\MyEnum', $runner->getViolations()->get(1)->getFqcn());
-        $this->assertEquals('App\MyInterface', $runner->getViolations()->get(2)->getFqcn());
-        $this->assertEquals('App\MyTrait', $runner->getViolations()->get(3)->getFqcn());
+        self::assertEquals('App\MyAbstract', $runner->getViolations()->get(0)->getFqcn());
+        self::assertEquals('App\MyEnum', $runner->getViolations()->get(1)->getFqcn());
+        self::assertEquals('App\MyInterface', $runner->getViolations()->get(2)->getFqcn());
+        self::assertEquals('App\MyTrait', $runner->getViolations()->get(3)->getFqcn());
     }
 
     public function test_is_not_final_in_should_should_consider_final_traits_enums_interfaces(): void
@@ -60,10 +60,10 @@ class IsFinalTest extends TestCase
 
         $runner->run($this->createClasses(), $rule);
 
-        $this->assertCount(1, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(1, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertEquals('App\MyFinal', $runner->getViolations()->get(0)->getFqcn());
+        self::assertEquals('App\MyFinal', $runner->getViolations()->get(0)->getFqcn());
     }
 
     protected function createClasses(): string

--- a/tests/Integration/IsReadonlyTest.php
+++ b/tests/Integration/IsReadonlyTest.php
@@ -25,8 +25,8 @@ class IsReadonlyTest extends TestCase
 
         $runner->run($this->createClasses(), $rule);
 
-        $this->assertCount(0, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(0, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
     }
 
     public function test_is_readonly_in_should_should_consider_traits_enums_interfaces(): void
@@ -40,12 +40,12 @@ class IsReadonlyTest extends TestCase
 
         $runner->run($this->createClasses(), $rule);
 
-        $this->assertCount(3, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(3, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertEquals('App\MyEnum', $runner->getViolations()->get(0)->getFqcn());
-        $this->assertEquals('App\MyInterface', $runner->getViolations()->get(1)->getFqcn());
-        $this->assertEquals('App\MyTrait', $runner->getViolations()->get(2)->getFqcn());
+        self::assertEquals('App\MyEnum', $runner->getViolations()->get(0)->getFqcn());
+        self::assertEquals('App\MyInterface', $runner->getViolations()->get(1)->getFqcn());
+        self::assertEquals('App\MyTrait', $runner->getViolations()->get(2)->getFqcn());
     }
 
     public function test_is_not_readonly_in_should_should_consider_traits_enums_interfaces(): void
@@ -59,10 +59,10 @@ class IsReadonlyTest extends TestCase
 
         $runner->run($this->createClasses(), $rule);
 
-        $this->assertCount(1, $runner->getViolations());
-        $this->assertCount(0, $runner->getParsingErrors());
+        self::assertCount(1, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
 
-        $this->assertEquals('App\MyReadonly', $runner->getViolations()->get(0)->getFqcn());
+        self::assertEquals('App\MyReadonly', $runner->getViolations()->get(0)->getFqcn());
     }
 
     protected function createClasses(): string

--- a/tests/Unit/Analyzer/ClassDependencyTest.php
+++ b/tests/Unit/Analyzer/ClassDependencyTest.php
@@ -24,27 +24,27 @@ class ClassDependencyTest extends TestCase
 
     public function test_it_should_create_class_dependency(): void
     {
-        $this->assertEquals(FullyQualifiedClassName::fromString($this->FQCN), $this->classDependency->getFQCN());
-        $this->assertEquals($this->line, $this->classDependency->getLine());
+        self::assertEquals(FullyQualifiedClassName::fromString($this->FQCN), $this->classDependency->getFQCN());
+        self::assertEquals($this->line, $this->classDependency->getLine());
     }
 
     public function test_it_should_match(): void
     {
-        $this->assertTrue($this->classDependency->matches('HappyIsland'));
+        self::assertTrue($this->classDependency->matches('HappyIsland'));
     }
 
     public function test_it_should_not_match(): void
     {
-        $this->assertFalse($this->classDependency->matches('Happy'));
+        self::assertFalse($this->classDependency->matches('Happy'));
     }
 
     public function test_it_should_match_one_of(): void
     {
-        $this->assertTrue($this->classDependency->matchesOneOf('HappyIsland', 'Foo', 'Bar'));
+        self::assertTrue($this->classDependency->matchesOneOf('HappyIsland', 'Foo', 'Bar'));
     }
 
     public function test_it_should_not_match_one_of(): void
     {
-        $this->assertFalse($this->classDependency->matchesOneOf('Baz', 'Foo', 'Bar'));
+        self::assertFalse($this->classDependency->matchesOneOf('Baz', 'Foo', 'Bar'));
     }
 }

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -23,10 +23,10 @@ class ClassDescriptionBuilderTest extends TestCase
             ->addInterface('InterfaceClass', 10)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
 
-        $this->assertEquals($FQCN, $classDescription->getName());
-        $this->assertEquals($FQCN, $classDescription->getFQCN());
+        self::assertEquals($FQCN, $classDescription->getName());
+        self::assertEquals($FQCN, $classDescription->getFQCN());
     }
 
     public function test_it_should_create_final_class(): void
@@ -39,9 +39,9 @@ class ClassDescriptionBuilderTest extends TestCase
             ->setFinal(true)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
 
-        $this->assertTrue($classDescription->isFinal());
+        self::assertTrue($classDescription->isFinal());
     }
 
     public function test_it_should_create_not_final_class(): void
@@ -54,9 +54,9 @@ class ClassDescriptionBuilderTest extends TestCase
             ->setFinal(false)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
 
-        $this->assertFalse($classDescription->isFinal());
+        self::assertFalse($classDescription->isFinal());
     }
 
     public function test_it_should_create_abstract_class(): void
@@ -69,9 +69,9 @@ class ClassDescriptionBuilderTest extends TestCase
             ->setAbstract(true)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
 
-        $this->assertTrue($classDescription->isAbstract());
+        self::assertTrue($classDescription->isAbstract());
     }
 
     public function test_it_should_create_not_abstract_class(): void
@@ -84,9 +84,9 @@ class ClassDescriptionBuilderTest extends TestCase
             ->setAbstract(false)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
 
-        $this->assertFalse($classDescription->isAbstract());
+        self::assertFalse($classDescription->isAbstract());
     }
 
     public function test_it_should_create_annotated_class(): void
@@ -105,8 +105,8 @@ class ClassDescriptionBuilderTest extends TestCase
             ->addDocBlock($docBlock)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
-        $this->assertEquals([$docBlock], $classDescription->getDocBlock());
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertEquals([$docBlock], $classDescription->getDocBlock());
     }
 
     public function test_it_should_add_attributes(): void
@@ -135,8 +135,8 @@ class ClassDescriptionBuilderTest extends TestCase
             ->setInterface(true)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
-        $this->assertTrue($classDescription->isInterface());
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertTrue($classDescription->isInterface());
     }
 
     public function test_it_should_create_not_interface(): void
@@ -149,8 +149,8 @@ class ClassDescriptionBuilderTest extends TestCase
             ->setInterface(false)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
-        $this->assertFalse($classDescription->isInterface());
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertFalse($classDescription->isInterface());
     }
 
     public function test_it_should_create_trait(): void
@@ -163,8 +163,8 @@ class ClassDescriptionBuilderTest extends TestCase
             ->setTrait(true)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
-        $this->assertTrue($classDescription->isTrait());
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertTrue($classDescription->isTrait());
     }
 
     public function test_it_should_create_not_trait(): void
@@ -177,7 +177,7 @@ class ClassDescriptionBuilderTest extends TestCase
             ->setTrait(false)
             ->build();
 
-        $this->assertInstanceOf(ClassDescription::class, $classDescription);
-        $this->assertFalse($classDescription->isTrait());
+        self::assertInstanceOf(ClassDescription::class, $classDescription);
+        self::assertFalse($classDescription->isTrait());
     }
 }

--- a/tests/Unit/Analyzer/ClassDescriptionTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionTest.php
@@ -21,28 +21,28 @@ class ClassDescriptionTest extends TestCase
     {
         $cd = $this->builder->build();
 
-        $this->assertEquals('src/Foo.php', $cd->getFilePath());
+        self::assertEquals('src/Foo.php', $cd->getFilePath());
     }
 
     public function test_should_return_true_if_there_class_is_in_namespace(): void
     {
         $cd = $this->builder->build();
 
-        $this->assertTrue($cd->namespaceMatches('Fruit'));
+        self::assertTrue($cd->namespaceMatches('Fruit'));
     }
 
     public function test_should_return_name(): void
     {
         $cd = $this->builder->build();
 
-        $this->assertEquals('Banana', $cd->getName());
+        self::assertEquals('Banana', $cd->getName());
     }
 
     public function test_should_return_true_if_there_class_is_in_namespace_array(): void
     {
         $cd = $this->builder->build();
 
-        $this->assertTrue($cd->namespaceMatchesOneOfTheseNamespaces(['Fruit']));
+        self::assertTrue($cd->namespaceMatchesOneOfTheseNamespaces(['Fruit']));
     }
 
     public function test_should_return_true_if_is_annotated_with(): void
@@ -53,7 +53,7 @@ class ClassDescriptionTest extends TestCase
  */')
             ->build();
 
-        $this->assertTrue($cd->containsDocBlock('@psalm-immutable'));
+        self::assertTrue($cd->containsDocBlock('@psalm-immutable'));
     }
 
     public function test_should_return_false_if_not_annotated_with(): void
@@ -64,7 +64,7 @@ class ClassDescriptionTest extends TestCase
  */')
             ->build();
 
-        $this->assertFalse($cd->containsDocBlock('@another-annotation'));
+        self::assertFalse($cd->containsDocBlock('@another-annotation'));
     }
 
     public function test_should_return_true_if_has_attribute(): void

--- a/tests/Unit/Analyzer/FilePathTest.php
+++ b/tests/Unit/Analyzer/FilePathTest.php
@@ -14,6 +14,6 @@ class FilePathTest extends TestCase
         $filePath = new FilePath();
         $filePath->set('thePath');
 
-        $this->assertEquals('thePath', $filePath->toString());
+        self::assertEquals('thePath', $filePath->toString());
     }
 }

--- a/tests/Unit/Analyzer/FileVisitorTest.php
+++ b/tests/Unit/Analyzer/FileVisitorTest.php
@@ -30,7 +30,7 @@ class FileVisitorTest extends TestCase
         $fp = FileParserFactory::createFileParser(TargetPhpVersion::create('7.4'));
         $fp->parse($code, 'path/to/class.php');
 
-        $this->assertEmpty($fp->getClassDescriptions());
+        self::assertEmpty($fp->getClassDescriptions());
     }
 
     public function test_violation_should_have_ref_to_filepath(): void
@@ -60,9 +60,9 @@ class FileVisitorTest extends TestCase
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Foo');
         $dependsOnTheseNamespaces->evaluate($fp->getClassDescriptions()[0], $violations, 'because');
 
-        $this->assertCount(2, $violations);
-        $this->assertEquals('path/to/class.php', $violations->get(0)->getFilePath());
-        $this->assertEquals('path/to/class.php', $violations->get(1)->getFilePath());
+        self::assertCount(2, $violations);
+        self::assertEquals('path/to/class.php', $violations->get(0)->getFilePath());
+        self::assertEquals('path/to/class.php', $violations->get(1)->getFilePath());
     }
 
     public function test_should_create_a_class_description(): void
@@ -145,7 +145,7 @@ class FileVisitorTest extends TestCase
             new ClassDependency('Root\Namespace1\Proj', 23),
         ];
 
-        $this->assertEquals($expectedInterfaces, $cd[0]->getDependencies());
+        self::assertEquals($expectedInterfaces, $cd[0]->getDependencies());
     }
 
     public function test_it_should_parse_extends_class(): void
@@ -171,7 +171,7 @@ class FileVisitorTest extends TestCase
 
         $cd = $fp->getClassDescriptions()[1];
 
-        $this->assertEquals('Root\Animals\Animal', $cd->getExtends()[0]->toString());
+        self::assertEquals('Root\Animals\Animal', $cd->getExtends()[0]->toString());
     }
 
     public function test_it_should_not_parse_extends_from_insider_anonymousclass(): void
@@ -200,7 +200,7 @@ class FileVisitorTest extends TestCase
 
         $cd = $fp->getClassDescriptions()[1];
 
-        $this->assertEquals('Root\Animals\Animal', $cd->getExtends()[0]->toString());
+        self::assertEquals('Root\Animals\Animal', $cd->getExtends()[0]->toString());
     }
 
     public function test_should_depends_on_these_namespaces(): void
@@ -232,7 +232,7 @@ class FileVisitorTest extends TestCase
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Foo', 'Symfony', 'Doctrine');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_should_returns_all_dependencies(): void
@@ -270,7 +270,7 @@ class FileVisitorTest extends TestCase
             new ClassDependency('Foo\Baz\StaticClass', 15),
         ];
 
-        $this->assertEquals($expectedDependencies, $cd[0]->getDependencies());
+        self::assertEquals($expectedDependencies, $cd[0]->getDependencies());
     }
 
     public function test_it_should_parse_arrow_function(): void
@@ -301,7 +301,7 @@ class FileVisitorTest extends TestCase
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Foo', 'Symfony', 'Doctrine');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_it_should_catch_parsing_errors(): void
@@ -325,7 +325,7 @@ class FileVisitorTest extends TestCase
         $fp->parse($code, 'relativePathName');
 
         $parsingErrors = $fp->getParsingErrors();
-        $this->assertEquals([
+        self::assertEquals([
             ParsingError::create('relativePathName', 'Syntax error, unexpected \'}\' on line 10'),
         ], $parsingErrors);
     }
@@ -356,7 +356,7 @@ class FileVisitorTest extends TestCase
 
         $violations = new Violations();
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_it_should_parse_self_correctly(): void
@@ -394,7 +394,7 @@ class FileVisitorTest extends TestCase
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('Root\Animals');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_it_should_return_errors_for_class_outside_namespace(): void
@@ -427,7 +427,7 @@ class FileVisitorTest extends TestCase
         $dependsOnlyOnTheseNamespaces = new DependsOnlyOnTheseNamespaces();
         $dependsOnlyOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_should_parse_class_attributes(): void
@@ -491,7 +491,7 @@ EOF;
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('Root\Cars');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_can_parse_enum(): void
@@ -519,7 +519,7 @@ EOF;
         $notHaveDependencyOutsideNamespace = new Implement('MyInterface');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_should_parse_enum_attributes(): void
@@ -647,12 +647,12 @@ EOF;
         $notHaveDependencyOutsideNamespace = new NotContainDocBlockLike('ItemNotFound');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
 
         $notHaveDependencyOutsideNamespace = new NotContainDocBlockLike('Exception');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(2, $violations);
+        self::assertCount(2, $violations);
     }
 
     public function test_it_parse_typed_property(): void
@@ -680,7 +680,7 @@ EOF;
         $notHaveDependencyOutsideNamespace = new DependsOnlyOnTheseNamespaces('MyProject\AppBundle\Application');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_parse_typed_nullable_property(): void
@@ -708,7 +708,7 @@ EOF;
         $notHaveDependencyOutsideNamespace = new DependsOnlyOnTheseNamespaces('MyProject\AppBundle\Application');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_parse_scalar_typed_property(): void
@@ -736,7 +736,7 @@ EOF;
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('MyProject\AppBundle\Application');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_it_parse_nullable_scalar_typed_property(): void
@@ -768,7 +768,7 @@ EOF;
         $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('MyProject\AppBundle\Application');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_it_parse_dependencies_in_docblocks_customs(): void
@@ -802,7 +802,7 @@ EOF;
         $notHaveDependencyOutsideNamespace = new DependsOnlyOnTheseNamespaces('MyProject\AppBundle\Application');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_parse_custom_tags_in_docblocks(): void
@@ -832,7 +832,7 @@ EOF;
         $notHaveDependencyOutsideNamespace = new DependsOnlyOnTheseNamespaces('MyProject\AppBundle\Application');
         $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_should_implement_exact_classname(): void
@@ -865,7 +865,7 @@ EOF;
         $implement = new Implement('Foo\Order');
         $implement->evaluate($cd, $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations, $violations->toString(Printer::FORMAT_TEXT));
+        self::assertCount(0, $violations, $violations->toString(Printer::FORMAT_TEXT));
     }
 
     public function test_it_parse_dependencies_in_docblocks_with_alias(): void
@@ -895,7 +895,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('MyProject\AppBundle\Application');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_parse_interfaces(): void
@@ -921,7 +921,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('MyProject\AppBundle\Application');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_parse_interface_extends(): void
@@ -953,9 +953,9 @@ EOF;
 
         $cd = $fp->getClassDescriptions();
 
-        $this->assertCount(3, $cd);
-        $this->assertEquals('MyProject\AppBundle\Application\FooAble', $cd[2]->getExtends()[0]->toString());
-        $this->assertEquals('MyProject\AppBundle\Application\BarAble', $cd[2]->getExtends()[1]->toString());
+        self::assertCount(3, $cd);
+        self::assertEquals('MyProject\AppBundle\Application\FooAble', $cd[2]->getExtends()[0]->toString());
+        self::assertEquals('MyProject\AppBundle\Application\BarAble', $cd[2]->getExtends()[1]->toString());
     }
 
     public function test_it_handles_return_types(): void
@@ -992,7 +992,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Foo', 'Symfony', 'Doctrine');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_it_skip_custom_annotations_in_docblocks_if_the_option_parse_custom_annotation_is_false(): void
@@ -1021,7 +1021,7 @@ EOF;
         $dependsOnlyOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('MyProject\AppBundle\Application');
         $dependsOnlyOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_it_parse_arrays_as_scalar_types(): void
@@ -1050,7 +1050,7 @@ EOF;
         $notHaveDependenciesOutside = new NotHaveDependencyOutsideNamespace('App\Domain');
         $notHaveDependenciesOutside->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_properties_with_generics_syntax(): void
@@ -1080,7 +1080,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_properties_with_list_syntax(): void
@@ -1110,7 +1110,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_properties_with_legacy_syntax(): void
@@ -1140,7 +1140,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_method_params_with_generics_syntax(): void
@@ -1172,7 +1172,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_method_params_with_list_syntax(): void
@@ -1204,7 +1204,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_method_params_with_legacy_syntax(): void
@@ -1236,7 +1236,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_method_params_with_multiple_params(): void
@@ -1271,7 +1271,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_return_type_with_generics_syntax(): void
@@ -1304,7 +1304,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_return_type_with_list_syntax(): void
@@ -1337,7 +1337,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_handles_typed_arrays_in_return_type_with_legacy_syntax(): void
@@ -1370,7 +1370,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('Domain');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     public function test_it_parse_traits(): void
@@ -1399,7 +1399,7 @@ EOF;
         $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces('MyProject\AppBundle\Application');
         $dependsOnTheseNamespaces->evaluate($cd[0], $violations, 'we want to add this rule for our software');
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 
     /**
@@ -1412,7 +1412,7 @@ EOF;
         $fp->parse($code, 'relativePathName');
 
         foreach ($fp->getClassDescriptions() as $classDescription) {
-            $this->assertTrue($classDescription->isEnum());
+            self::assertTrue($classDescription->isEnum());
         }
     }
 
@@ -1427,7 +1427,7 @@ EOF;
             {
                 case FOO;
             }
-            EOF
+            EOF,
         ];
 
         yield 'string enum' => [
@@ -1439,7 +1439,7 @@ EOF;
             {
                 case BAR: 'bar';
             }
-            EOF
+            EOF,
         ];
 
         yield 'integer enum' => [
@@ -1451,7 +1451,7 @@ EOF;
             {
                 case BAZ: 42;
             }
-            EOF
+            EOF,
         ];
 
         yield 'multiple enums' => [
@@ -1473,7 +1473,7 @@ EOF;
             {
                 case BAZ: 42;
             }
-            EOF
+            EOF,
         ];
     }
 
@@ -1505,6 +1505,6 @@ EOF;
 
         $cd = $fp->getClassDescriptions();
 
-        $this->assertInstanceOf(ClassDescription::class, $cd[0]);
+        self::assertInstanceOf(ClassDescription::class, $cd[0]);
     }
 }

--- a/tests/Unit/Analyzer/FullyQualifiedClassNameTest.php
+++ b/tests/Unit/Analyzer/FullyQualifiedClassNameTest.php
@@ -29,7 +29,7 @@ class FullyQualifiedClassNameTest extends TestCase
     {
         $fqcn = FullyQualifiedClassName::fromString($fqcn);
 
-        $this->assertEquals($shouldMatch, $fqcn->matches($pattern), "{$fqcn->toString()} should ".($shouldMatch ? '' : 'not ')."match $pattern");
+        self::assertEquals($shouldMatch, $fqcn->matches($pattern), "{$fqcn->toString()} should ".($shouldMatch ? '' : 'not ')."match $pattern");
     }
 
     public function test_should_throw_if_invalid_namespace_is_passed(): void
@@ -43,29 +43,29 @@ class FullyQualifiedClassNameTest extends TestCase
     public function test_single_letter_class_is_valid(): void
     {
         $fqcn = FullyQualifiedClassName::fromString('A');
-        $this->assertEquals('A', $fqcn->className());
+        self::assertEquals('A', $fqcn->className());
     }
 
     public function test_should_return_class_name(): void
     {
         $fqcn = FullyQualifiedClassName::fromString('Food\Vegetables\Fruits\Banana');
-        $this->assertEquals('Banana', $fqcn->className());
+        self::assertEquals('Banana', $fqcn->className());
     }
 
     public function test_should_have_root_ns_preserved(): void
     {
         $fqcn = FullyQualifiedClassName::fromString('\Banana');
 
-        $this->assertEquals('Banana', $fqcn->className());
-        $this->assertEquals('', $fqcn->namespace());
+        self::assertEquals('Banana', $fqcn->className());
+        self::assertEquals('', $fqcn->namespace());
     }
 
     public function test_should_have_ns_normalized(): void
     {
         $fqcn = FullyQualifiedClassName::fromString('Food\Vegetables\Fruits\Banana');
 
-        $this->assertEquals('Banana', $fqcn->className());
-        $this->assertEquals('Food\Vegetables\Fruits', $fqcn->namespace());
-        $this->assertEquals('Food\Vegetables\Fruits\Banana', $fqcn->toString());
+        self::assertEquals('Banana', $fqcn->className());
+        self::assertEquals('Food\Vegetables\Fruits', $fqcn->namespace());
+        self::assertEquals('Food\Vegetables\Fruits\Banana', $fqcn->toString());
     }
 }

--- a/tests/Unit/Analyzer/PatternStringTest.php
+++ b/tests/Unit/Analyzer/PatternStringTest.php
@@ -11,8 +11,8 @@ class PatternStringTest extends TestCase
     public function test_it_works_for_simple_strings(): void
     {
         $pattern = new PatternString('Example');
-        $this->assertTrue($pattern->matches('Example'));
-        $this->assertFalse($pattern->matches('Something else'));
+        self::assertTrue($pattern->matches('Example'));
+        self::assertFalse($pattern->matches('Something else'));
     }
 
     /**
@@ -20,7 +20,7 @@ class PatternStringTest extends TestCase
      */
     public function test_wildcard_is_for_alphanumeric(string $string, string $pattern, bool $expectedResult): void
     {
-        $this->assertEquals($expectedResult, (new PatternString($string))->matches($pattern));
+        self::assertEquals($expectedResult, (new PatternString($string))->matches($pattern));
     }
 
     public static function providePatterns(): array

--- a/tests/Unit/CLI/ConfigTest.php
+++ b/tests/Unit/CLI/ConfigTest.php
@@ -26,10 +26,10 @@ class ConfigTest extends TestCase
         $config = new Config();
         $config->add($classSet, ...[$rule]);
 
-        $this->assertInstanceOf(Config::class, $config);
+        self::assertInstanceOf(Config::class, $config);
 
         $classSetRulesExpected[] = ClassSetRules::create($classSet, ...[$rule]);
-        $this->assertEquals($classSetRulesExpected, $config->getClassSetRules());
+        self::assertEquals($classSetRulesExpected, $config->getClassSetRules());
     }
 
     public function test_it_should_create_config_with_only_one_rule_to_run(): void
@@ -50,18 +50,18 @@ class ConfigTest extends TestCase
         $config = new Config();
         $config->add($classSet, ...[$rule1, $rule2]);
 
-        $this->assertInstanceOf(Config::class, $config);
+        self::assertInstanceOf(Config::class, $config);
 
         $classSetRulesExpected[] = ClassSetRules::create($classSet, ...[$rule2]);
-        $this->assertEquals($classSetRulesExpected, $config->getClassSetRules());
+        self::assertEquals($classSetRulesExpected, $config->getClassSetRules());
     }
 
     public function test_it_should_allow_to_change_the_default_value_for_parsing_custom_annotations(): void
     {
         $config = new Config();
-        $this->assertTrue($config->isParseCustomAnnotationsEnabled());
+        self::assertTrue($config->isParseCustomAnnotationsEnabled());
 
         $config->skipParsingCustomAnnotations();
-        $this->assertFalse($config->isParseCustomAnnotationsEnabled());
+        self::assertFalse($config->isParseCustomAnnotationsEnabled());
     }
 }

--- a/tests/Unit/CLI/Printer/GitlabPrinterTest.php
+++ b/tests/Unit/CLI/Printer/GitlabPrinterTest.php
@@ -44,10 +44,10 @@ class GitlabPrinterTest extends TestCase
 
         $result = $printer->print($violationsCollection);
 
-        $this->assertIsString($result, 'Result should be a string');
-        $this->assertJson($result, 'Result should be a valid JSON string');
+        self::assertIsString($result, 'Result should be a string');
+        self::assertJson($result, 'Result should be a valid JSON string');
 
         $decodedResult = json_decode($result, true);
-        $this->assertEmpty($decodedResult, 'Result should be an empty array');
+        self::assertEmpty($decodedResult, 'Result should be an empty array');
     }
 }

--- a/tests/Unit/CLI/Printer/JsonPrinterTest.php
+++ b/tests/Unit/CLI/Printer/JsonPrinterTest.php
@@ -22,7 +22,7 @@ class JsonPrinterTest extends TestCase
             'details' => [],
         ]);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -53,7 +53,7 @@ class JsonPrinterTest extends TestCase
             ],
         ]);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -93,6 +93,6 @@ class JsonPrinterTest extends TestCase
             ],
         ]);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 }

--- a/tests/Unit/CLI/Printer/PrinterFactoryTest.php
+++ b/tests/Unit/CLI/Printer/PrinterFactoryTest.php
@@ -19,7 +19,7 @@ class PrinterFactoryTest extends TestCase
 
         $printer = $factory->create('json');
 
-        $this->assertInstanceOf(JsonPrinter::class, $printer);
+        self::assertInstanceOf(JsonPrinter::class, $printer);
     }
 
     /**
@@ -31,6 +31,6 @@ class PrinterFactoryTest extends TestCase
 
         $printer = $factory->create('text');
 
-        $this->assertInstanceOf(TextPrinter::class, $printer);
+        self::assertInstanceOf(TextPrinter::class, $printer);
     }
 }

--- a/tests/Unit/CLI/Printer/TextPrinterTest.php
+++ b/tests/Unit/CLI/Printer/TextPrinterTest.php
@@ -25,7 +25,7 @@ class TextPrinterTest extends TestCase
 
         $expectedOutput = "\nExampleClass has 1 violations\n  Error message\n";
 
-        $this->assertSame($expectedOutput, $result);
+        self::assertSame($expectedOutput, $result);
     }
 
     public function test_prints_violation_with_line(): void
@@ -41,7 +41,7 @@ class TextPrinterTest extends TestCase
 
         $expectedOutput = "\nExampleClass has 1 violations\n  Error message (on line 42)\n";
 
-        $this->assertSame($expectedOutput, $result);
+        self::assertSame($expectedOutput, $result);
     }
 
     public function test_prints_multiple_violations_grouped_by_fqcn(): void
@@ -61,6 +61,6 @@ class TextPrinterTest extends TestCase
 
         $expectedOutput = "\nExampleClass has 2 violations\n  First error\n  Second error (on line 10)\n\nAnotherClass has 1 violations\n  Another error (on line 15)\n";
 
-        $this->assertSame($expectedOutput, $result);
+        self::assertSame($expectedOutput, $result);
     }
 }

--- a/tests/Unit/CLI/TargetPhpVersionTest.php
+++ b/tests/Unit/CLI/TargetPhpVersionTest.php
@@ -14,21 +14,21 @@ class TargetPhpVersionTest extends TestCase
     {
         $targetPhpVersion = TargetPhpVersion::create('8.3');
 
-        $this->assertEquals('8.3', $targetPhpVersion->get());
+        self::assertEquals('8.3', $targetPhpVersion->get());
     }
 
     public function test_it_should_ignore_the_patch_number(): void
     {
         $targetPhpVersion = TargetPhpVersion::create('8.3.2');
 
-        $this->assertEquals('8.3', $targetPhpVersion->get());
+        self::assertEquals('8.3', $targetPhpVersion->get());
     }
 
     public function test_it_should_ignore_extra_informations(): void
     {
         $targetPhpVersion = TargetPhpVersion::create('7.4.10-14+ubuntu22.04.1+deb.sury.org+1');
 
-        $this->assertEquals('7.4', $targetPhpVersion->get());
+        self::assertEquals('7.4', $targetPhpVersion->get());
     }
 
     public function test_it_should_throw_exception_if_not_valid_php_version(): void

--- a/tests/Unit/ClassSetRulesTest.php
+++ b/tests/Unit/ClassSetRulesTest.php
@@ -32,7 +32,7 @@ class ClassSetRulesTest extends TestCase
 
         $classSetRules = ClassSetRules::create($classSet, ...$rules);
 
-        $this->assertEquals($classSet, $classSetRules->getClassSet());
-        $this->assertEquals($rules, $classSetRules->getRules());
+        self::assertEquals($classSet, $classSetRules->getClassSet());
+        self::assertEquals($rules, $classSetRules->getRules());
     }
 }

--- a/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
+++ b/tests/Unit/Expressions/ForClasses/HaveNameMatchingTest.php
@@ -32,7 +32,7 @@ class HaveNameMatchingTest extends TestCase
         $violations = new Violations();
         $expression->evaluate($badClass, $violations, $because);
         self::assertNotEquals(0, $violations->count());
-        $this->assertEquals(
+        self::assertEquals(
             'should have a name that matches *GoodName* because we want to add this rule for our software',
             $expression->describe($badClass, $because)->toString()
         );

--- a/tests/Unit/Expressions/ForClasses/IsReadonlyTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsReadonlyTest.php
@@ -24,7 +24,7 @@ class IsReadonlyTest extends TestCase
         $because = 'we want to add this rule for our software';
         $violationError = $isReadonly->describe($classDescription, $because)->toString();
 
-        $this->assertEquals('HappyIsland should be readonly because we want to add this rule for our software', $violationError);
+        self::assertEquals('HappyIsland should be readonly because we want to add this rule for our software', $violationError);
     }
 
     public function test_it_should_return_true_if_is_readonly(): void

--- a/tests/Unit/GlobTest.php
+++ b/tests/Unit/GlobTest.php
@@ -11,18 +11,18 @@ class GlobTest extends TestCase
     public function test_can_exclude_using_glob_pattern(): void
     {
         // * - Matches zero or more characters.
-        $this->assertEquals('/.*Catalog.*/', Glob::toRegex('*Catalog*'));
+        self::assertEquals('/.*Catalog.*/', Glob::toRegex('*Catalog*'));
 
         // * - Matches zero or more characters.
-        $this->assertEquals('/Cata\.log/', Glob::toRegex('Cata.log'));
+        self::assertEquals('/Cata\.log/', Glob::toRegex('Cata.log'));
 
         // ? - Matches exactly one character (any character).
-        $this->assertEquals('/C.talog/', Glob::toRegex('C?talog'));
+        self::assertEquals('/C.talog/', Glob::toRegex('C?talog'));
 
         // [...] - Matches one character from a group of characters. If the first character is !, matches any character not in the group.
-        $this->assertEquals('/prova[123]/', Glob::toRegex('prova[123]'));
+        self::assertEquals('/prova[123]/', Glob::toRegex('prova[123]'));
 
         // [...] - Matches one character from a group of characters. If the first character is !, matches any character not in the group.
-        $this->assertEquals('/prova[ˆ123]/', Glob::toRegex('prova[!123]'));
+        self::assertEquals('/prova[ˆ123]/', Glob::toRegex('prova[!123]'));
     }
 }

--- a/tests/Unit/Rules/ConstraintsTest.php
+++ b/tests/Unit/Rules/ConstraintsTest.php
@@ -18,7 +18,7 @@ class ConstraintsTest extends TestCase
 {
     public function test_it_should_not_add_to_violation_if_constraint_is_not_violated(): void
     {
-        $trueExpression = new class() implements Expression {
+        $trueExpression = new class implements Expression {
             public function describe(ClassDescription $theClass, string $because): Description
             {
                 return new Description('', '');
@@ -44,12 +44,12 @@ class ConstraintsTest extends TestCase
             $because
         );
 
-        $this->assertCount(0, $violations);
+        self::assertCount(0, $violations);
     }
 
     public function test_it_should_add_to_violation_store_if_constraint_is_violated(): void
     {
-        $falseExpression = new class() implements Expression {
+        $falseExpression = new class implements Expression {
             public function describe(ClassDescription $theClass, string $because): Description
             {
                 return new Description('bar', 'we want to add this rule');
@@ -82,6 +82,6 @@ class ConstraintsTest extends TestCase
             $because
         );
 
-        $this->assertCount(1, $violations);
+        self::assertCount(1, $violations);
     }
 }

--- a/tests/Unit/Rules/ParsingErrorsTest.php
+++ b/tests/Unit/Rules/ParsingErrorsTest.php
@@ -30,14 +30,14 @@ class ParsingErrorsTest extends TestCase
 
     public function test_add_elements_to_store_and_get_it(): void
     {
-        $this->assertEquals($this->parsingError, $this->parsingStore->get(0));
+        self::assertEquals($this->parsingError, $this->parsingStore->get(0));
     }
 
     public function test_add_elements_to_store_and_cant_get_it_if_index_not_valid(): void
     {
         $this->expectException(IndexNotFoundException::class);
         $this->expectExceptionMessage('Index not found 1111');
-        $this->assertEquals('', $this->parsingStore->get(1111));
+        self::assertEquals('', $this->parsingStore->get(1111));
     }
 
     public function test_count(): void
@@ -48,7 +48,7 @@ class ParsingErrorsTest extends TestCase
             2
         );
         $this->parsingStore->add($parsingError);
-        $this->assertEquals(2, $this->parsingStore->count());
+        self::assertEquals(2, $this->parsingStore->count());
     }
 
     public function test_to_string(): void
@@ -65,12 +65,12 @@ Syntax error, unexpected T_STRING on line 8 in file: App\Controller\ProductContr
 Syntax error, unexpected T_STRING on line 8 in file: App\Controller\Foo
 ';
 
-        $this->assertEquals($expected, $this->parsingStore->toString());
+        self::assertEquals($expected, $this->parsingStore->toString());
     }
 
     public function test_calling_iterator(): void
     {
-        $this->assertInstanceOf(\Generator::class, $this->parsingStore->getIterator());
+        self::assertInstanceOf(\Generator::class, $this->parsingStore->getIterator());
     }
 
     public function test_convert_to_array(): void
@@ -79,7 +79,7 @@ Syntax error, unexpected T_STRING on line 8 in file: App\Controller\Foo
             $this->parsingError,
         ];
 
-        $this->assertEquals($expected, $this->parsingStore->toArray());
+        self::assertEquals($expected, $this->parsingStore->toArray());
     }
 
     public function test_get_iterable(): void
@@ -92,6 +92,6 @@ Syntax error, unexpected T_STRING on line 8 in file: App\Controller\Foo
         $this->parsingStore->add($parsingError);
         $iterable = $this->parsingStore->getIterator();
 
-        $this->assertEquals([$this->parsingError, $parsingError], iterator_to_array($iterable));
+        self::assertEquals([$this->parsingError, $parsingError], iterator_to_array($iterable));
     }
 }

--- a/tests/Unit/Rules/SpecsTest.php
+++ b/tests/Unit/Rules/SpecsTest.php
@@ -20,7 +20,7 @@ class SpecsTest extends TestCase
         $classDescription = ClassDescription::getBuilder('MyNamespace\HappyIsland', 'src/Foo.php')->build();
         $because = 'we want to add this rule for our software';
 
-        $this->assertFalse($specStore->allSpecsAreMatchedBy($classDescription, $because));
+        self::assertFalse($specStore->allSpecsAreMatchedBy($classDescription, $because));
     }
 
     public function test_return_true_if_all_specs_are_matched(): void
@@ -33,6 +33,6 @@ class SpecsTest extends TestCase
             ->build();
         $because = 'we want to add this rule for our software';
 
-        $this->assertTrue($specStore->allSpecsAreMatchedBy($classDescription, $because));
+        self::assertTrue($specStore->allSpecsAreMatchedBy($classDescription, $because));
     }
 }

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -30,14 +30,14 @@ class ViolationsTest extends TestCase
 
     public function test_add_elements_to_store_and_get_it(): void
     {
-        $this->assertEquals($this->violation, $this->violationStore->get(0));
+        self::assertEquals($this->violation, $this->violationStore->get(0));
     }
 
     public function test_add_elements_to_store_and_cant_get_it_if_index_not_valid(): void
     {
         $this->expectException(IndexNotFoundException::class);
         $this->expectExceptionMessage('Index not found 1111');
-        $this->assertEquals('', $this->violationStore->get(1111));
+        self::assertEquals('', $this->violationStore->get(1111));
     }
 
     public function test_count(): void
@@ -47,7 +47,7 @@ class ViolationsTest extends TestCase
             'should have name end with Controller'
         );
         $this->violationStore->add($violation);
-        $this->assertEquals(2, $this->violationStore->count());
+        self::assertEquals(2, $this->violationStore->count());
     }
 
     public function test_to_string(): void
@@ -66,7 +66,7 @@ App\Controller\Foo has 1 violations
   should have name end with Controller
 ';
 
-        $this->assertEquals($expected, $this->violationStore->toString(Printer::FORMAT_TEXT));
+        self::assertEquals($expected, $this->violationStore->toString(Printer::FORMAT_TEXT));
     }
 
     public function test_get_iterable(): void
@@ -78,7 +78,7 @@ App\Controller\Foo has 1 violations
         $this->violationStore->add($violation);
         $iterable = $this->violationStore->getIterator();
 
-        $this->assertEquals([
+        self::assertEquals([
             $this->violation,
             $violation,
         ], iterator_to_array($iterable));
@@ -97,7 +97,7 @@ App\Controller\Foo has 1 violations
         $this->violationStore->add($violation1);
         $this->violationStore->add($violation2);
 
-        $this->assertEquals([
+        self::assertEquals([
             $this->violation,
             $violation1,
             $violation2,
@@ -118,15 +118,15 @@ App\Controller\Foo has 1 violations
         );
         $this->violationStore->add($violation2);
 
-        $this->assertCount(3, $this->violationStore->toArray());
+        self::assertCount(3, $this->violationStore->toArray());
 
         $violationsBaseline = new Violations();
         $violationsBaseline->add($this->violation);
 
         $this->violationStore->remove($violationsBaseline);
 
-        $this->assertCount(2, $this->violationStore->toArray());
-        $this->assertEquals([
+        self::assertCount(2, $this->violationStore->toArray());
+        self::assertEquals([
             $violation1,
             $violation2,
         ], $this->violationStore->toArray());
@@ -160,7 +160,7 @@ App\Controller\Foo has 1 violations
         $violationStore->add($violation3);
         $violationStore->add($violation4);
 
-        $this->assertEquals([
+        self::assertEquals([
             $violation1,
             $violation2,
             $violation3,
@@ -169,7 +169,7 @@ App\Controller\Foo has 1 violations
 
         $violationStore->sort();
 
-        $this->assertSame([
+        self::assertSame([
             $violation4, // fqcn is most important
             $violation3, // then line number
             $violation2, // then error message
@@ -200,7 +200,7 @@ App\Controller\Foo has 1 violations
         );
         $this->violationStore->add($violation3);
 
-        $this->assertCount(4, $this->violationStore->toArray());
+        self::assertCount(4, $this->violationStore->toArray());
 
         $violationsBaseline = new Violations();
         $violationsBaseline->add(new Violation(
@@ -211,8 +211,8 @@ App\Controller\Foo has 1 violations
 
         $this->violationStore->remove($violationsBaseline, true);
 
-        $this->assertCount(3, $this->violationStore->toArray());
-        $this->assertEquals([
+        self::assertCount(3, $this->violationStore->toArray());
+        self::assertEquals([
             $this->violation,
             $violation2,
             $violation3,

--- a/tests/Utils/TestRunner.php
+++ b/tests/Utils/TestRunner.php
@@ -23,14 +23,14 @@ class TestRunner
 
     private FileParser $fileParser;
 
-    private function __construct(string $version = null)
+    private function __construct(?string $version = null)
     {
         $this->violations = new Violations();
         $this->parsingErrors = new ParsingErrors();
         $this->fileParser = FileParserFactory::createFileParser(TargetPhpVersion::create($version));
     }
 
-    public static function create(string $version = null): self
+    public static function create(?string $version = null): self
     {
         if (null === self::$instance) {
             self::$instance = new self($version);


### PR DESCRIPTION
Apart from updating php cs fixer to the latest version a few new rules have been added: 

1. use `self::assert*` in phpunit test
2. use `array<something>` in docblocks 
3. add `PER-CS`, which is supposed to be an evolving standard to keep up with new language features