### PR TITLE
README: Add support for 'gitlab' as an output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ phparkitect check --ignore-baseline-linenumbers
 
 Output format can be controlled using the parameter `format=[FORMAT]`. There are two available output formats
 * `text`: the default one
-* `json`: this follows Gitlab's [code quality format](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format). Note that this will suppress any output apart from the violation reporting.
+* `json`: this format allows custom report using github action or another platform as Sonarqube and so on... Note that this will suppress any output apart from the violation reporting.
+* `gitlab`: this follows Gitlab's [code quality format](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format). Note that this will suppress any output apart from the violation reporting.
 
 ## Configuration
 


### PR DESCRIPTION
Updated the README to include 'gitlab' as an available output format in addition to 'text' and 'json'. Clarified the use cases for the 'json' format and specified its compatibility with platforms like GitHub Actions and SonarQube.