### PR TITLE
Print violations to stdout, everything else to stderr

### DIFF
--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Arkitect\CLI\Command;
 
 use Arkitect\CLI\Config;
-use Arkitect\CLI\Printer\Printer;
 use Arkitect\CLI\Progress\DebugProgress;
 use Arkitect\CLI\Progress\ProgressBarProgress;
 use Arkitect\CLI\Runner;

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -175,7 +175,7 @@ class Check extends Command
             $stdOut->writeln($violations->toString($format));
 
             if ($violations->count() > 0) {
-                $output->writeln(\sprintf('<error> %s Violations Detected!</error>', \count($violations)));
+                $output->writeln(\sprintf('<error>⚠️ %s violations detected!</error>', \count($violations)));
                 $this->printExecutionTime($output, $startTime);
 
                 return self::ERROR_CODE;

--- a/src/CLI/Printer/TextPrinter.php
+++ b/src/CLI/Printer/TextPrinter.php
@@ -9,7 +9,7 @@ class TextPrinter implements Printer
 {
     public function print(array $violationsCollection): string
     {
-        $errors = '';
+        $errors = "\n";
 
         /**
          * @var string           $key

--- a/src/CLI/Runner.php
+++ b/src/CLI/Runner.php
@@ -30,26 +30,22 @@ class Runner
         $this->parsingErrors = new ParsingErrors();
     }
 
-    public function run(Config $config, Progress $progress, TargetPhpVersion $targetPhpVersion, bool $onlyErrors): void
+    public function run(Config $config, Progress $progress, TargetPhpVersion $targetPhpVersion): void
     {
         /** @var FileParser $fileParser */
         $fileParser = FileParserFactory::createFileParser($targetPhpVersion, $config->isParseCustomAnnotationsEnabled());
 
         /** @var ClassSetRules $classSetRule */
         foreach ($config->getClassSetRules() as $classSetRule) {
-            if (!$onlyErrors) {
-                $progress->startFileSetAnalysis($classSetRule->getClassSet());
-            }
+            $progress->startFileSetAnalysis($classSetRule->getClassSet());
 
             try {
-                $this->check($classSetRule, $progress, $fileParser, $this->violations, $this->parsingErrors, $onlyErrors);
+                $this->check($classSetRule, $progress, $fileParser, $this->violations, $this->parsingErrors);
             } catch (FailOnFirstViolationException $e) {
                 return;
             }
 
-            if (!$onlyErrors) {
-                $progress->endFileSetAnalysis($classSetRule->getClassSet());
-            }
+            $progress->endFileSetAnalysis($classSetRule->getClassSet());
         }
     }
 
@@ -58,16 +54,13 @@ class Runner
         Progress $progress,
         Parser $fileParser,
         Violations $violations,
-        ParsingErrors $parsingErrors,
-        bool $onlyErrors = false
+        ParsingErrors $parsingErrors
     ): void {
         /** @var SplFileInfo $file */
         foreach ($classSetRule->getClassSet() as $file) {
             $fileViolations = new Violations();
 
-            if (!$onlyErrors) {
-                $progress->startParsingFile($file->getRelativePathname());
-            }
+            $progress->startParsingFile($file->getRelativePathname());
 
             $fileParser->parse($file->getContents(), $file->getRelativePathname());
             $parsedErrors = $fileParser->getParsingErrors();
@@ -91,9 +84,7 @@ class Runner
 
             $violations->merge($fileViolations);
 
-            if (!$onlyErrors) {
-                $progress->endParsingFile($file->getRelativePathname());
-            }
+            $progress->endParsingFile($file->getRelativePathname());
         }
     }
 

--- a/tests/E2E/Smoke/RunArkitectBinTest.php
+++ b/tests/E2E/Smoke/RunArkitectBinTest.php
@@ -13,8 +13,7 @@ class RunArkitectBinTest extends TestCase
 
     const ERROR_CODE = 1;
 
-    /** @var string */
-    private $phparkitect = __DIR__.'/../../../bin-stub/phparkitect';
+    private string $phparkitect = __DIR__.'/../../../bin-stub/phparkitect';
 
     public function test_returns_error_with_multiple_violations(): void
     {
@@ -96,6 +95,20 @@ App\Controller\Foo has 1 violations
 
         self::assertEquals(self::ERROR_CODE, $process->getExitCode());
         self::assertStringContainsString($expectedErrors, $process->getOutput());
+    }
+
+    public function test_only_violations_are_printed_on_stdout(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'format_json');
+        $binPath = $this->phparkitect;
+        $configFilePath = __DIR__.'/../_fixtures/configMvc.php';
+
+        $process = Process::fromShellCommandline("php {$binPath} check --config=$configFilePath --format=gitlab > $tmpFile");
+        $process->run();
+
+        $fileContent = file_get_contents($tmpFile);
+
+        self::assertJson($fileContent);
     }
 
     protected function runArkitectPassingConfigFilePath($configFilePath): Process

--- a/tests/E2E/Smoke/RunArkitectBinTest.php
+++ b/tests/E2E/Smoke/RunArkitectBinTest.php
@@ -19,7 +19,7 @@ class RunArkitectBinTest extends TestCase
     {
         $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/../_fixtures/configMvc.php');
 
-        $expectedErrors = 'ERRORS!
+        $expectedErrors = '
 
 App\Controller\Foo has 2 violations
   should have a name that matches *Controller because we want uniform naming
@@ -46,7 +46,7 @@ App\Domain\Model has 2 violations
     {
         $process = $this->runArkitect();
 
-        $expectedErrors = 'ERRORS!
+        $expectedErrors = '
 
 App\Controller\Foo has 2 violations
   should have a name that matches *Controller because we want uniform naming
@@ -81,14 +81,14 @@ App\Domain\Model has 2 violations
         $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/../_fixtures/configMvcWithoutErrors.php');
 
         self::assertEquals(self::SUCCESS_CODE, $process->getExitCode());
-        self::assertStringNotContainsString('ERRORS!', $process->getOutput());
+        self::assertStringNotContainsString('⚠️', $process->getOutput());
     }
 
     public function test_bug_yield(): void
     {
         $process = $this->runArkitectPassingConfigFilePath(__DIR__.'/../_fixtures/configMvcForYieldBug.php');
 
-        $expectedErrors = 'ERRORS!
+        $expectedErrors = '
 
 App\Controller\Foo has 1 violations
   should have a name that matches *Controller';

--- a/tests/Unit/CLI/Printer/TextPrinterTest.php
+++ b/tests/Unit/CLI/Printer/TextPrinterTest.php
@@ -23,7 +23,7 @@ class TextPrinterTest extends TestCase
         $printer = new TextPrinter();
         $result = $printer->print($violations);
 
-        $expectedOutput = "\nExampleClass has 1 violations\n  Error message\n";
+        $expectedOutput = "\n\nExampleClass has 1 violations\n  Error message\n";
 
         self::assertSame($expectedOutput, $result);
     }
@@ -39,7 +39,7 @@ class TextPrinterTest extends TestCase
         $printer = new TextPrinter();
         $result = $printer->print($violations);
 
-        $expectedOutput = "\nExampleClass has 1 violations\n  Error message (on line 42)\n";
+        $expectedOutput = "\n\nExampleClass has 1 violations\n  Error message (on line 42)\n";
 
         self::assertSame($expectedOutput, $result);
     }
@@ -59,7 +59,7 @@ class TextPrinterTest extends TestCase
         $printer = new TextPrinter();
         $result = $printer->print($violations);
 
-        $expectedOutput = "\nExampleClass has 2 violations\n  First error\n  Second error (on line 10)\n\nAnotherClass has 1 violations\n  Another error (on line 15)\n";
+        $expectedOutput = "\n\nExampleClass has 2 violations\n  First error\n  Second error (on line 10)\n\nAnotherClass has 1 violations\n  Another error (on line 15)\n";
 
         self::assertSame($expectedOutput, $result);
     }

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -12,11 +12,9 @@ use PHPUnit\Framework\TestCase;
 
 class ViolationsTest extends TestCase
 {
-    /** @var Violations */
-    private $violationStore;
+    private Violations $violationStore;
 
-    /** @var Violation */
-    private $violation;
+    private Violation $violation;
 
     protected function setUp(): void
     {
@@ -58,15 +56,16 @@ class ViolationsTest extends TestCase
         );
 
         $this->violationStore->add($violation);
-        $expected = '
-App\Controller\ProductController has 1 violations
-  should implement ContainerInterface
 
-App\Controller\Foo has 1 violations
-  should have name end with Controller
-';
+        $expected = <<<'ERRORS'
+        App\Controller\ProductController has 1 violations
+          should implement ContainerInterface
 
-        self::assertEquals($expected, $this->violationStore->toString(Printer::FORMAT_TEXT));
+        App\Controller\Foo has 1 violations
+          should have name end with Controller
+        ERRORS;
+
+        self::assertStringContainsString($expected, $this->violationStore->toString(Printer::FORMAT_TEXT));
     }
 
     public function test_get_iterable(): void


### PR DESCRIPTION
Here the output is divided between STDOUT and STDERR, in particular:
- the list of violations is printed on stdout
- everything else on stderr

This has several benefits
- we can remove the `$onlyError` logic scattered in the code
- the output now can be piped to other commands or in a file and in case of json/gitlab format you end up having a valid json
