### PR TITLE
Use Config class to collect several configurations

### DIFF
--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Arkitect\CLI;
+
+use Arkitect\Rules\Violations;
+
+class Baseline
+{
+    private Violations $violations;
+
+    private string $filename;
+
+    private function __construct(Violations $violations, string $filename)
+    {
+        $this->violations = $violations;
+        $this->filename = $filename;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    public function getViolations(): Violations
+    {
+        return $this->violations;
+    }
+
+    public function applyTo(Violations $violations, bool $ignoreBaselineLinenumbers): void
+    {
+        $violations->remove($this->violations, $ignoreBaselineLinenumbers);
+    }
+
+    public static function empty(): self
+    {
+        return new self(new Violations(), '');
+    }
+
+    /**
+     * @psalm-suppress RiskyTruthyFalsyComparison
+     */
+    public static function create(bool $skipBaseline, ?string $baselineFilePath, string $defaultFilePath): self
+    {
+        if ($skipBaseline) {
+            return self::empty();
+        }
+
+        if (!$baselineFilePath && file_exists($defaultFilePath)) {
+            $baselineFilePath = $defaultFilePath;
+        }
+
+        return $baselineFilePath ? self::loadFromFile($baselineFilePath) : self::empty();
+    }
+
+    public static function loadFromFile(string $filename): self
+    {
+        if (!file_exists($filename)) {
+            throw new \RuntimeException("Baseline file '$filename' not found.");
+        }
+
+        return new self(
+            Violations::fromJson(file_get_contents($filename)),
+            $filename
+        );
+    }
+
+    public static function save(?string $filename, string $defaultFilePath, Violations $violations): string
+    {
+        if (null === $filename) {
+            $filename = $defaultFilePath;
+        }
+
+        file_put_contents($filename, json_encode($violations, \JSON_PRETTY_PRINT));
+
+        return $filename;
+    }
+}

--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -22,11 +22,6 @@ class Baseline
         return $this->filename;
     }
 
-    public function getViolations(): Violations
-    {
-        return $this->violations;
-    }
-
     public function applyTo(Violations $violations, bool $ignoreBaselineLinenumbers): void
     {
         $violations->remove($this->violations, $ignoreBaselineLinenumbers);

--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -27,25 +27,30 @@ class Baseline
         $violations->remove($this->violations, $ignoreBaselineLinenumbers);
     }
 
+    /**
+     * @psalm-suppress RiskyTruthyFalsyComparison
+     */
+    public static function resolveFilePath(?string $filePath, string $defaultFilePath): ?string
+    {
+        if (!$filePath && file_exists($defaultFilePath)) {
+            $filePath = $defaultFilePath;
+        }
+
+        return $filePath ?: null;
+    }
+
     public static function empty(): self
     {
         return new self(new Violations(), '');
     }
 
-    /**
-     * @psalm-suppress RiskyTruthyFalsyComparison
-     */
-    public static function create(bool $skipBaseline, ?string $baselineFilePath, string $defaultFilePath): self
+    public static function create(bool $skipBaseline, ?string $baselineFilePath): self
     {
-        if ($skipBaseline) {
+        if ($skipBaseline || null === $baselineFilePath) {
             return self::empty();
         }
 
-        if (!$baselineFilePath && file_exists($defaultFilePath)) {
-            $baselineFilePath = $defaultFilePath;
-        }
-
-        return $baselineFilePath ? self::loadFromFile($baselineFilePath) : self::empty();
+        return self::loadFromFile($baselineFilePath);
     }
 
     public static function loadFromFile(string $filename): self

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -130,7 +130,7 @@ class Check extends Command
 
             $this->printHeadingLine($output);
 
-            $output->writeln("Baseline file '$useBaseline' found");
+            $baseline->getFilename() && $output->writeln("Baseline file '{$baseline->getFilename()}' found");
 
             $rulesFilename = $this->getConfigFilename($input);
 

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -50,7 +50,8 @@ class Check extends Command
                 self::CONFIG_FILENAME_PARAM,
                 'c',
                 InputOption::VALUE_OPTIONAL,
-                'File containing configs, such as rules to be matched'
+                'File containing configs, such as rules to be matched',
+                self::DEFAULT_RULES_FILENAME
             )
             ->addOption(
                 self::TARGET_PHP_PARAM,
@@ -127,8 +128,6 @@ class Check extends Command
             $progress = $verbose ? new DebugProgress($output) : new ProgressBarProgress($output);
 
             $baseline = Baseline::create($skipBaseline, $useBaseline, self::DEFAULT_BASELINE_FILENAME);
-
-            $rulesFilename = $rulesFilename ?: self::DEFAULT_RULES_FILENAME;
 
             $config = ConfigBuilder::loadFromFile($rulesFilename);
             $config->stopOnFailure($stopOnFailure);

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -151,10 +151,7 @@ class Check extends Command
             $violations = $result->getViolations();
 
             if (false !== $generateBaseline) {
-                if (null === $generateBaseline) {
-                    $generateBaseline = self::DEFAULT_BASELINE_FILENAME;
-                }
-                $this->saveBaseline($generateBaseline, $violations);
+                Baseline::save($generateBaseline, self::DEFAULT_BASELINE_FILENAME, $violations);
 
                 $output->writeln("ℹ️ Baseline file '$generateBaseline' created!");
 
@@ -227,11 +224,6 @@ class Check extends Command
         return Violations::fromJson(file_get_contents($filename));
     }
 
-    private function saveBaseline(string $filename, Violations $violations): void
-    {
-        file_put_contents($filename, json_encode($violations, \JSON_PRETTY_PRINT));
-    }
-
     private function getConfigFilename(InputInterface $input): string
     {
         $filename = $input->getOption(self::CONFIG_FILENAME_PARAM);
@@ -243,5 +235,17 @@ class Check extends Command
         Assert::file($filename, "Config file '$filename' not found");
 
         return $filename;
+    }
+}
+
+class Baseline
+{
+    public static function save(?string $filename, string $defaultFilePath, Violations $violations): void
+    {
+        if (null === $filename) {
+            $filename = $defaultFilePath;
+        }
+
+        file_put_contents($filename, json_encode($violations, \JSON_PRETTY_PRINT));
     }
 }

--- a/src/CLI/Config.php
+++ b/src/CLI/Config.php
@@ -5,6 +5,7 @@ namespace Arkitect\CLI;
 
 use Arkitect\ClassSet;
 use Arkitect\ClassSetRules;
+use Arkitect\CLI\Printer\PrinterFactory;
 use Arkitect\Rules\DSL\ArchRule;
 
 class Config
@@ -18,7 +19,13 @@ class Config
 
     private bool $stopOnFailure;
 
+    private bool $skipBaseline;
+
+    private ?string $baselineFilePath;
+
     private bool $ignoreBaselineLinenumbers;
+
+    private string $format;
 
     private TargetPhpVersion $targetPhpVersion;
 
@@ -28,7 +35,10 @@ class Config
         $this->runOnlyARule = false;
         $this->parseCustomAnnotations = true;
         $this->stopOnFailure = false;
+        $this->skipBaseline = false;
+        $this->baselineFilePath = null;
         $this->ignoreBaselineLinenumbers = false;
+        $this->format = PrinterFactory::default();
         $this->targetPhpVersion = TargetPhpVersion::latest();
     }
 
@@ -83,14 +93,28 @@ class Config
         return $this->targetPhpVersion;
     }
 
-    public function stopOnFailure(bool $stopOnFailure): bool
+    public function stopOnFailure(bool $stopOnFailure): self
     {
-        return $this->stopOnFailure = $stopOnFailure;
+        $this->stopOnFailure = $stopOnFailure;
+
+        return $this;
     }
 
     public function isStopOnFailure(): bool
     {
         return $this->stopOnFailure;
+    }
+
+    public function baselineFilePath(?string $baselineFilePath): self
+    {
+        $this->baselineFilePath = $baselineFilePath;
+
+        return $this;
+    }
+
+    public function getBaselineFilePath(): ?string
+    {
+        return $this->baselineFilePath;
     }
 
     public function ignoreBaselineLinenumbers(bool $ignoreBaselineLinenumbers): self
@@ -103,5 +127,29 @@ class Config
     public function isIgnoreBaselineLinenumbers(): bool
     {
         return $this->ignoreBaselineLinenumbers;
+    }
+
+    public function format(string $format): self
+    {
+        $this->format = $format;
+
+        return $this;
+    }
+
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    public function skipBaseline(bool $skipBaseline): self
+    {
+        $this->skipBaseline = $skipBaseline;
+
+        return $this;
+    }
+
+    public function isSkipBaseline(): bool
+    {
+        return $this->skipBaseline;
     }
 }

--- a/src/CLI/Config.php
+++ b/src/CLI/Config.php
@@ -16,11 +16,20 @@ class Config
 
     private bool $parseCustomAnnotations;
 
+    private bool $stopOnFailure;
+
+    private bool $ignoreBaselineLinenumbers;
+
+    private TargetPhpVersion $targetPhpVersion;
+
     public function __construct()
     {
         $this->classSetRules = [];
         $this->runOnlyARule = false;
         $this->parseCustomAnnotations = true;
+        $this->stopOnFailure = false;
+        $this->ignoreBaselineLinenumbers = false;
+        $this->targetPhpVersion = TargetPhpVersion::latest();
     }
 
     public function add(ClassSet $classSet, ArchRule ...$rules): self
@@ -60,5 +69,39 @@ class Config
     public function isParseCustomAnnotationsEnabled(): bool
     {
         return $this->parseCustomAnnotations;
+    }
+
+    public function targetPhpVersion(TargetPhpVersion $targetPhpVersion): self
+    {
+        $this->targetPhpVersion = $targetPhpVersion;
+
+        return $this;
+    }
+
+    public function getTargetPhpVersion(): TargetPhpVersion
+    {
+        return $this->targetPhpVersion;
+    }
+
+    public function stopOnFailure(bool $stopOnFailure): bool
+    {
+        return $this->stopOnFailure = $stopOnFailure;
+    }
+
+    public function isStopOnFailure(): bool
+    {
+        return $this->stopOnFailure;
+    }
+
+    public function ignoreBaselineLinenumbers(bool $ignoreBaselineLinenumbers): self
+    {
+        $this->ignoreBaselineLinenumbers = $ignoreBaselineLinenumbers;
+
+        return $this;
+    }
+
+    public function isIgnoreBaselineLinenumbers(): bool
+    {
+        return $this->ignoreBaselineLinenumbers;
     }
 }

--- a/src/CLI/ConfigBuilder.php
+++ b/src/CLI/ConfigBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\CLI;
+
+use Webmozart\Assert\Assert;
+
+class ConfigBuilder
+{
+    public static function loadFromFile(string $filePath): Config
+    {
+        Assert::file($filePath, "Config file '$filePath' not found");
+
+        $config = new Config();
+
+        \Closure::fromCallable(function () use ($config, $filePath): ?bool {
+            /** @psalm-suppress UnresolvableInclude $config */
+            $configFunction = require $filePath;
+
+            Assert::isCallable($configFunction);
+
+            return $configFunction($config);
+        })();
+
+        return $config;
+    }
+}

--- a/src/CLI/Printer/PrinterFactory.php
+++ b/src/CLI/Printer/PrinterFactory.php
@@ -5,7 +5,12 @@ namespace Arkitect\CLI\Printer;
 
 final class PrinterFactory
 {
-    public function create(string $format): Printer
+    public static function default(): string
+    {
+        return Printer::FORMAT_TEXT;
+    }
+
+    public static function create(string $format): Printer
     {
         switch ($format) {
             case Printer::FORMAT_GITLAB:

--- a/src/CLI/TargetPhpVersion.php
+++ b/src/CLI/TargetPhpVersion.php
@@ -33,6 +33,11 @@ class TargetPhpVersion
         $this->version = $version;
     }
 
+    public static function latest(): self
+    {
+        return new self('8.4');
+    }
+
     public static function create(?string $version): self
     {
         return new self($version ?? phpversion());

--- a/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
+++ b/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
@@ -9,6 +9,7 @@ use Arkitect\Analyzer\FileParserFactory;
 use Arkitect\ClassSet;
 use Arkitect\ClassSetRules;
 use Arkitect\CLI\Printer\Printer;
+use Arkitect\CLI\Printer\PrinterFactory;
 use Arkitect\CLI\Progress\VoidProgress;
 use Arkitect\CLI\Runner;
 use Arkitect\CLI\TargetPhpVersion;
@@ -40,6 +41,8 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
     /** @var ParsingErrors */
     private $parsingErrors;
 
+    private Printer $printer;
+
     public function __construct(ClassSet $classSet)
     {
         $targetPhpVersion = TargetPhpVersion::create(null);
@@ -48,6 +51,7 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
         $this->classSet = $classSet;
         $this->violations = new Violations();
         $this->parsingErrors = new ParsingErrors();
+        $this->printer = PrinterFactory::create(Printer::FORMAT_TEXT);
     }
 
     public function toString(): string
@@ -80,6 +84,6 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
             return "\n parsing error: ".$this->parsingErrors->toString();
         }
 
-        return "\n".$this->violations->toString(Printer::FORMAT_TEXT);
+        return "\n".$this->printer->print($this->violations->groupedByFqcn());
     }
 }

--- a/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
+++ b/src/PHPUnit/ArchRuleCheckerConstraintAdapter.php
@@ -64,7 +64,8 @@ class ArchRuleCheckerConstraintAdapter extends Constraint
             new VoidProgress(),
             $this->fileparser,
             $this->violations,
-            $this->parsingErrors
+            $this->parsingErrors,
+            false
         );
 
         $violationsCount = $this->violations->count();

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Arkitect\Rules;
 
-use Arkitect\CLI\Printer\PrinterFactory;
 use Arkitect\Exceptions\IndexNotFoundException;
 
 /**
@@ -73,13 +72,6 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
 
             return $accumulator;
         }, []);
-    }
-
-    public function toString(string $format): string
-    {
-        $printer = (new PrinterFactory())->create($format);
-
-        return $printer->print($this->groupedByFqcn());
     }
 
     public function toArray(): array

--- a/tests/Unit/CLI/Printer/PrinterFactoryTest.php
+++ b/tests/Unit/CLI/Printer/PrinterFactoryTest.php
@@ -15,9 +15,7 @@ class PrinterFactoryTest extends TestCase
      */
     public function test_create_returns_json_printer_for_json_format(): void
     {
-        $factory = new PrinterFactory();
-
-        $printer = $factory->create('json');
+        $printer = PrinterFactory::create('json');
 
         self::assertInstanceOf(JsonPrinter::class, $printer);
     }
@@ -27,9 +25,7 @@ class PrinterFactoryTest extends TestCase
      */
     public function test_create_returns_text_printer_for_non_json_format(): void
     {
-        $factory = new PrinterFactory();
-
-        $printer = $factory->create('text');
+        $printer = PrinterFactory::create('text');
 
         self::assertInstanceOf(TextPrinter::class, $printer);
     }

--- a/tests/Unit/Rules/RuleCheckerTest.php
+++ b/tests/Unit/Rules/RuleCheckerTest.php
@@ -24,6 +24,7 @@ class RuleCheckerTest extends TestCase
         $fileParser = new FakeParser();
         $rule = new FakeRule();
         $parsingErrors = new ParsingErrors();
+        $stopOnFailure = false;
 
         $runner = new Runner();
 
@@ -32,7 +33,8 @@ class RuleCheckerTest extends TestCase
             new VoidProgress(),
             $fileParser,
             $violations,
-            $parsingErrors
+            $parsingErrors,
+            $stopOnFailure
         );
 
         self::assertCount(3, $violations);

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Rules;
 
-use Arkitect\CLI\Printer\Printer;
 use Arkitect\Exceptions\IndexNotFoundException;
 use Arkitect\Rules\Violation;
 use Arkitect\Rules\Violations;
@@ -46,26 +45,6 @@ class ViolationsTest extends TestCase
         );
         $this->violationStore->add($violation);
         self::assertEquals(2, $this->violationStore->count());
-    }
-
-    public function test_to_string(): void
-    {
-        $violation = new Violation(
-            'App\Controller\Foo',
-            'should have name end with Controller'
-        );
-
-        $this->violationStore->add($violation);
-
-        $expected = <<<'ERRORS'
-        App\Controller\ProductController has 1 violations
-          should implement ContainerInterface
-
-        App\Controller\Foo has 1 violations
-          should have name end with Controller
-        ERRORS;
-
-        self::assertStringContainsString($expected, $this->violationStore->toString(Printer::FORMAT_TEXT));
     }
 
     public function test_get_iterable(): void


### PR DESCRIPTION
Introduce a ConfigBuilder and moves several params into the Config class. With that, 
- the Runner class has more information about the input params. and can make potentially more decision on how to run the analisys
- it enables (still some more work is needed) to specify the input params also in the phparkitect.php config file and having the command line option overriding those values
 
