### PR TITLE
Check: adds an option to specifiy an autoloader file to be included

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ chmod +x phparkitect.phar
 ./phparkitect.phar check
 ```
 
+ When you run phparkitect as phar and you have custom rules in need of autoloading the project classes you'll need to specify the option `--autoload=[AUTOLOAD_FILE]`. 
+
 # Usage
 
 To use this tool you need to launch a command via Bash:
@@ -473,6 +475,7 @@ phparkitect check --config=/project/yourConfigFile.php
 * `--target-php-version`: With this parameter, you can specify which PHP version should use the parser. This can be useful to debug problems and to understand if there are problems with a different PHP version.
 Supported PHP versions are: 7.4, 8.0, 8.1, 8.2 8.3
  * `--stop-on-failure`: With this option the process will end immediately after the first violation.
+ * `--autoload`: specify the path of an autoload file to be loaded when running phparkitect.
 
 ## Run only a specific rule
 For some reasons, you might want to run only a specific rule, you can do it using `runOnlyThis` like this:

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -141,10 +141,10 @@ class Check extends Command
                 ->skipBaseline($skipBaseline)
                 ->format($format);
 
-            $this->requireAutoload($config->getAutoloadFilePath(), $output);
-            $printer = $this->createPrinter($config->getFormat(), $output);
-            $progress = $this->createProgress($verbose, $output);
-            $baseline = $this->createBaseline($config->isSkipBaseline(), $config->getBaselineFilePath(), $output);
+            $this->requireAutoload($output, $config->getAutoloadFilePath());
+            $printer = $this->createPrinter($output, $config->getFormat());
+            $progress = $this->createProgress($output, $verbose);
+            $baseline = $this->createBaseline($output, $config->isSkipBaseline(), $config->getBaselineFilePath());
 
             $output->writeln("Config file '$rulesFilename' found\n");
 
@@ -189,7 +189,7 @@ class Check extends Command
     /**
      * @psalm-suppress UnresolvableInclude
      */
-    protected function requireAutoload(?string $filePath, OutputInterface $output): void
+    protected function requireAutoload(OutputInterface $output, ?string $filePath): void
     {
         if (null === $filePath) {
             return;
@@ -202,21 +202,21 @@ class Check extends Command
         $output->writeln("Autoload file '$filePath' added");
     }
 
-    protected function createPrinter(string $format, OutputInterface $output): Printer
+    protected function createPrinter(OutputInterface $output, string $format): Printer
     {
         $output->writeln("Output format: $format");
 
         return PrinterFactory::create($format);
     }
 
-    protected function createProgress(bool $verbose, OutputInterface $output): Progress
+    protected function createProgress(OutputInterface $output, bool $verbose): Progress
     {
         $output->writeln('Progress: '.($verbose ? 'debug' : 'bar'));
 
         return $verbose ? new DebugProgress($output) : new ProgressBarProgress($output);
     }
 
-    protected function createBaseline(bool $skipBaseline, ?string $baselineFilePath, OutputInterface $output): Baseline
+    protected function createBaseline(OutputInterface $output, bool $skipBaseline, ?string $baselineFilePath): Baseline
     {
         $baseline = Baseline::create($skipBaseline, $baselineFilePath);
 

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -6,8 +6,10 @@ namespace Arkitect\CLI\Command;
 
 use Arkitect\CLI\Baseline;
 use Arkitect\CLI\ConfigBuilder;
+use Arkitect\CLI\Printer\Printer;
 use Arkitect\CLI\Printer\PrinterFactory;
 use Arkitect\CLI\Progress\DebugProgress;
+use Arkitect\CLI\Progress\Progress;
 use Arkitect\CLI\Progress\ProgressBarProgress;
 use Arkitect\CLI\Runner;
 use Arkitect\CLI\TargetPhpVersion;
@@ -16,6 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\Assert\Assert;
 
 class Check extends Command
 {
@@ -26,6 +29,7 @@ class Check extends Command
     private const SKIP_BASELINE_PARAM = 'skip-baseline';
     private const IGNORE_BASELINE_LINENUMBERS_PARAM = 'ignore-baseline-linenumbers';
     private const FORMAT_PARAM = 'format';
+    private const AUTOLOAD_PARAM = 'autoload';
 
     private const GENERATE_BASELINE_PARAM = 'generate-baseline';
     private const DEFAULT_RULES_FILENAME = 'phparkitect.php';
@@ -95,6 +99,12 @@ class Check extends Command
                 InputOption::VALUE_OPTIONAL,
                 'Output format: text (default), json, gitlab',
                 'text'
+            )
+            ->addOption(
+                self::AUTOLOAD_PARAM,
+                'a',
+                InputOption::VALUE_REQUIRED,
+                'Specify an autoload file to use',
             );
     }
 
@@ -123,6 +133,7 @@ class Check extends Command
             $this->printHeadingLine($output);
 
             $config = ConfigBuilder::loadFromFile($rulesFilename)
+                ->autoloadFilePath($input->getOption(self::AUTOLOAD_PARAM))
                 ->stopOnFailure($stopOnFailure)
                 ->targetPhpVersion(TargetPhpVersion::create($phpVersion))
                 ->baselineFilePath(Baseline::resolveFilePath($useBaseline, self::DEFAULT_BASELINE_FILENAME))
@@ -130,13 +141,11 @@ class Check extends Command
                 ->skipBaseline($skipBaseline)
                 ->format($format);
 
-            $printer = PrinterFactory::create($config->getFormat());
+            $this->requireAutoload($config->getAutoloadFilePath(), $output);
+            $printer = $this->createPrinter($config->getFormat(), $output);
+            $progress = $this->createProgress($verbose, $output);
+            $baseline = $this->createBaseline($config->isSkipBaseline(), $config->getBaselineFilePath(), $output);
 
-            $progress = $verbose ? new DebugProgress($output) : new ProgressBarProgress($output);
-
-            $baseline = Baseline::create($config->isSkipBaseline(), $config->getBaselineFilePath());
-
-            $baseline->getFilename() && $output->writeln("Baseline file '{$baseline->getFilename()}' found");
             $output->writeln("Config file '$rulesFilename' found\n");
 
             $runner = new Runner();
@@ -175,6 +184,45 @@ class Check extends Command
         } finally {
             $this->printExecutionTime($output, $startTime);
         }
+    }
+
+    /**
+     * @psalm-suppress UnresolvableInclude
+     */
+    protected function requireAutoload(?string $filePath, OutputInterface $output): void
+    {
+        if (null === $filePath) {
+            return;
+        }
+
+        Assert::file($filePath, "Cannot find '$filePath'");
+
+        require_once $filePath;
+
+        $output->writeln("Autoload file '$filePath' added");
+    }
+
+    protected function createPrinter(string $format, OutputInterface $output): Printer
+    {
+        $output->writeln("Output format: $format");
+
+        return PrinterFactory::create($format);
+    }
+
+    protected function createProgress(bool $verbose, OutputInterface $output): Progress
+    {
+        $output->writeln('Progress: '.($verbose ? 'debug' : 'bar'));
+
+        return $verbose ? new DebugProgress($output) : new ProgressBarProgress($output);
+    }
+
+    protected function createBaseline(bool $skipBaseline, ?string $baselineFilePath, OutputInterface $output): Baseline
+    {
+        $baseline = Baseline::create($skipBaseline, $baselineFilePath);
+
+        $baseline->getFilename() && $output->writeln("Baseline file '{$baseline->getFilename()}' found");
+
+        return $baseline;
     }
 
     protected function printHeadingLine(OutputInterface $output): void

--- a/src/CLI/Config.php
+++ b/src/CLI/Config.php
@@ -27,6 +27,8 @@ class Config
 
     private string $format;
 
+    private ?string $autoloadFilePath;
+
     private TargetPhpVersion $targetPhpVersion;
 
     public function __construct()
@@ -39,6 +41,7 @@ class Config
         $this->baselineFilePath = null;
         $this->ignoreBaselineLinenumbers = false;
         $this->format = PrinterFactory::default();
+        $this->autoloadFilePath = null;
         $this->targetPhpVersion = TargetPhpVersion::latest();
     }
 
@@ -151,5 +154,17 @@ class Config
     public function isSkipBaseline(): bool
     {
         return $this->skipBaseline;
+    }
+
+    public function autoloadFilePath(?string $autoloadFilePath): self
+    {
+        $this->autoloadFilePath = $autoloadFilePath;
+
+        return $this;
+    }
+
+    public function getAutoloadFilePath(): ?string
+    {
+        return $this->autoloadFilePath;
     }
 }

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -252,6 +252,15 @@ class CheckCommandTest extends TestCase
         self::assertJsonStringEqualsJsonString($expectedJson, $cmdTester->getDisplay());
     }
 
+    public function test_autoload_file(): void
+    {
+        $configFilePath = __DIR__.'/../_fixtures/autoload/phparkitect.php';
+
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, false, 'text', __DIR__.'/../_fixtures/autoload/autoload.php');
+
+        self::assertCommandWasSuccessful($cmdTester);
+    }
+
     protected function runCheck(
         $configFilePath = null,
         ?bool $stopOnFailure = null,
@@ -259,9 +268,11 @@ class CheckCommandTest extends TestCase
         $generateBaseline = false,
         bool $skipBaseline = false,
         bool $ignoreBaselineNumbers = false,
-        string $format = 'text'
+        string $format = 'text',
+        ?string $autoloadFilePath = null
     ): ApplicationTester {
         $input = ['check'];
+
         if (null !== $configFilePath) {
             $input['--config'] = $configFilePath;
         }
@@ -285,6 +296,10 @@ class CheckCommandTest extends TestCase
         }
 
         $input['--format'] = $format;
+
+        if ($autoloadFilePath) {
+            $input['--autoload'] = $autoloadFilePath;
+        }
 
         $app = new PhpArkitectApplication();
         $app->setAutoExit(false);

--- a/tests/E2E/_fixtures/autoload/autoload.php
+++ b/tests/E2E/_fixtures/autoload/autoload.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-spl_autoload_register(function ($class) {
+spl_autoload_register(function ($class): void {
     $classmap = [
         'Autoload\Services\UserService' => __DIR__.'/src/Service/UserService.php',
         'Autoload\Model\User' => __DIR__.'/src/Model/User.php',
@@ -18,5 +18,5 @@ spl_autoload_register(function ($class) {
         return;
     }
 
-    return require $path;
+    require_once $path;
 });

--- a/tests/E2E/_fixtures/autoload/autoload.php
+++ b/tests/E2E/_fixtures/autoload/autoload.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+spl_autoload_register(function ($class) {
+    $classmap = [
+        'Autoload\Services\UserService' => __DIR__.'/src/Service/UserService.php',
+        'Autoload\Model\User' => __DIR__.'/src/Model/User.php',
+        'Autoload\Model\UserInterface' => __DIR__.'/src/Model/UserInterface.php',
+    ];
+
+    $path = $classmap[$class] ?? null;
+
+    if (null === $path) {
+        return;
+    }
+
+    if (!file_exists($path)) {
+        return;
+    }
+
+    return require $path;
+});

--- a/tests/E2E/_fixtures/autoload/phparkitect.php
+++ b/tests/E2E/_fixtures/autoload/phparkitect.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+use Arkitect\Analyzer\ClassDescription;
+use Arkitect\ClassSet;
+use Arkitect\CLI\Config;
+use Arkitect\Expression\Description;
+use Arkitect\Expression\Expression;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
+use Arkitect\Rules\Violations;
+
+return static function (Config $config): void {
+    // a dummy rule to check if the class is autoloaded
+    $autoload_rule = new class('Autoload\Model\UserInterface') implements Expression {
+        public string $implements;
+
+        public function __construct(string $implements)
+        {
+            $this->implements = $implements;
+        }
+
+        public function describe(ClassDescription $theClass, string $because): Description
+        {
+            return new Description("{$theClass->getFQCN()} should implement {$this->implements}", $because);
+        }
+
+        public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
+        {
+            if (is_a($theClass->getFQCN(), $this->implements, true)) {
+                return;
+            }
+
+            $violation = Violation::create(
+                $theClass->getFQCN(),
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
+            );
+
+            $violations->add($violation);
+        }
+    };
+
+    $mvc_class_set = ClassSet::fromDir(__DIR__.'/src');
+
+    $rule = Rule::allClasses()
+        ->except('Autoload\Model\UserInterface')
+        ->that(new ResideInOneOfTheseNamespaces('Autoload\Model'))
+        ->should($autoload_rule)
+        ->because('we want check if the class is autoloaded');
+
+    $config
+        ->add($mvc_class_set, $rule);
+};

--- a/tests/E2E/_fixtures/autoload/phparkitect.php
+++ b/tests/E2E/_fixtures/autoload/phparkitect.php
@@ -14,6 +14,7 @@ use Arkitect\Rules\Violations;
 
 return static function (Config $config): void {
     // a dummy rule to check if the class is autoloaded
+    // is_a with 'true' passed as the third parameter triggers the autoloader
     $autoload_rule = new class('Autoload\Model\UserInterface') implements Expression {
         public string $implements;
 
@@ -43,7 +44,7 @@ return static function (Config $config): void {
         }
     };
 
-    $mvc_class_set = ClassSet::fromDir(__DIR__.'/src');
+    $class_set = ClassSet::fromDir(__DIR__.'/src');
 
     $rule = Rule::allClasses()
         ->except('Autoload\Model\UserInterface')
@@ -52,5 +53,5 @@ return static function (Config $config): void {
         ->because('we want check if the class is autoloaded');
 
     $config
-        ->add($mvc_class_set, $rule);
+        ->add($class_set, $rule);
 };

--- a/tests/E2E/_fixtures/autoload/src/Model/User.php
+++ b/tests/E2E/_fixtures/autoload/src/Model/User.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Autoload\Model;
+
+class User implements UserInterface
+{
+}

--- a/tests/E2E/_fixtures/autoload/src/Model/UserInterface.php
+++ b/tests/E2E/_fixtures/autoload/src/Model/UserInterface.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Autoload\Model;
+
+interface UserInterface
+{
+}

--- a/tests/E2E/_fixtures/autoload/src/Service/UserService.php
+++ b/tests/E2E/_fixtures/autoload/src/Service/UserService.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Autoload\Services;
+
+class UserService
+{
+}

--- a/tests/Unit/CLI/Printer/GitlabPrinterTest.php
+++ b/tests/Unit/CLI/Printer/GitlabPrinterTest.php
@@ -27,8 +27,33 @@ class GitlabPrinterTest extends TestCase
 
         $result = $printer->print($violationsCollection);
 
-        self::assertSame(<<<JSON
-        [{"description":"Some error message","check_name":"RuleA.some-error-message","fingerprint":"7ddcfd42f5f2af3d00864ef959a0327f508cb5227aedca96d919d681a5dcde4a","severity":"major","location":{"path":"tests\/Unit\/CLI\/Printer\/GitlabPrinterTest.php","lines":{"begin":42}}},{"description":"Another error message","check_name":"RuleB.another-error-message","fingerprint":"800c2ceafbf4023e401200186ecabdfe59891c5d6670e86571e3c50339df07dc","severity":"major","location":{"path":"tests\/Unit\/CLI\/Printer\/GitlabPrinterTest.php","lines":{"begin":1}}}]
+        self::assertJsonStringEqualsJsonString(<<<JSON
+        [
+            {
+                "description": "Some error message",
+                "check_name": "RuleA.some-error-message",
+                "fingerprint": "7ddcfd42f5f2af3d00864ef959a0327f508cb5227aedca96d919d681a5dcde4a",
+                "severity": "major",
+                "location": {
+                    "path": "tests\/Unit\/CLI\/Printer\/GitlabPrinterTest.php",
+                    "lines": {
+                        "begin": 42
+                    }
+                }
+            },
+            {
+                "description": "Another error message",
+                "check_name": "RuleB.another-error-message",
+                "fingerprint": "800c2ceafbf4023e401200186ecabdfe59891c5d6670e86571e3c50339df07dc",
+                "severity": "major",
+                "location": {
+                    "path": "tests\/Unit\/CLI\/Printer\/GitlabPrinterTest.php",
+                    "lines": {
+                        "begin": 1
+                    }
+                }
+            }
+        ]
         JSON, $result);
     }
 


### PR DESCRIPTION
**Context:** as we are considering the possibility to use functions like `is_a` in the rules, we need a way to deal with the autoload of the classes phparkitect is analizyng

We have two scenarios based on how phparkitect is installed

**as a project dependency via composer:** this is the simplest case since, since phparkitect shares the autoload with the project it analyzes, no additional autoloader is needed ✅ 

**as a phar:** here phparkitect autoload is embedded in the phar itself, so we need a way to autoload the project's classes

In the second scenario, we should consider the phar could be in different locations: 
- global, like in `/usr/local/bin/phparkitect`
- in the project root
- in the project `bin` dir
- ...

so trying to guess where the project autoload could be can be challenging. Possible solutions to tackle that:
1. do nothing and keep things as they are 😢 .
2. improve the parser to recursively fetch ancestors for classes, interfaces, enum, traits.
3. allow to specify an extra autoloader. 

Solution no 2. would be the most consistent with the current approach as the ClassDescription object would contain all the info needed to apply a rule and no autoload will be triggered. This is also the most complex to implement properly and it may need rethinking the architecture which now assumes we parse a file -> create one or more ClassDescription objects -> apply rules on them. 

Solution no.3 is kinda common on other tools ([rector](https://getrector.com/documentation/static-reflection-and-autoload), [psalm](https://psalm.dev/docs/running_psalm/configuration/#autoloader), [phpstan](https://phpstan.org/user-guide/discovering-symbols#custom-autoloader)) so it should not be a big surprise for the users. It is also the easiest to implement. _Is there any chance of getting conflicts between phparkitect's classes and the project classes?_ No, because the tool we use to package the phar uses [php-scoper](https://github.com/humbug/php-scoper) to avoid this kind of problems

**Choosen solution:** while it could be nice to do spike in order to understand the effort of implementing 2. it properly here I went for solution no 3.: _adding the capability to specify the path of an extra autoloader file via command line option_. 

this should allow what is asked in #401  
