### PR TITLE
Collect types declared in @throws tags and consider them dependencies (1/2)

### DIFF
--- a/src/Analyzer/Docblock.php
+++ b/src/Analyzer/Docblock.php
@@ -6,8 +6,10 @@ namespace Arkitect\Analyzer;
 
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 
 class Docblock
@@ -41,8 +43,37 @@ class Docblock
         return array_filter($returnTypes);
     }
 
+    public function getVarTagTypes(): array
+    {
+        $varTypes = array_map(
+            fn (VarTagValueNode $varTag) => $this->getType($varTag->type),
+            $this->phpDocNode->getVarTagValues()
+        );
+
+        // remove null values
+        return array_filter($varTypes);
+    }
+
+    public function getDoctrineLikeAnnotationTypes(): array
+    {
+        $doctrineAnnotations = [];
+
+        foreach ($this->phpDocNode->getTags() as $tag) {
+            if ('@' === $tag->name[0] && !str_contains($tag->name, '@var')) {
+                $doctrineAnnotations[] = str_replace('@', '', $tag->name);
+            }
+        }
+
+        return $doctrineAnnotations;
+    }
+
     private function getType(TypeNode $typeNode): ?string
     {
+        if ($typeNode instanceof IdentifierTypeNode) {
+            // this handles ClassName
+            return $typeNode->name;
+        }
+
         if ($typeNode instanceof GenericTypeNode) {
             // this handles list<ClassName>
             if (1 === \count($typeNode->genericTypes)) {

--- a/src/Analyzer/Docblock.php
+++ b/src/Analyzer/Docblock.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Analyzer;
+
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+
+class Docblock
+{
+    private PhpDocNode $phpDocNode;
+
+    public function __construct(PhpDocNode $phpDocNode)
+    {
+        $this->phpDocNode = $phpDocNode;
+    }
+
+    public function getParamTagTypesByName(string $name): ?string
+    {
+        foreach ($this->phpDocNode->getParamTagValues() as $paramTag) {
+            if ($paramTag->parameterName === $name) {
+                return $this->getType($paramTag->type);
+            }
+        }
+
+        return null;
+    }
+
+    public function getReturnTagTypes(): array
+    {
+        $returnTypes = array_map(
+            fn (ReturnTagValueNode $returnTag) => $this->getType($returnTag->type),
+            $this->phpDocNode->getReturnTagValues()
+        );
+
+        // remove null values
+        return array_filter($returnTypes);
+    }
+
+    private function getType(TypeNode $typeNode): ?string
+    {
+        if ($typeNode instanceof GenericTypeNode) {
+            // this handles list<ClassName>
+            if (1 === \count($typeNode->genericTypes)) {
+                return (string) $typeNode->genericTypes[0];
+            }
+
+            // this handles array<int, ClassName>
+            if (2 === \count($typeNode->genericTypes)) {
+                return (string) $typeNode->genericTypes[1];
+            }
+        }
+
+        // this handles ClassName[]
+        if ($typeNode instanceof ArrayTypeNode) {
+            return (string) $typeNode->type;
+        }
+
+        return null;
+    }
+}

--- a/src/Analyzer/DocblockParser.php
+++ b/src/Analyzer/DocblockParser.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Arkitect\Analyzer;
 
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
@@ -20,11 +19,11 @@ class DocblockParser
         $this->innerLexer = $innerLexer;
     }
 
-    public function parse(string $docblock): PhpDocNode
+    public function parse(string $docblock): Docblock
     {
         $tokens = $this->innerLexer->tokenize($docblock);
         $tokenIterator = new TokenIterator($tokens);
 
-        return $this->innerParser->parse($tokenIterator);
+        return new Docblock($this->innerParser->parse($tokenIterator));
     }
 }

--- a/src/Analyzer/DocblockTypesResolver.php
+++ b/src/Analyzer/DocblockTypesResolver.php
@@ -35,15 +35,6 @@ class DocblockTypesResolver extends NodeVisitorAbstract
 
     private DocblockParser $docblockParser;
 
-<<<<<<< HEAD
-    private DocblockParser $docblockParser;
-
-=======
-    /**
-     * @psalm-suppress TooFewArguments
-     * @psalm-suppress InvalidArgument
-     */
->>>>>>> c3d808e (wip)
     public function __construct(bool $parseCustomAnnotations = true)
     {
         $this->nameContext = new NameContext(new ErrorHandler\Throwing());

--- a/src/Analyzer/DocblockTypesResolver.php
+++ b/src/Analyzer/DocblockTypesResolver.php
@@ -35,6 +35,15 @@ class DocblockTypesResolver extends NodeVisitorAbstract
 
     private DocblockParser $docblockParser;
 
+<<<<<<< HEAD
+    private DocblockParser $docblockParser;
+
+=======
+    /**
+     * @psalm-suppress TooFewArguments
+     * @psalm-suppress InvalidArgument
+     */
+>>>>>>> c3d808e (wip)
     public function __construct(bool $parseCustomAnnotations = true)
     {
         $this->nameContext = new NameContext(new ErrorHandler\Throwing());

--- a/src/Analyzer/DocblockTypesResolver.php
+++ b/src/Analyzer/DocblockTypesResolver.php
@@ -14,10 +14,6 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeAbstract;
 use PhpParser\NodeVisitorAbstract;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
-use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 
 /**
  * This class is used to collect type information from dockblocks, in particular
@@ -68,51 +64,39 @@ class DocblockTypesResolver extends NodeVisitorAbstract
 
         $this->resolveFunctionTypes($node);
 
-        $this->resolveParamTypes($node);
+        $this->resolvePropertyTypes($node);
     }
 
-    private function resolveParamTypes(Node $node): void
+    private function resolvePropertyTypes(Node $node): void
     {
         if (!($node instanceof Stmt\Property)) {
             return;
         }
 
-        $phpDocNode = $this->parseDocblock($node);
+        $docblock = $this->parseDocblock($node);
 
-        if (null === $phpDocNode) {
+        if (null === $docblock) {
             return;
         }
 
-        if ($this->isNodeOfTypeArray($node)) {
-            $arrayItemType = null;
+        $arrayItemType = $docblock->getVarTagTypes();
+        $arrayItemType = array_pop($arrayItemType);
 
-            foreach ($phpDocNode->getVarTagValues() as $tagValue) {
-                $arrayItemType = $this->getArrayItemType($tagValue->type);
-            }
+        if (null !== $arrayItemType) {
+            $node->type = $this->resolveName(new Name($arrayItemType), Stmt\Use_::TYPE_NORMAL);
 
-            if (null !== $arrayItemType) {
-                $node->type = $this->resolveName(new Name($arrayItemType), Stmt\Use_::TYPE_NORMAL);
-
-                return;
-            }
-        }
-
-        foreach ($phpDocNode->getVarTagValues() as $tagValue) {
-            $type = $this->resolveName(new Name((string) $tagValue->type), Stmt\Use_::TYPE_NORMAL);
-            $node->type = $type;
-            break;
+            return;
         }
 
         if ($this->parseCustomAnnotations && !($node->type instanceof FullyQualified)) {
-            foreach ($phpDocNode->getTags() as $tagValue) {
-                if ('@' === $tagValue->name[0] && !str_contains($tagValue->name, '@var')) {
-                    $customTag = str_replace('@', '', $tagValue->name);
-                    $type = $this->resolveName(new Name($customTag), Stmt\Use_::TYPE_NORMAL);
-                    $node->type = $type;
+            $doctrineAnnotations = $docblock->getDoctrineLikeAnnotationTypes();
+            $doctrineAnnotations = array_shift($doctrineAnnotations);
 
-                    break;
-                }
+            if (null === $doctrineAnnotations) {
+                return;
             }
+
+            $node->type = $this->resolveName(new Name($doctrineAnnotations), Stmt\Use_::TYPE_NORMAL);
         }
     }
 
@@ -127,13 +111,11 @@ class DocblockTypesResolver extends NodeVisitorAbstract
             return;
         }
 
-        $phpDocNode = $this->parseDocblock($node);
+        $docblock = $this->parseDocblock($node);
 
-        if (null === $phpDocNode) { // no docblock, nothing to do
+        if (null === $docblock) { // no docblock, nothing to do
             return;
         }
-
-        $docblock = new Docblock($phpDocNode);
 
         // extract param types from param tags
         foreach ($node->params as $param) {
@@ -183,14 +165,6 @@ class DocblockTypesResolver extends NodeVisitorAbstract
             return $resolvedName;
         }
 
-        // unqualified names inside a namespace cannot be resolved at compile-time
-        // add the namespaced version of the name as an attribute
-        $name->setAttribute('namespacedName', FullyQualified::concat(
-            $this->nameContext->getNamespace(),
-            $name,
-            $name->getAttributes()
-        ));
-
         return $name;
     }
 
@@ -223,7 +197,7 @@ class DocblockTypesResolver extends NodeVisitorAbstract
         );
     }
 
-    private function parseDocblock(NodeAbstract $node): ?PhpDocNode
+    private function parseDocblock(NodeAbstract $node): ?Docblock
     {
         if (null === $node->getDocComment()) {
             return null;
@@ -236,46 +210,10 @@ class DocblockTypesResolver extends NodeVisitorAbstract
     }
 
     /**
-     * @param Node\Param|Stmt\Property $node
-     */
-    private function isNodeOfTypeArray($node): bool
-    {
-        return null !== $node->type && isset($node->type->name) && 'array' === $node->type->name;
-    }
-
-    /**
      * @param Node\Identifier|Name|Node\ComplexType|null $type
      */
     private function isTypeArray($type): bool
     {
         return null !== $type && isset($type->name) && 'array' === $type->name;
-    }
-
-    private function getArrayItemType(TypeNode $typeNode): ?string
-    {
-        $arrayItemType = null;
-
-        if ($typeNode instanceof GenericTypeNode) {
-            if (1 === \count($typeNode->genericTypes)) {
-                // this handles list<ClassName>
-                $arrayItemType = (string) $typeNode->genericTypes[0];
-            } elseif (2 === \count($typeNode->genericTypes)) {
-                // this handles array<int, ClassName>
-                $arrayItemType = (string) $typeNode->genericTypes[1];
-            }
-        }
-
-        if ($typeNode instanceof ArrayTypeNode) {
-            // this handles ClassName[]
-            $arrayItemType = (string) $typeNode->type;
-        }
-
-        $validFqcn = '/^[a-zA-Z_\x7f-\xff\\\\][a-zA-Z0-9_\x7f-\xff\\\\]*[a-zA-Z0-9_\x7f-\xff]$/';
-
-        if (null !== $arrayItemType && !(bool) preg_match($validFqcn, $arrayItemType)) {
-            return null;
-        }
-
-        return $arrayItemType;
     }
 }

--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -12,7 +12,8 @@ use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser as PhpParser;
 use PhpParser\ParserFactory;
 use PhpParser\PhpVersion;
-
+use Arkitect\Analyzer\DocblockTypesResolver;
+use PhpParser\NodeVisitor\NameResolver;
 class FileParser implements Parser
 {
     private PhpParser $parser;

--- a/src/Analyzer/FileParser.php
+++ b/src/Analyzer/FileParser.php
@@ -12,8 +12,7 @@ use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser as PhpParser;
 use PhpParser\ParserFactory;
 use PhpParser\PhpVersion;
-use Arkitect\Analyzer\DocblockTypesResolver;
-use PhpParser\NodeVisitor\NameResolver;
+
 class FileParser implements Parser
 {
     private PhpParser $parser;

--- a/tests/Unit/Analyzer/DocblockParserTest.php
+++ b/tests/Unit/Analyzer/DocblockParserTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Analyzer;
 
-use Arkitect\Analyzer\Docblock;
 use Arkitect\Analyzer\DocblockParserFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -24,20 +23,17 @@ class DocblockParserTest extends TestCase
              * @param int $aValue
              * @param MyPlainDto $plainDto
              */
-        }
         PHP;
 
-        $phpdoc = $parser->parse($code);
-
-        $db = new Docblock($phpdoc);
+        $db = $parser->parse($code);
 
         self::assertEquals('MyDto', $db->getParamTagTypesByName('$dtoList'));
         self::assertEquals('MyOtherDto', $db->getParamTagTypesByName('$dtoList2'));
         self::assertEquals('ValueObject', $db->getParamTagTypesByName('$voList'));
         self::assertEquals('User', $db->getParamTagTypesByName('$user'));
 
-        self::assertNull($db->getParamTagTypesByName('$aValue'));
-        self::assertNull($db->getParamTagTypesByName('$plainDto'));
+        self::assertEquals('int', $db->getParamTagTypesByName('$aValue'));
+        self::assertEquals('MyPlainDto', $db->getParamTagTypesByName('$plainDto'));
     }
 
     public function test_it_should_extract_return_type_from_return_tag(): void
@@ -53,18 +49,70 @@ class DocblockParserTest extends TestCase
              * @return int
              * @return MyPlainDto
              */
-        }
         PHP;
 
-        $phpdoc = $parser->parse($code);
-
-        $db = new Docblock($phpdoc);
+        $db = $parser->parse($code);
 
         $returnTypes = $db->getReturnTagTypes();
-        self::assertCount(4, $returnTypes);
+        self::assertCount(6, $returnTypes);
         self::assertEquals('MyDto', $returnTypes[0]);
         self::assertEquals('MyOtherDto', $returnTypes[1]);
         self::assertEquals('ValueObject', $returnTypes[2]);
         self::assertEquals('User', $returnTypes[3]);
+        self::assertEquals('int', $returnTypes[4]);
+        self::assertEquals('MyPlainDto', $returnTypes[5]);
+    }
+
+    public function test_it_should_extract_types_from_var_tag(): void
+    {
+        $parser = DocblockParserFactory::create();
+
+        $code = <<< 'PHP'
+            /**
+             * @var MyDto[] $dtoList
+             * @var list<MyOtherDto> $dtoList2
+             * @var array<int, ValueObject> $voList
+             * @var array<User> $user
+             * @var int $aValue
+             * @var MyPlainDto $plainDto
+             */
+        PHP;
+
+        $db = $parser->parse($code);
+
+        $varTags = $db->getVarTagTypes();
+        self::assertCount(6, $varTags);
+        self::assertEquals('MyDto', $varTags[0]);
+        self::assertEquals('MyOtherDto', $varTags[1]);
+        self::assertEquals('ValueObject', $varTags[2]);
+        self::assertEquals('User', $varTags[3]);
+        self::assertEquals('int', $varTags[4]);
+        self::assertEquals('MyPlainDto', $varTags[5]);
+    }
+
+    public function test_it_should_extract_doctrine_like_annotations(): void
+    {
+        $parser = DocblockParserFactory::create();
+
+        $code = <<< 'PHP'
+            /**
+             * @ORM\Id
+             * @ORM\Column(type="integer")
+             * @ORM\GeneratedValue
+             * @Assert\NotBlank
+             * @Assert\Length(min=5)
+             */
+        PHP;
+
+        $db = $parser->parse($code);
+
+        $doctrineAnnotations = $db->getDoctrineLikeAnnotationTypes();
+
+        self::assertCount(5, $doctrineAnnotations);
+        self::assertEquals('ORM\Id', $doctrineAnnotations[0]);
+        self::assertEquals('ORM\Column', $doctrineAnnotations[1]);
+        self::assertEquals('ORM\GeneratedValue', $doctrineAnnotations[2]);
+        self::assertEquals('Assert\NotBlank', $doctrineAnnotations[3]);
+        self::assertEquals('Assert\Length', $doctrineAnnotations[4]);
     }
 }

--- a/tests/Unit/Analyzer/DocblockParserTest.php
+++ b/tests/Unit/Analyzer/DocblockParserTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Analyzer;
+
+use Arkitect\Analyzer\Docblock;
+use Arkitect\Analyzer\DocblockParserFactory;
+use PHPUnit\Framework\TestCase;
+
+class DocblockParserTest extends TestCase
+{
+    public function test_it_should_exctract_types_from_param_tag(): void
+    {
+        $parser = DocblockParserFactory::create();
+
+        $code = <<< 'PHP'
+            /**
+             * @param MyDto[] $dtoList
+             * @param list<MyOtherDto> $dtoList2
+             * @param array<int, ValueObject> $voList
+             * @param array<User> $user
+             * @param array<User> $user
+             * @param int $aValue
+             * @param MyPlainDto $plainDto
+             */
+        }
+        PHP;
+
+        $phpdoc = $parser->parse($code);
+
+        $db = new Docblock($phpdoc);
+
+        self::assertEquals('MyDto', $db->getParamTagTypesByName('$dtoList'));
+        self::assertEquals('MyOtherDto', $db->getParamTagTypesByName('$dtoList2'));
+        self::assertEquals('ValueObject', $db->getParamTagTypesByName('$voList'));
+        self::assertEquals('User', $db->getParamTagTypesByName('$user'));
+
+        self::assertNull($db->getParamTagTypesByName('$aValue'));
+        self::assertNull($db->getParamTagTypesByName('$plainDto'));
+    }
+
+    public function test_it_should_extract_return_type_from_return_tag(): void
+    {
+        $parser = DocblockParserFactory::create();
+
+        $code = <<< 'PHP'
+            /**
+             * @return MyDto[]
+             * @return list<MyOtherDto>
+             * @return array<int, ValueObject>
+             * @return array<User>
+             * @return int
+             * @return MyPlainDto
+             */
+        }
+        PHP;
+
+        $phpdoc = $parser->parse($code);
+
+        $db = new Docblock($phpdoc);
+
+        $returnTypes = $db->getReturnTagTypes();
+        self::assertCount(4, $returnTypes);
+        self::assertEquals('MyDto', $returnTypes[0]);
+        self::assertEquals('MyOtherDto', $returnTypes[1]);
+        self::assertEquals('ValueObject', $returnTypes[2]);
+        self::assertEquals('User', $returnTypes[3]);
+    }
+}


### PR DESCRIPTION
This first step is a refactoring to simplify `DocblockResolver` introducing some new support classes 

One thing I noticed during this refactoring is even in case of multiple types defined, like 

```php
/**
* @Assert\Blank
* @var Foo
*/ 
public $foo
``` 

we collect just one. Is that intended? do we want to address it in some way? We could support it using union types 
cc @fain182  @AlessandroMinoccheri? 

