### PR TITLE
Fix FileVisitor issues with wrong class detection

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -247,6 +247,10 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
+        if (FullyQualifiedClassName::isNotAValidFqcn($type->toString())) {
+            return;
+        }
+
         $this->classDescriptionBuilder
             ->addDependency(new ClassDependency($type->toString(), $node->getLine()));
     }
@@ -314,6 +318,10 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
+        if (FullyQualifiedClassName::isNotAValidFqcn($returnType->toString())) {
+            return;
+        }
+
         $this->classDescriptionBuilder
             ->addDependency(new ClassDependency($returnType->toString(), $returnType->getLine()));
     }
@@ -330,6 +338,10 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
+        if (FullyQualifiedClassName::isNotAValidFqcn($nodeName->toString())) {
+            return;
+        }
+
         $this->classDescriptionBuilder
             ->addAttribute($node->name->toString(), $node->getLine());
     }
@@ -343,6 +355,10 @@ class FileVisitor extends NodeVisitorAbstract
         $type = $node->type instanceof NullableType ? $node->type->type : $node->type;
 
         if (!($type instanceof Node\Name\FullyQualified)) {
+            return;
+        }
+
+        if (FullyQualifiedClassName::isNotAValidFqcn($type->toString())) {
             return;
         }
 

--- a/src/Analyzer/FullyQualifiedClassName.php
+++ b/src/Analyzer/FullyQualifiedClassName.php
@@ -27,7 +27,7 @@ class FullyQualifiedClassName
 
     public function classMatches(string $pattern): bool
     {
-        if ($this->isNotAValidPattern($pattern)) {
+        if (self::isNotAValidFqcn($pattern)) {
             throw new InvalidPatternException("'$pattern' is not a valid class or namespace pattern. Regex are not allowed, only * and ? wildcard.");
         }
 
@@ -36,7 +36,7 @@ class FullyQualifiedClassName
 
     public function matches(string $pattern): bool
     {
-        if ($this->isNotAValidPattern($pattern)) {
+        if (self::isNotAValidFqcn($pattern)) {
             throw new InvalidPatternException("'$pattern' is not a valid class or namespace pattern. Regex are not allowed, only * and ? wildcard.");
         }
 
@@ -69,12 +69,12 @@ class FullyQualifiedClassName
         return new self(new PatternString($fqcn), new PatternString($namespace), new PatternString($className));
     }
 
-    public function isNotAValidPattern(string $pattern): bool
+    public static function isNotAValidFqcn(string $fqcn): bool
     {
         $validClassNameCharacters = '[a-zA-Z0-9_\x80-\xff]';
         $or = '|';
         $backslash = '\\\\';
 
-        return 0 === preg_match('/^('.$validClassNameCharacters.$or.$backslash.$or.'\*'.$or.'\?)*$/', $pattern);
+        return 0 === preg_match('/^('.$validClassNameCharacters.$or.$backslash.$or.'\*'.$or.'\?)*$/', $fqcn);
     }
 }


### PR DESCRIPTION
It seems the php parser is using phpdocs and deciding that
 something like
/**
 * @return array<int, string|int>
 * / 
 is a class with FQCN `My\Namespace\array<int, string|int>` which then ofc fails to create a FullyQualifiedClassName.