### PR TITLE
Ignore union types in dockblock definitions

### DIFF
--- a/src/Analyzer/DocblockTypesResolver.php
+++ b/src/Analyzer/DocblockTypesResolver.php
@@ -82,7 +82,7 @@ class DocblockTypesResolver extends NodeVisitorAbstract
         $arrayItemType = $docblock->getVarTagTypes();
         $arrayItemType = array_pop($arrayItemType);
 
-        if (null !== $arrayItemType) {
+        if ($this->isTypeClass($arrayItemType)) {
             $node->type = $this->resolveName(new Name($arrayItemType), Stmt\Use_::TYPE_NORMAL);
 
             return;
@@ -129,7 +129,8 @@ class DocblockTypesResolver extends NodeVisitorAbstract
 
             $type = $docblock->getParamTagTypesByName('$'.$param->var->name);
 
-            if (null === $type) {
+            // we ignore any type which is not a class
+            if (!$this->isTypeClass($type)) {
                 continue;
             }
 
@@ -141,7 +142,8 @@ class DocblockTypesResolver extends NodeVisitorAbstract
             $type = $docblock->getReturnTagTypes();
             $type = array_pop($type);
 
-            if (null === $type) {
+            // we ignore any type which is not a class
+            if (!$this->isTypeClass($type)) {
                 return;
             }
 
@@ -215,5 +217,19 @@ class DocblockTypesResolver extends NodeVisitorAbstract
     private function isTypeArray($type): bool
     {
         return null !== $type && isset($type->name) && 'array' === $type->name;
+    }
+
+    /**
+     * @psalm-assert-if-true string $fqcn
+     */
+    private function isTypeClass(?string $fqcn): bool
+    {
+        if (null === $fqcn) {
+            return false;
+        }
+
+        $validFqcn = '/^[a-zA-Z0-9_\x7f-\xff\\\\]*[a-zA-Z0-9_\x7f-\xff]$/';
+
+        return (bool) preg_match($validFqcn, $fqcn);
     }
 }

--- a/tests/Unit/Analyzer/DocblockParserTest.php
+++ b/tests/Unit/Analyzer/DocblockParserTest.php
@@ -23,6 +23,7 @@ class DocblockParserTest extends TestCase
              * @param int $aValue
              * @param MyPlainDto $plainDto
              * @param array<int, int|string> $unionType
+             * @param array<int, array<int, int|string>> $nestedUnionType
              */
         PHP;
 
@@ -36,6 +37,7 @@ class DocblockParserTest extends TestCase
         self::assertEquals('int', $db->getParamTagTypesByName('$aValue'));
         self::assertEquals('MyPlainDto', $db->getParamTagTypesByName('$plainDto'));
         self::assertEquals('(int | string)', $db->getParamTagTypesByName('$unionType'));
+        self::assertEquals('array<int, (int | string)>', $db->getParamTagTypesByName('$nestedUnionType'));
     }
 
     public function test_it_should_extract_return_type_from_return_tag(): void

--- a/tests/Unit/Analyzer/DocblockParserTest.php
+++ b/tests/Unit/Analyzer/DocblockParserTest.php
@@ -22,6 +22,7 @@ class DocblockParserTest extends TestCase
              * @param array<User> $user
              * @param int $aValue
              * @param MyPlainDto $plainDto
+             * @param array<int, int|string> $unionType
              */
         PHP;
 
@@ -34,6 +35,7 @@ class DocblockParserTest extends TestCase
 
         self::assertEquals('int', $db->getParamTagTypesByName('$aValue'));
         self::assertEquals('MyPlainDto', $db->getParamTagTypesByName('$plainDto'));
+        self::assertEquals('(int | string)', $db->getParamTagTypesByName('$unionType'));
     }
 
     public function test_it_should_extract_return_type_from_return_tag(): void
@@ -48,19 +50,21 @@ class DocblockParserTest extends TestCase
              * @return array<User>
              * @return int
              * @return MyPlainDto
+             * @return array<int, int|string>
              */
         PHP;
 
         $db = $parser->parse($code);
 
         $returnTypes = $db->getReturnTagTypes();
-        self::assertCount(6, $returnTypes);
+        self::assertCount(7, $returnTypes);
         self::assertEquals('MyDto', $returnTypes[0]);
         self::assertEquals('MyOtherDto', $returnTypes[1]);
         self::assertEquals('ValueObject', $returnTypes[2]);
         self::assertEquals('User', $returnTypes[3]);
         self::assertEquals('int', $returnTypes[4]);
         self::assertEquals('MyPlainDto', $returnTypes[5]);
+        self::assertEquals('(int | string)', $returnTypes[6]);
     }
 
     public function test_it_should_extract_types_from_var_tag(): void
@@ -75,19 +79,21 @@ class DocblockParserTest extends TestCase
              * @var array<User> $user
              * @var int $aValue
              * @var MyPlainDto $plainDto
+             * @var array<int, int|string> $unionType
              */
         PHP;
 
         $db = $parser->parse($code);
 
         $varTags = $db->getVarTagTypes();
-        self::assertCount(6, $varTags);
+        self::assertCount(7, $varTags);
         self::assertEquals('MyDto', $varTags[0]);
         self::assertEquals('MyOtherDto', $varTags[1]);
         self::assertEquals('ValueObject', $varTags[2]);
         self::assertEquals('User', $varTags[3]);
         self::assertEquals('int', $varTags[4]);
         self::assertEquals('MyPlainDto', $varTags[5]);
+        self::assertEquals('(int | string)', $varTags[6]);
     }
 
     public function test_it_should_extract_doctrine_like_annotations(): void

--- a/tests/Unit/Analyzer/DocblockTypesResolverTest.php
+++ b/tests/Unit/Analyzer/DocblockTypesResolverTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class DocblockTypesResolverTest extends TestCase
 {
-    public function test_it_should_boh(): void
+    public function test_it_should_collect_dependencies_defined_in_docblock(): void
     {
         $parser = new FileParser(
             new NodeTraverser(),
@@ -36,6 +36,13 @@ class DocblockTypesResolverTest extends TestCase
 
         class MyClass
         {
+            /** @var array<int, int|string> */
+            public array $myArray;
+
+            /** @var array<int, User> */
+            public array $users;
+
+
             /**
              * @param MyDto[] $dtoList
              * @param int $var2
@@ -52,19 +59,30 @@ class DocblockTypesResolverTest extends TestCase
             public function myMethod(array $users, array $products, MyOtherClass $other): void
             {
             }
+
+            /**
+             *
+             * @param array<int, int|string> $aParam
+             * @param array<int, User> $users
+             *
+             * @return array<int, int|string>
+             */
+            public function myMethod2(array $aParam, array $users): array
         }
         EOF;
 
-        $parser->parse($code, 'boh');
+        $parser->parse($code, 'src/path/file.php');
 
         $cd = $parser->getClassDescriptions()[0];
         $dep = $cd->getDependencies();
 
-        self::assertCount(5, $cd->getDependencies());
-        self::assertEquals('Application\MyDto', $dep[0]->getFQCN()->toString());
-        self::assertEquals('Domain\ValueObject', $dep[1]->getFQCN()->toString());
-        self::assertEquals('Application\Model\User', $dep[2]->getFQCN()->toString());
-        self::assertEquals('Application\Model\Product', $dep[3]->getFQCN()->toString());
-        self::assertEquals('Domain\Foo\MyOtherClass', $dep[4]->getFQCN()->toString());
+        self::assertCount(7, $cd->getDependencies());
+        self::assertEquals('Application\Model\User', $dep[0]->getFQCN()->toString());
+        self::assertEquals('Application\MyDto', $dep[1]->getFQCN()->toString());
+        self::assertEquals('Domain\ValueObject', $dep[2]->getFQCN()->toString());
+        self::assertEquals('Application\Model\User', $dep[3]->getFQCN()->toString());
+        self::assertEquals('Application\Model\Product', $dep[4]->getFQCN()->toString());
+        self::assertEquals('Domain\Foo\MyOtherClass', $dep[5]->getFQCN()->toString());
+        self::assertEquals('Application\Model\User', $dep[6]->getFQCN()->toString());
     }
 }


### PR DESCRIPTION
This should fix #509. The updated implementation ignores any type defined in docblock which is not a class fqcn

NB: support for union types is still missing we are going to tackle it in separate PR(s) 