### PR TITLE
FileVisitor improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ csfix: ## it launches cs fix
 	PHP_CS_FIXER_IGNORE_ENV=1 bin/php-cs-fixer fix -v
 
 psalm: ## it launches psalm
-	bin/psalm.phar
+	bin/psalm.phar --no-cache
 
 build: ## it launches all the build
 	composer install

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -247,10 +247,6 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
-        if ($this->isBuiltInType($type->toString())) {
-            return;
-        }
-
         $this->classDescriptionBuilder
             ->addDependency(new ClassDependency($type->toString(), $node->getLine()));
     }
@@ -350,38 +346,7 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
-        if ($type->isSpecialClassName()) {
-            return;
-        }
-
-        if ($this->isBuiltInType($type->toString())) {
-            return;
-        }
-
         $this->classDescriptionBuilder
             ->addDependency(new ClassDependency($type->toString(), $node->getLine()));
-    }
-
-    private function isBuiltInType(string $typeName): bool
-    {
-        $builtInTypes = [
-            'bool',
-            'int',
-            'float',
-            'string',
-            'array',
-            'object',
-            'resource',
-            'never',
-            'void',
-            'false',
-            'true',
-            'null',
-            'callable',
-            'mixed',
-            'iterable',
-        ];
-
-        return \in_array($typeName, $builtInTypes);
     }
 }

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -50,14 +50,19 @@ class FileVisitor extends NodeVisitorAbstract
         // handles code lik $a instanceof MyClass
         $this->handleInstanceOf($node);
 
+        // handles code like $a = new MyClass();
         $this->handleNewExpression($node);
 
+        // handles code like public MyClass $myClass;
         $this->handleTypedProperty($node);
 
+        // handles docblock like /** @var MyClass $myClass */
         $this->handleDocComment($node);
 
+        // handles code like public function myMethod(MyClass $myClass) {}
         $this->handleParamDependency($node);
 
+        // handles code like public function myMethod(): MyClass {}
         $this->handleReturnTypeDependency($node);
 
         // handles attribute definition like #[MyAttribute]

--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -185,10 +185,6 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
-        if ($node->class->isSpecialClassName()) {
-            return;
-        }
-
         $this->classDescriptionBuilder
             ->addDependency(new ClassDependency($node->class->toString(), $node->getLine()));
     }
@@ -200,10 +196,6 @@ class FileVisitor extends NodeVisitorAbstract
         }
 
         if (!($node->class instanceof Node\Name\FullyQualified)) {
-            return;
-        }
-
-        if ($node->class->isSpecialClassName()) {
             return;
         }
 
@@ -221,10 +213,6 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
-        if ($node->class->isSpecialClassName()) {
-            return;
-        }
-
         $this->classDescriptionBuilder
             ->addDependency(new ClassDependency($node->class->toString(), $node->getLine()));
     }
@@ -236,10 +224,6 @@ class FileVisitor extends NodeVisitorAbstract
         }
 
         if (!($node->class instanceof Node\Name\FullyQualified)) {
-            return;
-        }
-
-        if ($node->class->isSpecialClassName()) {
             return;
         }
 

--- a/tests/Unit/Analyzer/FileParser/CanParseClassPropertiesTest.php
+++ b/tests/Unit/Analyzer/FileParser/CanParseClassPropertiesTest.php
@@ -51,6 +51,10 @@ class CanParseClassPropertiesTest extends TestCase
         class ApplicationLevelDto
         {
             public ?NotBlank $foo;
+
+            public ?string $bar;
+
+            public self $baz;
         }
         EOF;
 
@@ -59,12 +63,11 @@ class CanParseClassPropertiesTest extends TestCase
 
         $cd = $fp->getClassDescriptions();
 
-        $violations = new Violations();
+        $cd = $fp->getClassDescriptions();
+        $dep = $cd[0]->getDependencies();
 
-        $notHaveDependencyOutsideNamespace = new DependsOnlyOnTheseNamespaces(['MyProject\AppBundle\Application']);
-        $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
-
-        self::assertCount(1, $violations);
+        self::assertCount(1, $dep);
+        self::assertEquals('Symfony\Component\Validator\Constraints\NotBlank', $dep[0]->getFQCN()->toString());
     }
 
     public function test_it_parse_scalar_typed_property(): void
@@ -87,13 +90,9 @@ class CanParseClassPropertiesTest extends TestCase
         $fp->parse($code, 'relativePathName');
 
         $cd = $fp->getClassDescriptions();
+        $dep = $cd[0]->getDependencies();
 
-        $violations = new Violations();
-
-        $notHaveDependencyOutsideNamespace = new NotHaveDependencyOutsideNamespace('MyProject\AppBundle\Application');
-        $notHaveDependencyOutsideNamespace->evaluate($cd[0], $violations, 'we want to add this rule for our software');
-
-        self::assertCount(0, $violations);
+        self::assertCount(0, $dep);
     }
 
     public function test_it_parse_nullable_scalar_typed_property(): void
@@ -137,9 +136,11 @@ class CanParseClassPropertiesTest extends TestCase
         class MyClass
         {
             private array $field1;
-            public function __construct(array $field1)
+            public function __construct(array $field1, int $field2, self $field3)
             {
                 $this->field1 = $field1;
+                $this->field2 = $field2;
+                $this->field3 = $field3;
             }
         }
         EOF;
@@ -148,12 +149,8 @@ class CanParseClassPropertiesTest extends TestCase
         $fp->parse($code, 'relativePathName');
 
         $cd = $fp->getClassDescriptions();
+        $dep = $cd[0]->getDependencies();
 
-        $violations = new Violations();
-
-        $notHaveDependenciesOutside = new NotHaveDependencyOutsideNamespace('App\Domain');
-        $notHaveDependenciesOutside->evaluate($cd[0], $violations, 'we want to add this rule for our software');
-
-        self::assertCount(0, $violations);
+        self::assertCount(0, $dep);
     }
 }

--- a/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
+++ b/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
@@ -51,6 +51,33 @@ class CanParseClassTest extends TestCase
         self::assertEquals('path/to/class.php', $violations->get(1)->getFilePath());
     }
 
+    public function test_should_parse_instanceof(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+
+        class Foo
+        {
+            public function bar($a, $b)
+            {
+                $is_var = $a instanceof $b;
+
+                $is_myclass = $a instanceof \Foo\Bar\MyClass;
+
+                $is_another = $a instanceof self;
+            }
+        }
+        EOF;
+
+        $fp = FileParserFactory::forPhpVersion(TargetPhpVersion::PHP_7_4);
+        $fp->parse($code, 'relativePathName');
+        $cd = $fp->getClassDescriptions();
+
+        self::assertCount(1, $cd);
+        self::assertCount(1, $cd[0]->getDependencies());
+        self::assertEquals('Foo\Bar\MyClass', $cd[0]->getDependencies()[0]->getFQCN()->toString());
+    }
+
     public function test_should_create_a_class_description(): void
     {
         $code = <<< 'EOF'
@@ -275,6 +302,8 @@ class CanParseClassTest extends TestCase
             {
                 $collection = new Collection($request);
                 $static = StaticClass::foo();
+
+                $self_static = self::foo();
             }
         }
         EOF;


### PR DESCRIPTION
some more refactorings before tackling the @throws tag dependency collection 

1. refactored to avoid nested conditionals
2. preferred checks like `$node->class instanceof Node\Name\FullyQualified` instead of `method_exists($node->class, 'toString')`. This allows to skip checks on parent:: self:: static:: and native types since a `Node\Name\FullyQualified` refers always to a class