### PR TITLE
Remove unnecessary Psalm suppressions from ProgressBarProgress

### DIFF
--- a/src/CLI/Progress/ProgressBarProgress.php
+++ b/src/CLI/Progress/ProgressBarProgress.php
@@ -9,10 +9,6 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * @psalm-suppress UndefinedDocblockClass
- * @psalm-suppress UndefinedClass
- */
 class ProgressBarProgress implements Progress
 {
     /** @var OutputInterface */


### PR DESCRIPTION
Fixes #299

The @psalm-suppress UndefinedDocblockClass and @psalm-suppress UndefinedClass annotations are no longer needed in ProgressBarProgress.php because:

- All imported classes (OutputInterface, ProgressBar, NullOutput) are from symfony/console, which is a required dependency
- CiDetector is from ondram/ci-detector, which is a required dependency
- ClassSet and Progress are from the same project namespace
- All type annotations in docblocks properly reference imported classes

All tests pass successfully after removing these suppressions.