### PR TITLE
Fix Is(Not)Abstract expression so that it does not ignore final classes

### DIFF
--- a/src/Expression/ForClasses/IsAbstract.php
+++ b/src/Expression/ForClasses/IsAbstract.php
@@ -20,7 +20,7 @@ class IsAbstract implements Expression
 
     public function appliesTo(ClassDescription $theClass): bool
     {
-        return !($theClass->isInterface() || $theClass->isTrait() || $theClass->isEnum() || $theClass->isFinal());
+        return !($theClass->isInterface() || $theClass->isTrait() || $theClass->isEnum());
     }
 
     public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void

--- a/src/Expression/ForClasses/IsNotAbstract.php
+++ b/src/Expression/ForClasses/IsNotAbstract.php
@@ -20,7 +20,7 @@ class IsNotAbstract implements Expression
 
     public function appliesTo(ClassDescription $theClass): bool
     {
-        return !($theClass->isInterface() || $theClass->isTrait() || $theClass->isEnum() || $theClass->isFinal());
+        return !($theClass->isInterface() || $theClass->isTrait() || $theClass->isEnum());
     }
 
     public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void

--- a/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
+++ b/tests/Unit/Expressions/ForClasses/IsAbstractTest.php
@@ -95,7 +95,7 @@ class IsAbstractTest extends TestCase
         self::assertFalse($isNotAbstract->appliesTo($classDescription));
     }
 
-    public function test_final_classes_can_not_be_abstract_and_should_be_ignored(): void
+    public function test_final_classes_should_not_be_ignored(): void
     {
         $isAbstract = new IsAbstract();
         $isNotAbstract = new IsNotAbstract();
@@ -106,7 +106,7 @@ class IsAbstractTest extends TestCase
             ->setFinal(true)
             ->build();
 
-        self::assertFalse($isAbstract->appliesTo($classDescription));
-        self::assertFalse($isNotAbstract->appliesTo($classDescription));
+        self::assertTrue($isAbstract->appliesTo($classDescription));
+        self::assertTrue($isNotAbstract->appliesTo($classDescription));
     }
 }


### PR DESCRIPTION
We have this rule in our codebase (and other similar rules too):

```php
    public function __invoke(): ArchRule
    {
        return Rule::allClasses()
            ->that(new RecursivelyExtend(EndToEndTestCase::class))
            ->andThat(new IsNotAbstract())
            ->should(new HaveNameMatching('*EndToEndTest'))
            ->because('all end-to-end tests must be named ending with EndToEndTest')
        ;
    }
```

Basically we want to make sure that all test class names in our testsuite that extend the base `EndToEndTestCase` class that are not abstract classes themselves must end with `EndToEndTest`.

After https://github.com/phparkitect/arkitect/pull/454 this no longer works as the logic early returns in `\Arkitect\Rules\Specs::allSpecsAreMatchedBy` because `\Arkitect\Expression\ForClasses\IsNotAbstract::appliesTo` returns `false` for final classes (and all our test classes are final) and because of that the `\Arkitect\Expression\ForClasses\HaveNameMatching` expression never gets evaluated so no violations are reported.

After this fix `appliesTo` would return `true` and everything would continue to work as it did prior to that https://github.com/phparkitect/arkitect/pull/454 PR. 