### PR TITLE
Remove GitHub Actions integration section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,15 +622,6 @@ $rules[] = Rule::allClasses()
 
 # Integrations
 
-## GitHub Actions
-
-You can easily integrate PHPArkitect into your CI/CD pipeline using the official GitHub Action.
-
-For setup instructions and usage examples, please refer to the official documentation:
-
-- [GitHub Action Repository](https://github.com/phparkitect/arkitect-github-actions) - Complete setup guide and examples
-- [GitHub Marketplace](https://github.com/marketplace/actions/phparkitect-arkitect) - Action listing
-
 ## Laravel
 
 If you plan to use Arkitect with Laravel, [smortexa](https://github.com/smortexa) wrote a nice wrapper with some predefined rules for laravel: https://github.com/smortexa/laravel-arkitect


### PR DESCRIPTION
## Summary
Removed the GitHub Actions integration documentation section from the README.

## Changes
- Deleted the "GitHub Actions" subsection under the "Integrations" section
- Removed references to the official GitHub Action repository and GitHub Marketplace listing

## Rationale
The GitHub Action is no longer actively maintained.

https://claude.ai/code/session_01J8yuP8ycqHucYYDuszTxsX