### PR TITLE
Revert "Fix code style instead of just checking it, in the pull request workflow"

### DIFF
--- a/.github/workflows/cs-fixer.yml
+++ b/.github/workflows/cs-fixer.yml
@@ -3,17 +3,11 @@ name: PHP CS Fixer
 on:
   pull_request:
 
-permissions:
-  contents: write
-
 jobs:
   cs-fixer:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -35,10 +29,4 @@ jobs:
         run: composer install --prefer-dist
 
       - name: Run PHP CS Fixer
-        run: ./bin/php-cs-fixer fix --diff
-
-      - name: Commit CS Fixer fixes
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "style: apply php-cs-fixer changes"
-          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+        run: ./bin/php-cs-fixer check --diff


### PR DESCRIPTION
## Summary
This PR converts the PHP CS Fixer GitHub Actions workflow from an auto-fixing mode that commits changes to a check-only mode that reports violations without modifying code.

## Key Changes
- Removed `permissions.contents: write` - no longer needed since workflow won't commit changes
- Removed custom checkout parameters (`ref` and `token`) - standard checkout is sufficient for read-only operations
- Changed PHP CS Fixer command from `fix --diff` to `check --diff` - validates code style without applying automatic fixes
- Removed the git auto-commit action step - no longer commits style fixes automatically

## Implementation Details
The workflow now operates in a validation-only capacity, reporting any PHP coding standard violations without automatically fixing them. This encourages developers to fix style issues locally before pushing, rather than relying on automated commits. The `--diff` flag is retained to show what violations were found.

https://claude.ai/code/session_01TRNQg795oQmXbu8pXNgYCT