### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/architectural-rules.yml
+++ b/.github/workflows/architectural-rules.yml
@@ -3,6 +3,9 @@ name: Architectural test
 on:
     push:
 
+permissions:
+  contents: read
+
 jobs:
     phparkitect:
         name: PHPArkitect

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/cs-fixer.yml
+++ b/.github/workflows/cs-fixer.yml
@@ -3,6 +3,9 @@ name: PHP CS Fixer
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   cs-fixer:
     runs-on: ubuntu-22.04

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "0 12 * * 0"
   workflow_dispatch:
+
+permissions:
+  contents: write
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR adds explicit `permissions` declarations to GitHub Actions workflows to follow the principle of least privilege and improve security posture.

## Key Changes
- **update-contributors.yml**: Added `contents: write` permission (required for the workflow to commit contributor updates)
- **architectural-rules.yml**: Added `contents: read` permission (required for PHPArkitect to analyze the codebase)
- **build.yml**: Added `contents: read` permission (required for build process to access repository contents)
- **cs-fixer.yml**: Added `contents: read` permission (required for PHP CS Fixer to analyze code)

## Implementation Details
Each workflow now explicitly declares the minimum required permissions needed for its operations. This follows GitHub's security best practices by:
- Preventing workflows from requesting unnecessary permissions by default
- Making permission requirements transparent and auditable
- Reducing the attack surface in case of workflow compromise

https://claude.ai/code/session_01K1TiMQ8Xb3v2TioBaGgdaE