### PR TITLE
Fix composer dependency issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
         "phpspec/prophecy-phpunit": "^2.5",
         "phpunit/phpunit": "^9.6|^10.0|^11.0",
         "roave/security-advisories": "dev-master",
-        "shipmonk/composer-dependency-analyser": "^1.8",
         "symfony/process": "^5.4|^6.0|^7.0|^8.0",
         "symfony/var-dumper": "^5.4|^6.0|^7.0|^8.0"
     },


### PR DESCRIPTION
Using `shipmonk/composer-dependency-analyser` we identified and fixed two dependency issues:

- **Remove unused `symfony/event-dispatcher` from `require`**: no usage was found anywhere in the source code
- **Add `symfony/process` to `require-dev`**: it was used in E2E tests (`RunArkitectBinTest`) but not declared as a dependency (shadow dependency)

