### PR TITLE
Restore support for phpdoc-parser ^1.2 alongside ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*",
         "nikic/php-parser": "~5",
         "ondram/ci-detector": "^4.2",
-        "phpstan/phpdoc-parser": "^2.0",
+        "phpstan/phpdoc-parser": "^1.2|^2.0",
         "symfony/console": "^5.4|^6.0|^7.0|^8.0",
         "symfony/finder": "^5.4|^6.0|^7.0|^8.0",
         "webmozart/assert": "^1.12|^2.0"


### PR DESCRIPTION
The DocblockParserFactory already handles both versions via a runtime
class_exists(ParserConfig::class) check. This commit simply broadens
the composer constraint to allow installations with either v1.2+ or v2.x.

https://claude.ai/code/session_01YZZi4mYn7d99QqxoRTUyvn