### PR TITLE
fix(phar): keep Symfony polyfills out of the scoper prefix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,8 @@ jobs:
       matrix:
         php-versions: [ '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
     steps:
+      - uses: actions/checkout@v6
+
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -118,6 +120,12 @@ jobs:
 
       - name: "Smoke test phar"
         run: php ./phparkitect-${{ github.sha }}.phar
+
+      - name: "End-to-end test phar: run check on fixture"
+        run: |
+          php ./phparkitect-${{ github.sha }}.phar check \
+            --config tests/E2E/_fixtures/autoload/phparkitect.php \
+            --autoload tests/E2E/_fixtures/autoload/autoload.php
 
   publish_phar:
     needs: [build, smoke-test-phar]

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -2,6 +2,28 @@
 
 declare(strict_types=1);
 
+// Polyfill stubs (Resources/stubs/*.php) declare classes like \Normalizer,
+// \JsonException, \Attribute in the global namespace and bootstrap files
+// (bootstrap*.php) declare global functions like \normalizer_normalize().
+// Both have no `namespace` declaration, so php-scoper would otherwise add
+// one. They must remain global because callers like
+// Symfony\Component\String\AbstractUnicodeString reference them as
+// \Normalizer / \normalizer_normalize() at runtime. exclude-namespaces
+// does not catch these files since they declare no namespace, so list
+// them explicitly.
+$polyfillGlobalFiles = array_map(
+    static fn (SplFileInfo $file): string => $file->getPathname(),
+    iterator_to_array(
+        new RegexIterator(
+            new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator(__DIR__.'/vendor/symfony', RecursiveDirectoryIterator::SKIP_DOTS),
+            ),
+            '#vendor/symfony/polyfill-[^/]+/(Resources/stubs/.+|bootstrap[^/]*)\.php$#',
+        ),
+        false,
+    ),
+);
+
 return [
     'prefix' => '_PhpArkitect',
 
@@ -9,8 +31,15 @@ return [
     'expose-global-classes' => true,
     'expose-global-functions' => true,
 
+    'exclude-files' => $polyfillGlobalFiles,
+
     'exclude-namespaces' => [
         'Arkitect',
         'Composer',
+        // The polyfill packages register their global functions
+        // (normalizer_normalize, ...) via composer's files autoloader.
+        // Scoping them moves the functions into _PhpArkitect\, which
+        // breaks callers that invoke them through the global namespace.
+        'Symfony\\Polyfill',
     ],
 ];


### PR DESCRIPTION
## Summary

- The PHAR build switched to php-scoper in `f0e7bba` and started shipping a broken PHAR: running `check` fails with `Class "Normalizer" not found` (or `Call to undefined function normalizer_is_normalized()` once the class lookup is fixed).
- Root cause: the php-scoper bundled in `bin/box.phar` (Box 3.16, Feb 2022) wraps the Symfony polyfill stubs (`Resources/stubs/*.php`) and bootstraps (`bootstrap*.php`) in `namespace _PhpArkitect;` even with `expose-global-classes` / `expose-global-functions` enabled, so `Symfony\Component\String\AbstractUnicodeString` can no longer resolve `\Normalizer` / `\normalizer_normalize()` inside the PHAR.
- Add `Symfony\Polyfill` to `exclude-namespaces` for the implementation files, and list the stubs + bootstraps via `exclude-files` (they declare no namespace, so `exclude-namespaces` does not catch them).
- Add an end-to-end smoke test that runs `phparkitect.phar check` against a fixture (default progress bar + `--autoload`) so any future regression in PHAR scoping fails CI instead of slipping through the help-only smoke test.

## Test plan

- [x] Reproduce locally with the CI build environment (`composer config platform.php 8.0 && composer update --no-dev`) — confirmed the failing test commit reproduces the regression and the released `0.8.0` PHAR passes it.
- [x] Rebuild the PHAR with the fix and run `check` end-to-end on the autoload fixture and on `configMvc.php` (violation rendering also exercises the polyfill path) — both work.
- [x] Full unit test suite still green (405/405 on PHP 8.5).
- [ ] CI green on the matrix (PHP 8.0 → 8.5) for both `phar` and `smoke-test-phar` jobs.