### PR TITLE
Remove redundant ext-json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "nikic/php-parser": "~5",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^1.2|^2.0",


### PR DESCRIPTION
Since PHP 8.0, ext-json is bundled into the PHP core and cannot be disabled. Given that the project already requires php ^8.0, declaring ext-json as a separate dependency is unnecessary.

Fixes #612