### PR TITLE
ci: revert architectural-rules to composer install

### DIFF
--- a/.github/workflows/architectural-rules.yml
+++ b/.github/workflows/architectural-rules.yml
@@ -20,11 +20,12 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.2'
+                  tools: composer:v2.2
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Download phparkitect
-              run: curl -LS https://github.com/phparkitect/arkitect/releases/latest/download/phparkitect.phar -o phparkitect.phar
+            - name: Install dependencies
+              run: composer install --prefer-dist
 
             - name: PHPArkitect
-              run: php phparkitect.phar check
+              run: php bin-stub/phparkitect check


### PR DESCRIPTION
## Summary
- Reverts f37a022, which switched the self-architectural-test from `composer install + bin-stub/phparkitect` to downloading the released PHAR.
- That switch is incompatible with the v1.0 PHAR by design: running phparkitect as a PHAR requires `--autoload`, but phparkitect's own `vendor/autoload.php` registers `Arkitect\\: src/` and shadows the PHAR's internal scoped classes — typehints resolve to the unscoped `Symfony\…\OutputInterface` while runtime instances are `_PhpArkitect\Symfony\…\StreamOutput`, and `check` blows up.
- See the run that surfaced this: https://github.com/phparkitect/arkitect/actions/runs/24964604016/job/73097115614
- Going via composer install runs everything in the same (unscoped) namespace, so there's no conflict — same approach we used before f37a022.
