### PR TITLE
added Not have attribute expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,13 +518,18 @@ $rules[] = Rule::allClasses()
     ->because('we don\'t want to enforce immutability');
 ```
 
-### Has an attribute (requires PHP >= 8.0)
+### Has an attribute / Does not have an attribute
 
 ```php
 $rules[] = Rule::allClasses()
     ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
     ->should(new HaveAttribute('Symfony\Component\HttpKernel\Attribute\AsController'))
     ->because('it configures the service container');
+
+$rules[] = Rule::allClasses()
+    ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+    ->should(new NotHaveAttribute('Deprecated'))
+    ->because('deprecated controllers should be removed, not kept in production');
 ```
 
 You can also define components and ensure that a component:

--- a/src/Expression/ForClasses/NotHaveAttribute.php
+++ b/src/Expression/ForClasses/NotHaveAttribute.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Expression\ForClasses;
+
+use Arkitect\Analyzer\ClassDescription;
+use Arkitect\Expression\Description;
+use Arkitect\Expression\Expression;
+use Arkitect\Rules\Violation;
+use Arkitect\Rules\ViolationMessage;
+use Arkitect\Rules\Violations;
+
+final class NotHaveAttribute implements Expression
+{
+    /** @var string */
+    private $attribute;
+
+    public function __construct(string $attribute)
+    {
+        $this->attribute = $attribute;
+    }
+
+    public function describe(ClassDescription $theClass, string $because): Description
+    {
+        return new Description("should not have the attribute {$this->attribute}", $because);
+    }
+
+    public function evaluate(ClassDescription $theClass, Violations $violations, string $because): void
+    {
+        if (!$theClass->hasAttribute($this->attribute)) {
+            return;
+        }
+
+        $violations->add(
+            Violation::create(
+                $theClass->getFQCN(),
+                ViolationMessage::selfExplanatory($this->describe($theClass, $because)),
+                $theClass->getFilePath()
+            )
+        );
+    }
+}

--- a/tests/Integration/CheckClassNotHaveAttributeTest.php
+++ b/tests/Integration/CheckClassNotHaveAttributeTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Integration\PHPUnit;
+
+use Arkitect\Expression\ForClasses\HaveNameMatching;
+use Arkitect\Expression\ForClasses\NotHaveAttribute;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+use Arkitect\Tests\Utils\TestRunner;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+final class CheckClassNotHaveAttributeTest extends TestCase
+{
+    public function test_controllers_should_not_have_deprecated_attribute(): void
+    {
+        $dir = vfsStream::setup('root', null, $this->createDirStructure())->url();
+
+        $runner = TestRunner::create('8.4');
+
+        $rule = Rule::allClasses()
+            ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+            ->should(new NotHaveAttribute('Deprecated'))
+            ->because('deprecated controllers should be removed, not kept in production');
+
+        $runner->run($dir, $rule);
+
+        self::assertCount(1, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
+
+        self::assertEquals('App\Controller\LegacyController', $runner->getViolations()->get(0)->getFqcn());
+    }
+
+    public function test_models_without_prohibited_attribute_pass(): void
+    {
+        $dir = vfsStream::setup('root', null, $this->createDirStructure())->url();
+
+        $runner = TestRunner::create('8.4');
+
+        $rule = Rule::allClasses()
+            ->that(new HaveNameMatching('*Model'))
+            ->should(new NotHaveAttribute('Deprecated'))
+            ->because('deprecated models should be removed');
+
+        $runner->run($dir, $rule);
+
+        self::assertCount(0, $runner->getViolations());
+        self::assertCount(0, $runner->getParsingErrors());
+    }
+
+    public function createDirStructure(): array
+    {
+        return [
+            'Controller' => [
+                'ProductsController.php' => <<<'EOT'
+                    <?php
+
+                    namespace App\Controller;
+
+                    #[\AsController]
+                    class ProductsController
+                    {
+                    }
+                    EOT,
+                'LegacyController.php' => <<<'EOT'
+                    <?php
+
+                    namespace App\Controller;
+
+                    #[\Deprecated]
+                    #[\AsController]
+                    class LegacyController
+                    {
+                    }
+                    EOT,
+            ],
+            'Model' => [
+                'UserModel.php' => <<<'EOT'
+                    <?php
+
+                    namespace App\Model;
+
+                    #[\Entity]
+                    class UserModel
+                    {
+                    }
+                    EOT,
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Expressions/ForClasses/NotHaveAttributeTest.php
+++ b/tests/Unit/Expressions/ForClasses/NotHaveAttributeTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Expressions\ForClasses;
+
+use Arkitect\Analyzer\ClassDescriptionBuilder;
+use Arkitect\Expression\ForClasses\NotHaveAttribute;
+use Arkitect\Rules\Violations;
+use PHPUnit\Framework\TestCase;
+
+class NotHaveAttributeTest extends TestCase
+{
+    public function test_it_should_return_no_violation_if_class_does_not_have_attribute(): void
+    {
+        $expression = new NotHaveAttribute('myAttribute');
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland\Myclass')
+            ->build();
+
+        $because = 'we want to add this rule for our software';
+        $violations = new Violations();
+        $expression->evaluate($classDescription, $violations, $because);
+
+        self::assertEquals(0, $violations->count());
+    }
+
+    public function test_it_should_return_no_violation_if_class_has_different_attribute(): void
+    {
+        $expression = new NotHaveAttribute('myAttribute');
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland\Myclass')
+            ->addAttribute('anotherAttribute', 1)
+            ->build();
+
+        $because = 'we want to add this rule for our software';
+        $violations = new Violations();
+        $expression->evaluate($classDescription, $violations, $because);
+
+        self::assertEquals(0, $violations->count());
+    }
+
+    public function test_it_should_return_violation_if_class_has_attribute(): void
+    {
+        $expression = new NotHaveAttribute('myAttribute');
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland\Myclass')
+            ->addAttribute('myAttribute', 1)
+            ->build();
+
+        $because = 'we want to add this rule for our software';
+        $violations = new Violations();
+        $expression->evaluate($classDescription, $violations, $because);
+
+        self::assertEquals(1, $violations->count());
+        self::assertEquals(
+            'should not have the attribute myAttribute because we want to add this rule for our software',
+            $expression->describe($classDescription, $because)->toString()
+        );
+    }
+
+    public function test_it_should_return_correct_description_without_because(): void
+    {
+        $expression = new NotHaveAttribute('myAttribute');
+
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setFilePath('src/Foo.php')
+            ->setClassName('HappyIsland\Myclass')
+            ->build();
+
+        self::assertEquals(
+            'should not have the attribute myAttribute',
+            $expression->describe($classDescription, '')->toString()
+        );
+    }
+}


### PR DESCRIPTION
Summary
Adds NotHaveAttribute, the missing negative counterpart to HaveAttribute, following the same pattern used by every other expression pair in the codebase (HaveTrait/NotHaveTrait, Implement/NotImplement, etc.).

This allows rules like:
```
php$rules[] = Rule::allClasses()
    ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
    ->should(new NotHaveAttribute('Deprecated'))
    ->because('deprecated controllers should be removed, not kept in production');
```


Notes
No breaking changes. No new dependencies.