### PR TITLE
Prevent autoloader invocation when checking for PHP core classes

### DIFF
--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -203,12 +203,7 @@ class ClassDescriptionBuilder
 
     private function checkIsPhpCoreClass(string $className): bool
     {
-        // Use $autoload=false to avoid triggering the Composer autoloader for arbitrary class
-        // names encountered during file parsing. PHP built-in classes are always pre-loaded and
-        // do not need autoloading. Triggering the autoloader here can cause side-effects: if a
-        // class's file fails to load (e.g. because a required PHP extension is missing), PHP
-        // throws an Error that propagates out of class_exists() and gets mistakenly treated as
-        // a parsing error by FileParser. See: https://github.com/phparkitect/arkitect/issues/XXX
+        // PHP built-ins are always pre-loaded; skip autoloading to avoid side-effects.
         if (!class_exists($className, false) && !interface_exists($className, false) && !trait_exists($className, false) && !enum_exists($className, false)) {
             return false;
         }

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -205,11 +205,7 @@ class ClassDescriptionBuilder
     {
         // PHP built-ins are always pre-loaded; skip autoloading to avoid side-effects.
         // See: https://github.com/Sylius/Sylius/pull/19003
-        // enum_exists() is PHP 8.1+; enums cannot exist on 8.0 so we skip the check there.
-        if (!class_exists($className, false)
-            && !interface_exists($className, false)
-            && !trait_exists($className, false)
-            && (\PHP_VERSION_ID < 80100 || !enum_exists($className, false))) {
+        if (!$this->isSymbolLoaded($className)) {
             return false;
         }
 
@@ -217,5 +213,24 @@ class ClassDescriptionBuilder
         $reflection = new \ReflectionClass($className);
 
         return $reflection->isInternal();
+    }
+
+    private function isSymbolLoaded(string $className): bool
+    {
+        if (class_exists($className, false)) {
+            return true;
+        }
+        if (interface_exists($className, false)) {
+            return true;
+        }
+        if (trait_exists($className, false)) {
+            return true;
+        }
+        // enum_exists() is PHP 8.1+; enums cannot exist on 8.0 so we skip the check there.
+        if (\PHP_VERSION_ID >= 80100 && enum_exists($className, false)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -205,7 +205,11 @@ class ClassDescriptionBuilder
     {
         // PHP built-ins are always pre-loaded; skip autoloading to avoid side-effects.
         // See: https://github.com/Sylius/Sylius/pull/19003
-        if (!class_exists($className, false) && !interface_exists($className, false) && !trait_exists($className, false) && !enum_exists($className, false)) {
+        // enum_exists() is PHP 8.1+; enums cannot exist on 8.0 so we skip the check there.
+        if (!class_exists($className, false)
+            && !interface_exists($className, false)
+            && !trait_exists($className, false)
+            && (\PHP_VERSION_ID < 80100 || !enum_exists($className, false))) {
             return false;
         }
 

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -203,7 +203,13 @@ class ClassDescriptionBuilder
 
     private function checkIsPhpCoreClass(string $className): bool
     {
-        if (!class_exists($className) && !interface_exists($className) && !trait_exists($className) && !enum_exists($className)) {
+        // Use $autoload=false to avoid triggering the Composer autoloader for arbitrary class
+        // names encountered during file parsing. PHP built-in classes are always pre-loaded and
+        // do not need autoloading. Triggering the autoloader here can cause side-effects: if a
+        // class's file fails to load (e.g. because a required PHP extension is missing), PHP
+        // throws an Error that propagates out of class_exists() and gets mistakenly treated as
+        // a parsing error by FileParser. See: https://github.com/phparkitect/arkitect/issues/XXX
+        if (!class_exists($className, false) && !interface_exists($className, false) && !trait_exists($className, false) && !enum_exists($className, false)) {
             return false;
         }
 

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -204,6 +204,7 @@ class ClassDescriptionBuilder
     private function checkIsPhpCoreClass(string $className): bool
     {
         // PHP built-ins are always pre-loaded; skip autoloading to avoid side-effects.
+        // See: https://github.com/Sylius/Sylius/pull/19003
         if (!class_exists($className, false) && !interface_exists($className, false) && !trait_exists($className, false) && !enum_exists($className, false)) {
             return false;
         }

--- a/src/Analyzer/ClassDescriptionBuilder.php
+++ b/src/Analyzer/ClassDescriptionBuilder.php
@@ -203,8 +203,6 @@ class ClassDescriptionBuilder
 
     private function checkIsPhpCoreClass(string $className): bool
     {
-        // PHP built-ins are always pre-loaded; skip autoloading to avoid side-effects.
-        // See: https://github.com/Sylius/Sylius/pull/19003
         if (!$this->isSymbolLoaded($className)) {
             return false;
         }
@@ -217,6 +215,8 @@ class ClassDescriptionBuilder
 
     private function isSymbolLoaded(string $className): bool
     {
+        // PHP built-ins are always pre-loaded; skip autoloading to avoid side-effects.
+        // See: https://github.com/Sylius/Sylius/pull/19003
         if (class_exists($className, false)) {
             return true;
         }

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -280,4 +280,42 @@ class ClassDescriptionBuilderTest extends TestCase
         self::assertCount(1, $classDescription->getDependencies());
         self::assertEquals('App\MyClass', $classDescription->getDependencies()[0]->getFQCN()->toString());
     }
+
+    /**
+     * Regression test: addDependency() must NOT trigger the Composer autoloader.
+     *
+     * When phparkitect parses a file that references a class from an optional/uninstalled
+     * package (e.g. Doctrine\ODM\MongoDB\DocumentRepository in a Symfony services config),
+     * calling class_exists($className, $autoload=true) can cause the autoloader to load the
+     * class file. If that file in turn requires a PHP extension that is not available (e.g.
+     * the mongodb extension), PHP throws an Error which propagates out of class_exists() and
+     * gets caught by FileParser's \Throwable handler – turning a perfectly valid PHP file into
+     * a spurious "parsing error" that fails the check with exit code 1.
+     *
+     * The fix is to always pass $autoload=false: PHP built-in classes are pre-loaded and never
+     * need autoloading; any class that is not already loaded cannot be a PHP internal class.
+     */
+    public function test_adding_dependency_on_unloaded_optional_vendor_class_does_not_throw(): void
+    {
+        // This FQCN simulates a class from an optional package (e.g. Doctrine MongoDB ODM)
+        // that is NOT loaded in the current PHP process. If class_exists() is called with
+        // $autoload=true this could trigger the Composer autoloader and potentially throw.
+        $unloadedVendorClass = 'Doctrine\ODM\MongoDB\DocumentRepository';
+
+        // Pre-condition: the class must not be loaded already for this test to be meaningful.
+        self::assertFalse(class_exists($unloadedVendorClass, false), sprintf(
+            'Pre-condition failed: %s should not be loaded in the current process.',
+            $unloadedVendorClass,
+        ));
+
+        // This must not throw and must treat the class as a user-defined dependency.
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setFilePath('src/Foo.php')
+            ->setClassName('MyRepository')
+            ->addDependency(new ClassDependency($unloadedVendorClass, 10))
+            ->build();
+
+        self::assertCount(1, $classDescription->getDependencies());
+        self::assertEquals($unloadedVendorClass, $classDescription->getDependencies()[0]->getFQCN()->toString());
+    }
 }

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -287,7 +287,7 @@ class ClassDescriptionBuilderTest extends TestCase
         // a class whose required extension is absent, which FileParser catches as a parsing error.
         $unloadedVendorClass = 'Doctrine\ODM\MongoDB\DocumentRepository';
 
-        self::assertFalse(class_exists($unloadedVendorClass, false), sprintf(
+        self::assertFalse(class_exists($unloadedVendorClass, false), \sprintf(
             'Pre-condition failed: %s should not be loaded in the current process.',
             $unloadedVendorClass,
         ));

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Arkitect\Tests\Unit\Analyzer;
 
+// Defined at file scope so trait_exists(__NAMESPACE__.'\UserTestTrait', false) === true
+// without triggering the autoloader, exercising that branch of isSymbolLoaded().
+trait UserTestTrait
+{
+}
+
 use Arkitect\Analyzer\ClassDependency;
 use Arkitect\Analyzer\ClassDescription;
 use Arkitect\Analyzer\ClassDescriptionBuilder;
@@ -300,5 +306,30 @@ class ClassDescriptionBuilderTest extends TestCase
 
         self::assertCount(1, $classDescription->getDependencies());
         self::assertEquals($unloadedVendorClass, $classDescription->getDependencies()[0]->getFQCN()->toString());
+    }
+
+    public function test_it_should_filter_php_core_interfaces(): void
+    {
+        // Countable is a PHP built-in interface; it must be treated as a core symbol and filtered.
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setFilePath('src/Foo.php')
+            ->setClassName('MyClass')
+            ->addDependency(new ClassDependency(\Countable::class, 10))
+            ->build();
+
+        self::assertCount(0, $classDescription->getDependencies());
+    }
+
+    public function test_it_should_not_filter_already_loaded_user_traits(): void
+    {
+        // UserTestTrait is defined in this file; trait_exists($name, false) returns true,
+        // but ReflectionClass::isInternal() returns false, so it must NOT be filtered.
+        $classDescription = (new ClassDescriptionBuilder())
+            ->setFilePath('src/Foo.php')
+            ->setClassName('MyClass')
+            ->addDependency(new ClassDependency(UserTestTrait::class, 10))
+            ->build();
+
+        self::assertCount(1, $classDescription->getDependencies());
     }
 }

--- a/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
+++ b/tests/Unit/Analyzer/ClassDescriptionBuilderTest.php
@@ -281,34 +281,17 @@ class ClassDescriptionBuilderTest extends TestCase
         self::assertEquals('App\MyClass', $classDescription->getDependencies()[0]->getFQCN()->toString());
     }
 
-    /**
-     * Regression test: addDependency() must NOT trigger the Composer autoloader.
-     *
-     * When phparkitect parses a file that references a class from an optional/uninstalled
-     * package (e.g. Doctrine\ODM\MongoDB\DocumentRepository in a Symfony services config),
-     * calling class_exists($className, $autoload=true) can cause the autoloader to load the
-     * class file. If that file in turn requires a PHP extension that is not available (e.g.
-     * the mongodb extension), PHP throws an Error which propagates out of class_exists() and
-     * gets caught by FileParser's \Throwable handler – turning a perfectly valid PHP file into
-     * a spurious "parsing error" that fails the check with exit code 1.
-     *
-     * The fix is to always pass $autoload=false: PHP built-in classes are pre-loaded and never
-     * need autoloading; any class that is not already loaded cannot be a PHP internal class.
-     */
-    public function test_adding_dependency_on_unloaded_optional_vendor_class_does_not_throw(): void
+    public function test_adding_dependency_on_unloaded_vendor_class_does_not_trigger_autoloader(): void
     {
-        // This FQCN simulates a class from an optional package (e.g. Doctrine MongoDB ODM)
-        // that is NOT loaded in the current PHP process. If class_exists() is called with
-        // $autoload=true this could trigger the Composer autoloader and potentially throw.
+        // Regression: class_exists($name, true) can cause the autoloader to throw when loading
+        // a class whose required extension is absent, which FileParser catches as a parsing error.
         $unloadedVendorClass = 'Doctrine\ODM\MongoDB\DocumentRepository';
 
-        // Pre-condition: the class must not be loaded already for this test to be meaningful.
         self::assertFalse(class_exists($unloadedVendorClass, false), sprintf(
             'Pre-condition failed: %s should not be loaded in the current process.',
             $unloadedVendorClass,
         ));
 
-        // This must not throw and must treat the class as a user-defined dependency.
         $classDescription = (new ClassDescriptionBuilder())
             ->setFilePath('src/Foo.php')
             ->setClassName('MyRepository')


### PR DESCRIPTION
## Summary

Fixes a bug where `checkIsPhpCoreClass()` could trigger the Composer autoloader during file parsing, causing a spurious "parsing error" and exit code 1 on valid PHP files.

## How we found it

Reported via [Sylius/Sylius#19003](https://github.com/Sylius/Sylius/pull/19003), where upgrading phparkitect from `^0.8` to `^1.0` broke the architectural check with:

```
❌ found parsing errors in these files:
Class "Doctrine\ODM\MongoDB\DocumentRepository" not found in file: TaxonomyBundle/Resources/config/services/integrations/doctrine/mongodb-odm.php
```

The file is a perfectly valid Symfony DI config. The error was triggered because phparkitect's own process called `class_exists('Doctrine\ODM\MongoDB\DocumentRepository', true)` while analysing it, which invoked the autoloader. Since the `mongodb` PHP extension was not installed in that CI environment, loading the class file threw a PHP `Error` that propagated out of `class_exists()` and was caught by `FileParser`'s `\Throwable` handler — turning a valid file into a parsing error.

## Fix

Pass `$autoload = false` to all `*_exists()` calls in `checkIsPhpCoreClass()`. PHP built-in classes are always pre-loaded; if a symbol is not already present in the process it cannot be a PHP internal class, so triggering the autoloader is both unnecessary and harmful.

https://claude.ai/code/session_01A9BJtoBs8od2HvUya66nq2