### PR TITLE
Replace property docblocks with native typed properties

### DIFF
--- a/src/CLI/Command/DebugExpression.php
+++ b/src/CLI/Command/DebugExpression.php
@@ -17,13 +17,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DebugExpression extends Command
 {
-    /** @var string|null */
-    public static $defaultDescription = <<< 'EOT'
+    public static ?string $defaultDescription = <<< 'EOT'
 Check which classes respect an expression
 EOT;
 
-    /** @var string */
-    public static $help = <<< 'EOT'
+    public static string $help = <<< 'EOT'
 Check which classes respect an expression
 EOT;
 

--- a/src/CLI/Command/DebugExpression.php
+++ b/src/CLI/Command/DebugExpression.php
@@ -17,7 +17,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DebugExpression extends Command
 {
-    public static ?string $defaultDescription = <<< 'EOT'
+    /** @var string|null */
+    public static $defaultDescription = <<< 'EOT'
 Check which classes respect an expression
 EOT;
 

--- a/src/CLI/Command/Init.php
+++ b/src/CLI/Command/Init.php
@@ -11,7 +11,8 @@ use Webmozart\Assert\Assert;
 
 class Init extends Command
 {
-    public static ?string $defaultDescription = <<< 'EOT'
+    /** @var string|null */
+    public static $defaultDescription = <<< 'EOT'
 Creates a new phparkitect.php file
 EOT;
 

--- a/src/CLI/Command/Init.php
+++ b/src/CLI/Command/Init.php
@@ -11,13 +11,11 @@ use Webmozart\Assert\Assert;
 
 class Init extends Command
 {
-    /** @var string|null */
-    public static $defaultDescription = <<< 'EOT'
+    public static ?string $defaultDescription = <<< 'EOT'
 Creates a new phparkitect.php file
 EOT;
 
-    /** @var string */
-    public static $help = <<< 'EOT'
+    public static string $help = <<< 'EOT'
 This command creates a new phparkitect.php in the current directory
 You can customize the directory where the file is created specifying <comment>-d /dest/path</comment>
 EOT;

--- a/src/CLI/Progress/DebugProgress.php
+++ b/src/CLI/Progress/DebugProgress.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DebugProgress implements Progress
 {
-    private $output;
+    private OutputInterface $output;
 
     public function __construct(OutputInterface $output)
     {

--- a/src/CLI/Progress/ProgressBarProgress.php
+++ b/src/CLI/Progress/ProgressBarProgress.php
@@ -11,11 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ProgressBarProgress implements Progress
 {
-    /** @var OutputInterface */
-    private $output;
+    private OutputInterface $output;
 
-    /** @var ProgressBar */
-    private $progress;
+    private ProgressBar $progress;
 
     public function __construct(OutputInterface $output)
     {

--- a/src/Expression/Description.php
+++ b/src/Expression/Description.php
@@ -6,8 +6,7 @@ namespace Arkitect\Expression;
 
 class Description
 {
-    /** @var string */
-    private $description;
+    private string $description;
 
     public function __construct(string $description, string $because)
     {

--- a/src/Expression/ForClasses/ContainDocBlockLike.php
+++ b/src/Expression/ForClasses/ContainDocBlockLike.php
@@ -13,8 +13,7 @@ use Arkitect\Rules\Violations;
 
 class ContainDocBlockLike implements Expression
 {
-    /** @var string */
-    private $docBlock;
+    private string $docBlock;
 
     public function __construct(string $docBlock)
     {

--- a/src/Expression/ForClasses/HaveAttribute.php
+++ b/src/Expression/ForClasses/HaveAttribute.php
@@ -12,8 +12,7 @@ use Arkitect\Rules\Violations;
 
 final class HaveAttribute implements Expression
 {
-    /** @var string */
-    private $attribute;
+    private string $attribute;
 
     public function __construct(string $attribute)
     {

--- a/src/Expression/ForClasses/HaveNameMatching.php
+++ b/src/Expression/ForClasses/HaveNameMatching.php
@@ -14,8 +14,7 @@ use Arkitect\Rules\Violations;
 
 class HaveNameMatching implements Expression
 {
-    /** @var string */
-    private $name;
+    private string $name;
 
     public function __construct(string $name)
     {

--- a/src/Expression/ForClasses/HaveTrait.php
+++ b/src/Expression/ForClasses/HaveTrait.php
@@ -12,8 +12,7 @@ use Arkitect\Rules\Violations;
 
 final class HaveTrait implements Expression
 {
-    /** @var string */
-    private $trait;
+    private string $trait;
 
     public function __construct(string $trait)
     {

--- a/src/Expression/ForClasses/Implement.php
+++ b/src/Expression/ForClasses/Implement.php
@@ -14,8 +14,7 @@ use Arkitect\Rules\Violations;
 
 class Implement implements Expression
 {
-    /** @var string */
-    private $interface;
+    private string $interface;
 
     public function __construct(string $interface)
     {

--- a/src/Expression/ForClasses/MatchOneOfTheseNames.php
+++ b/src/Expression/ForClasses/MatchOneOfTheseNames.php
@@ -15,7 +15,7 @@ use Arkitect\Rules\Violations;
 class MatchOneOfTheseNames implements Expression
 {
     /** @var array<string> */
-    private $names;
+    private array $names;
 
     public function __construct(array $names)
     {

--- a/src/Expression/ForClasses/NotContainDocBlockLike.php
+++ b/src/Expression/ForClasses/NotContainDocBlockLike.php
@@ -13,8 +13,7 @@ use Arkitect\Rules\Violations;
 
 class NotContainDocBlockLike implements Expression
 {
-    /** @var string */
-    private $docBlock;
+    private string $docBlock;
 
     public function __construct(string $docBlock)
     {

--- a/src/Expression/ForClasses/NotHaveAttribute.php
+++ b/src/Expression/ForClasses/NotHaveAttribute.php
@@ -13,8 +13,7 @@ use Arkitect\Rules\Violations;
 
 final class NotHaveAttribute implements Expression
 {
-    /** @var string */
-    private $attribute;
+    private string $attribute;
 
     public function __construct(string $attribute)
     {

--- a/src/Expression/ForClasses/NotHaveNameMatching.php
+++ b/src/Expression/ForClasses/NotHaveNameMatching.php
@@ -14,8 +14,7 @@ use Arkitect\Rules\Violations;
 
 class NotHaveNameMatching implements Expression
 {
-    /** @var string */
-    private $name;
+    private string $name;
 
     public function __construct(string $name)
     {

--- a/src/Expression/ForClasses/NotHaveTrait.php
+++ b/src/Expression/ForClasses/NotHaveTrait.php
@@ -14,8 +14,7 @@ use Arkitect\Rules\Violations;
 
 class NotHaveTrait implements Expression
 {
-    /** @var string */
-    private $trait;
+    private string $trait;
 
     public function __construct(string $trait)
     {

--- a/src/Expression/ForClasses/NotImplement.php
+++ b/src/Expression/ForClasses/NotImplement.php
@@ -14,8 +14,7 @@ use Arkitect\Rules\Violations;
 
 class NotImplement implements Expression
 {
-    /** @var string */
-    private $interface;
+    private string $interface;
 
     public function __construct(string $interface)
     {

--- a/src/Expression/ForClasses/NotResideInOneOfTheseNamespacesExactly.php
+++ b/src/Expression/ForClasses/NotResideInOneOfTheseNamespacesExactly.php
@@ -14,7 +14,7 @@ use Arkitect\Rules\Violations;
 class NotResideInOneOfTheseNamespacesExactly implements Expression
 {
     /** @var array<string> */
-    private $namespaces;
+    private array $namespaces;
 
     public function __construct(string ...$namespaces)
     {

--- a/src/Expression/ForClasses/NotResideInTheseNamespaces.php
+++ b/src/Expression/ForClasses/NotResideInTheseNamespaces.php
@@ -14,7 +14,7 @@ use Arkitect\Rules\Violations;
 class NotResideInTheseNamespaces implements Expression
 {
     /** @var array<string> */
-    private $namespaces;
+    private array $namespaces;
 
     public function __construct(string ...$namespaces)
     {

--- a/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
+++ b/src/Expression/ForClasses/ResideInOneOfTheseNamespaces.php
@@ -14,7 +14,7 @@ use Arkitect\Rules\Violations;
 class ResideInOneOfTheseNamespaces implements Expression
 {
     /** @var array<string> */
-    private $namespaces;
+    private array $namespaces;
 
     public function __construct(string ...$namespaces)
     {

--- a/src/Expression/ForClasses/ResideInOneOfTheseNamespacesExactly.php
+++ b/src/Expression/ForClasses/ResideInOneOfTheseNamespacesExactly.php
@@ -14,7 +14,7 @@ use Arkitect\Rules\Violations;
 class ResideInOneOfTheseNamespacesExactly implements Expression
 {
     /** @var array<string> */
-    private $namespaces;
+    private array $namespaces;
 
     public function __construct(string ...$namespaces)
     {

--- a/src/RuleBuilders/Architecture/Architecture.php
+++ b/src/RuleBuilders/Architecture/Architecture.php
@@ -10,14 +10,13 @@ use Arkitect\Rules\Rule;
 
 class Architecture implements Component, DefinedBy, Where, MayDependOnComponents, MayDependOnAnyComponent, ShouldNotDependOnAnyComponent, ShouldOnlyDependOnComponents, Rules
 {
-    /** @var string */
-    private $componentName;
+    private string $componentName;
     /** @var array<string, string> */
-    private $componentSelectors;
+    private array $componentSelectors;
     /** @var array<string, array<string>> */
-    private $allowedDependencies;
+    private array $allowedDependencies;
     /** @var array<string, array<string>> */
-    private $componentDependsOnlyOnTheseNamespaces;
+    private array $componentDependsOnlyOnTheseNamespaces;
 
     private function __construct()
     {

--- a/src/Rules/AllClasses.php
+++ b/src/Rules/AllClasses.php
@@ -9,8 +9,7 @@ use Arkitect\Rules\DSL\ThatParser;
 
 class AllClasses implements ThatParser
 {
-    /** @var RuleBuilder */
-    protected $ruleBuilder;
+    protected RuleBuilder $ruleBuilder;
 
     public function __construct()
     {

--- a/src/Rules/AndThatShould.php
+++ b/src/Rules/AndThatShould.php
@@ -9,8 +9,7 @@ use Arkitect\Rules\DSL\BecauseParser;
 
 class AndThatShould implements AndThatShouldParser
 {
-    /** @var RuleBuilder */
-    private $ruleBuilder;
+    private RuleBuilder $ruleBuilder;
 
     public function __construct(RuleBuilder $expressionBuilder)
     {

--- a/src/Rules/ArchRule.php
+++ b/src/Rules/ArchRule.php
@@ -8,20 +8,15 @@ use Arkitect\Analyzer\ClassDescription;
 
 class ArchRule implements DSL\ArchRule
 {
-    /** @var Specs */
-    private $thats;
+    private Specs $thats;
 
-    /** @var Constraints */
-    private $shoulds;
+    private Constraints $shoulds;
 
-    /** @var string */
-    private $because;
+    private string $because;
 
-    /** @var array */
-    private $classesToBeExcluded;
+    private array $classesToBeExcluded;
 
-    /** @var bool */
-    private $runOnlyThis;
+    private bool $runOnlyThis;
 
     public function __construct(
         Specs $specs,

--- a/src/Rules/Because.php
+++ b/src/Rules/Because.php
@@ -9,8 +9,7 @@ use Arkitect\Rules\DSL\BecauseParser;
 
 class Because implements BecauseParser
 {
-    /** @var RuleBuilder */
-    private $ruleBuilder;
+    private RuleBuilder $ruleBuilder;
 
     public function __construct(RuleBuilder $expressionBuilder)
     {

--- a/src/Rules/Constraints.php
+++ b/src/Rules/Constraints.php
@@ -9,8 +9,7 @@ use Arkitect\Expression\Expression;
 
 class Constraints
 {
-    /** @var array */
-    private $expressions = [];
+    private array $expressions = [];
 
     public function add(Expression $expression): void
     {

--- a/src/Rules/RuleBuilder.php
+++ b/src/Rules/RuleBuilder.php
@@ -7,19 +7,14 @@ use Arkitect\Expression\Expression;
 
 class RuleBuilder
 {
-    /** @var Specs */
-    private $thats;
+    private Specs $thats;
 
-    /** @var Constraints */
-    private $shoulds;
+    private Constraints $shoulds;
 
-    /** @var string */
-    private $because;
+    private string $because;
 
-    /** @var array */
-    private $classesToBeExcluded;
-    /** @var bool */
-    private $runOnlyThis;
+    private array $classesToBeExcluded;
+    private bool $runOnlyThis;
 
     public function __construct()
     {

--- a/src/Rules/Specs.php
+++ b/src/Rules/Specs.php
@@ -9,8 +9,7 @@ use Arkitect\Expression\Expression;
 
 class Specs
 {
-    /** @var array */
-    private $expressions = [];
+    private array $expressions = [];
 
     public function add(Expression $expression): void
     {

--- a/src/Rules/ViolationMessage.php
+++ b/src/Rules/ViolationMessage.php
@@ -8,10 +8,8 @@ use Arkitect\Expression\Description;
 
 class ViolationMessage
 {
-    /** @var string */
-    private $rule;
-    /** @var string|null */
-    private $violation;
+    private string $rule;
+    private ?string $violation;
 
     private function __construct(string $rule, ?string $violation)
     {


### PR DESCRIPTION
## Summary

Converts legacy `/** @var Type */` property annotations into native PHP **typed properties** across `src/`, taking advantage of the `php: ^8.0` requirement.

### Conversion rules applied
- Scalar / class / nullable types → native typed property, redundant docblock removed (e.g. `/** @var Specs */ private $thats;` → `private Specs $thats;`).
- `array<...>` / `list<...>` generics → property typed as `array` while **keeping** the docblock, since PHPStan/Psalm still need the element type.
- Bare redundant `@var` docblocks removed automatically by php-cs-fixer (`no_superfluous_phpdoc_tags`).
- Local-variable `@var` annotations inside method bodies and `@var class-string` casts left untouched.

### Notable exception
`$defaultDescription` in `Init` and `DebugExpression` is kept **untyped** (docblock only): the Symfony `Command` base class declares it without a native type, so a typed redeclaration would break property type invariance (caught by Psalm in CI on PHP 8.0).

## Testing
- `bin/phpunit` → 426 tests green.
- `php-cs-fixer` → clean.
- Psalm verified via CI (it cannot run locally on this container's PHP 8.4).

https://claude.ai/code/session_01RXGoDJXp2YaSpwGyJcUWzT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXGoDJXp2YaSpwGyJcUWzT)_