### PR TITLE
ignored line numbers in the baseline

### DIFF
--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -65,10 +65,14 @@ class Baseline
         );
     }
 
-    public static function save(?string $filename, string $defaultFilePath, Violations $violations): string
+    public static function save(?string $filename, string $defaultFilePath, Violations $violations, bool $ignoreLineNumbers = false): string
     {
         if (null === $filename) {
             $filename = $defaultFilePath;
+        }
+
+        if ($ignoreLineNumbers) {
+            $violations = $violations->withoutLineNumbers();
         }
 
         file_put_contents($filename, json_encode($violations, \JSON_PRETTY_PRINT));

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -164,7 +164,7 @@ class Check extends Command
             if (false !== $generateBaseline) {
                 $result = $runner->baseline($config, $progress);
 
-                $baselineFilePath = Baseline::save($generateBaseline, self::DEFAULT_BASELINE_FILENAME, $result->getViolations());
+                $baselineFilePath = Baseline::save($generateBaseline, self::DEFAULT_BASELINE_FILENAME, $result->getViolations(), $ignoreBaselineLinenumbers);
 
                 $output->writeln("ℹ️ Baseline file '$baselineFilePath' created!");
 

--- a/src/Rules/Violation.php
+++ b/src/Rules/Violation.php
@@ -61,4 +61,9 @@ class Violation implements \JsonSerializable
     {
         return new self($json['fqcn'], $json['error'], $json['line'], $json['filePath'] ?? null);
     }
+
+    public function withoutLineNumber(): self
+    {
+        return new self($this->fqcn, $this->error, null, $this->filePath);
+    }
 }

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -109,6 +109,16 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
         $this->violations = array_values($this->violations);
     }
 
+    public function withoutLineNumbers(): self
+    {
+        $copy = new self();
+        foreach ($this->violations as $violation) {
+            $copy->add($violation->withoutLineNumber());
+        }
+
+        return $copy;
+    }
+
     public function sort(): void
     {
         usort($this->violations, static fn (Violation $v1, Violation $v2): int => $v1 <=> $v2);

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -237,6 +237,42 @@ class ViolationsTest extends TestCase
         self::assertCount(0, $violations);
     }
 
+    public function test_violation_without_line_number_returns_copy_with_null_line(): void
+    {
+        $violation = new Violation('App\Foo', 'some error', 42, '/src/Foo.php');
+        $stripped = $violation->withoutLineNumber();
+
+        self::assertNull($stripped->getLine());
+        self::assertEquals('App\Foo', $stripped->getFqcn());
+        self::assertEquals('some error', $stripped->getError());
+        self::assertEquals('/src/Foo.php', $stripped->getFilePath());
+    }
+
+    public function test_without_line_numbers_strips_all_line_numbers(): void
+    {
+        $violations = new Violations();
+        $violations->add(new Violation('App\Foo', 'some error', 42, '/src/Foo.php'));
+        $violations->add(new Violation('App\Bar', 'other error', 10, '/src/Bar.php'));
+
+        $stripped = $violations->withoutLineNumbers();
+
+        self::assertCount(2, $stripped);
+        self::assertNull($stripped->get(0)->getLine());
+        self::assertNull($stripped->get(1)->getLine());
+        self::assertEquals('App\Foo', $stripped->get(0)->getFqcn());
+        self::assertEquals('App\Bar', $stripped->get(1)->getFqcn());
+    }
+
+    public function test_without_line_numbers_does_not_mutate_original(): void
+    {
+        $violations = new Violations();
+        $violations->add(new Violation('App\Foo', 'some error', 42, '/src/Foo.php'));
+
+        $violations->withoutLineNumbers();
+
+        self::assertEquals(42, $violations->get(0)->getLine());
+    }
+
     public function test_remove_violations_from_violations_ignore_linenumber(): void
     {
         $violation1 = new Violation(


### PR DESCRIPTION
Fix --ignore-baseline-linenumbers not applied when generating baseline
Fixes #620 

When using --generate-baseline --ignore-baseline-linenumbers, line numbers were still written to the baseline file. 

The flag only affected runtime comparison, not serialization, causing constant merge conflicts in large teams on legacy codebases.
Line numbers are now stripped before saving when --ignore-baseline-linenumbers is passed. No existing behaviour is affected — the fix only applies when both flags are used together.