### PR TITLE
fix: make init suggest a command instead of a wrong path

### DIFF
--- a/src/CLI/Command/Init.php
+++ b/src/CLI/Command/Init.php
@@ -54,7 +54,7 @@ EOT;
 
             if (file_exists($destFilePath)) {
                 $output->writeln('<info>File</info> phparkitect.php <info>found in current directory, nothing to do</info>');
-                $output->writeln('<info>You are good to go, customize it and run with </info>php bin/phparkitect check');
+                $output->writeln('<info>You are good to go, customize it and run with </info>phparkitect check');
 
                 return 0;
             }
@@ -73,7 +73,7 @@ EOT;
             copy($sourceFilePath, $destFilePath);
 
             $output->writeln('<info> done</info>');
-            $output->writeln('<info>customize it and run with </info>php bin/phparkitect check');
+            $output->writeln('<info>customize it and run with </info>phparkitect check');
         } catch (\Throwable $e) {
             $output->writeln('');
             $output->writeln('<error>Ops, something went wrong: </error>');

--- a/tests/E2E/Cli/InitCommandTest.php
+++ b/tests/E2E/Cli/InitCommandTest.php
@@ -21,7 +21,7 @@ class InitCommandTest extends TestCase
 
         self::assertFileExists($fs.'/phparkitect.php');
         self::assertStringContainsString('Creating phparkitect.php file...', $output);
-        self::assertStringContainsString('customize it and run with php bin/phparkitect check', $output);
+        self::assertStringContainsString('customize it and run with phparkitect check', $output);
     }
 
     public function test_it_creates_a_file_in_a_custom_dir(): void
@@ -40,7 +40,7 @@ class InitCommandTest extends TestCase
 
         self::assertFileExists($fs.'/nested/path/phparkitect.php');
         self::assertStringContainsString('Creating phparkitect.php file...', $output);
-        self::assertStringContainsString('customize it and run with php bin/phparkitect check', $output);
+        self::assertStringContainsString('customize it and run with phparkitect check', $output);
     }
 
     public function test_do_nothing_if_file_exists(): void


### PR DESCRIPTION
## What

The `init` command prints `php bin/phparkitect check` after creating the config file, but that path is wrong for most users:

- **Composer install**: the binary lands in `vendor/bin/phparkitect` (Composer's default `bin-dir`), not `bin/`.
- **Phar**: it's run as `./phparkitect.phar check`.
- `bin/phparkitect` is only correct when developing inside this repo (where `config.bin-dir` is set to `bin`).

Since no single path is correct for every install method, this changes the message to the neutral `phparkitect check`, which is right regardless of how the tool was installed. The same string in the "file already exists" branch is updated for consistency, along with the E2E assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)