### PR TITLE
Ignore the because() reason when matching baseline violations

### DIFF
--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -156,16 +156,22 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
      *
      * ViolationMessage produces two formats:
      * - withDescription: "$violation, but $ruleDescription" → returns $violation
-     * - selfExplanatory: "$ruleDescription" (no ", but ") → returns the full string
+     * - selfExplanatory: "$ruleDescription" (no ", but ") → returns $ruleDescription without its trailing " because $because"
      *
-     * The rule description may include configuration-dependent values (like namespace lists)
-     * that change when the rule config is updated. The violation part is always stable.
+     * The rule description may include configuration-dependent values (like namespace lists),
+     * and the because() reason is free text — both change when the config is reworded.
+     * The violation part is always stable.
      */
     private static function extractViolationKey(string $error): string
     {
         $pos = strpos($error, ', but ');
         if (false !== $pos) {
             return substr($error, 0, $pos);
+        }
+
+        $becausePos = strpos($error, ' because ');
+        if (false !== $becausePos) {
+            return substr($error, 0, $becausePos);
         }
 
         return $error;

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -237,6 +237,25 @@ class ViolationsTest extends TestCase
         self::assertCount(0, $violations);
     }
 
+    public function test_remove_violations_matches_self_explanatory_messages_when_because_is_reworded(): void
+    {
+        $violations = new Violations();
+        $violations->add(new Violation(
+            'App\Foo',
+            'should be final because we want immutability and avoid side-effects'
+        ));
+
+        $baseline = new Violations();
+        $baseline->add(new Violation(
+            'App\Foo',
+            'should be final because we want immutability'
+        ));
+
+        $violations->remove($baseline);
+
+        self::assertCount(0, $violations);
+    }
+
     public function test_violation_without_line_number_returns_copy_with_null_line(): void
     {
         $violation = new Violation('App\Foo', 'some error', 42, '/src/Foo.php');


### PR DESCRIPTION
### Improvement

|    Q        |   A
|------------ | ------
| New Feature | no
| BC Break    | no
| Issue       | Related to #636

#### Summary

Changing only the `because()` text of a rule has no real meaning for baseline matching: it changes neither the rule nor the violation it explains, so it shouldn't make existing baseline entries look invalidated.

Today this happens to work for violations whose message has a `, but ` part (e.g. dependency rules), only because everything after `, but ` — `because()` included — is already dropped from the comparison for an unrelated reason (so that changing the rule's configuration doesn't invalidate the baseline either). For self-explanatory messages (e.g. `IsFinal`, `IsReadonly`, `HaveNameMatching`), there's no `, but ` part, so the whole message — `because()` included — is used as-is, and rewording it breaks the match.

This PR makes the `because()` reason excluded from baseline matching in general, instead of it only working as a side effect for some message formats.