### PR TITLE
Add message to report when baseline violations look fixed

### DIFF
--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -11,6 +11,8 @@ class Baseline
 
     private string $filename;
 
+    private int $staleViolationsCount = 0;
+
     private function __construct(Violations $violations, string $filename)
     {
         $this->violations = $violations;
@@ -24,7 +26,19 @@ class Baseline
 
     public function applyTo(Violations $violations, bool $ignoreBaselineLinenumbers): void
     {
+        $this->staleViolationsCount = $this->violations->countUnmatchedIn($violations, $ignoreBaselineLinenumbers);
+
         $violations->remove($this->violations, $ignoreBaselineLinenumbers);
+    }
+
+    /**
+     * Number of baseline entries that no longer match any current violation,
+     * i.e. that have already been fixed and could be removed from the baseline.
+     * Only meaningful after applyTo() has run.
+     */
+    public function getStaleViolationsCount(): int
+    {
+        return $this->staleViolationsCount;
     }
 
     /**

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -180,6 +180,14 @@ class Check extends Command
                 $output->writeln("⚠️ {$result->getViolations()->count()} violations detected!");
             }
 
+            $staleViolationsCount = $baseline->getStaleViolationsCount();
+            if ($staleViolationsCount > 0) {
+                $verb = 1 === $staleViolationsCount ? 'looks' : 'look';
+                $pronoun = 1 === $staleViolationsCount ? 'it' : 'them';
+                $noun = 1 === $staleViolationsCount ? 'violation' : 'violations';
+                $output->writeln("💡 {$staleViolationsCount} {$noun} in the baseline {$verb} fixed — regenerate the baseline to remove {$pronoun}");
+            }
+
             if ($result->hasParsingErrors()) {
                 $output->writeln('❌ found parsing errors in these files:');
                 foreach ($result->getParsingErrors() as $parsingError) {

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -109,6 +109,40 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
         $this->violations = array_values($this->violations);
     }
 
+    /**
+     * Counts how many violations in this set (typically the baseline) have no
+     * corresponding entry in $current (typically the current run's violations) —
+     * i.e. how many are stale and could be removed from the baseline.
+     */
+    public function countUnmatchedIn(self $current, bool $ignoreLineNumbers): int
+    {
+        if (!$ignoreLineNumbers) {
+            return \count(array_udiff(
+                $this->violations,
+                $current->violations,
+                [__CLASS__, 'compareViolations']
+            ));
+        }
+
+        $currentViolations = $current->violations;
+        $unmatched = 0;
+        foreach ($this->violations as $violation) {
+            foreach ($currentViolations as $idx => $currentViolation) {
+                if (
+                    $currentViolation->getFqcn() === $violation->getFqcn()
+                    && self::extractViolationKey($currentViolation->getError()) === self::extractViolationKey($violation->getError())
+                ) {
+                    unset($currentViolations[$idx]);
+                    continue 2;
+                }
+            }
+
+            ++$unmatched;
+        }
+
+        return $unmatched;
+    }
+
     public function withoutLineNumbers(): self
     {
         $copy = new self();

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -180,6 +180,29 @@ class CheckCommandTest extends TestCase
         self::assertCommandExitedWithError($cmdTester);
     }
 
+    public function test_baseline_reports_stale_violations(): void
+    {
+        $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
+
+        // Produce the baseline matching the current violation
+        $this->runCheck($configFilePath, null, null, $this->customBaselineFilename);
+
+        // Add a fake, already-fixed entry to the baseline
+        $baseline = json_decode((string) file_get_contents($this->customBaselineFilename), true);
+        $baseline['violations'][] = [
+            'fqcn' => 'App\Controller\AlreadyFixed',
+            'error' => 'should have a name that matches *Controller because all controllers should be end name with Controller',
+            'line' => 1,
+            'filePath' => 'Controller/AlreadyFixed.php',
+        ];
+        file_put_contents($this->customBaselineFilename, json_encode($baseline));
+
+        $cmdTester = $this->runCheck($configFilePath, null, $this->customBaselineFilename);
+
+        self::assertCommandWasSuccessful($cmdTester);
+        self::assertStringContainsString('💡 1 violation in the baseline looks fixed — regenerate the baseline to remove it', $cmdTester->getErrorOutput());
+    }
+
     public function test_json_format_output_errors(): void
     {
         $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -314,4 +314,63 @@ class ViolationsTest extends TestCase
             $violation3,
         ], $this->violationStore->toArray());
     }
+
+    public function test_count_unmatched_in_returns_zero_when_everything_still_occurs(): void
+    {
+        $baseline = new Violations();
+        $baseline->add($this->violation);
+
+        $current = new Violations();
+        $current->add($this->violation);
+
+        self::assertSame(0, $baseline->countUnmatchedIn($current, false));
+    }
+
+    public function test_count_unmatched_in_counts_fixed_baseline_entries(): void
+    {
+        $stillPresent = new Violation('App\Controller\Shop', 'should have name end with Controller', 10);
+        $fixed = new Violation('App\Controller\Shop', 'should implement AbstractController', 20);
+
+        $baseline = new Violations();
+        $baseline->add($stillPresent);
+        $baseline->add($fixed);
+
+        $current = new Violations();
+        $current->add($stillPresent);
+
+        self::assertSame(1, $baseline->countUnmatchedIn($current, false));
+    }
+
+    public function test_count_unmatched_in_counts_fixed_baseline_entries_ignoring_line_numbers(): void
+    {
+        $stillPresent = new Violation('App\Controller\Shop', 'should have name end with Controller', 10);
+        $fixed = new Violation('App\Controller\Shop', 'should implement AbstractController', 20);
+        $stillPresentMovedLine = new Violation('App\Controller\Shop', 'should have name end with Controller', 15);
+
+        $baseline = new Violations();
+        $baseline->add($stillPresent);
+        $baseline->add($fixed);
+
+        $current = new Violations();
+        $current->add($stillPresentMovedLine);
+
+        self::assertSame(1, $baseline->countUnmatchedIn($current, true));
+        self::assertSame(2, $baseline->countUnmatchedIn($current, false));
+    }
+
+    public function test_count_unmatched_in_does_not_mutate_either_set(): void
+    {
+        $stillPresent = new Violation('App\Controller\Shop', 'should have name end with Controller', 10);
+
+        $baseline = new Violations();
+        $baseline->add($stillPresent);
+
+        $current = new Violations();
+        $current->add($stillPresent);
+
+        $baseline->countUnmatchedIn($current, true);
+
+        self::assertCount(1, $baseline);
+        self::assertCount(1, $current);
+    }
 }


### PR DESCRIPTION
### New Feature

|    Q        |   A
|------------ | ------
| New Feature | yes
| RFC         | no
| BC Break    | no

#### Summary

A flat baseline file tends to become invisible: nothing prompts anyone to notice that some of its entries no longer occur and could be removed, so debt that's already paid down stays recorded forever.

`check` now counts, after applying the baseline, how many baseline entries have no matching violation in the current run, and prints a message when that count is greater than zero:

    💡 3 violations in the baseline look fixed — regenerate the baseline to remove them