### PR TITLE
Fix nullable return type dependency not detected

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -332,7 +332,7 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
-        $returnType = $node->returnType;
+        $returnType = $node->returnType instanceof NullableType ? $node->returnType->type : $node->returnType;
 
         if (!$returnType instanceof Node\Name\FullyQualified) {
             return;

--- a/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
+++ b/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
@@ -539,6 +539,34 @@ class CanParseClassTest extends TestCase
         self::assertCount(0, $violations);
     }
 
+    public function test_it_handles_nullable_return_types(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+        namespace Foo\Bar;
+
+        use Symfony\Component\HttpFoundation\Request;
+
+        class MyClass
+        {
+            public function getRequest(): ?Request
+            {
+                return null;
+            }
+        }
+        EOF;
+
+        $cd = $this->parseCode($code);
+
+        self::assertCount(1, $cd[0]->getDependencies());
+        self::assertEquals('Symfony\Component\HttpFoundation\Request', $cd[0]->getDependencies()[0]->getFQCN()->toString());
+
+        $dependsOnTheseNamespaces = new DependsOnlyOnTheseNamespaces(['Foo']);
+        $violations = $this->evaluateRule($dependsOnTheseNamespaces, $cd[0]);
+
+        self::assertCount(1, $violations);
+    }
+
     public function test_is_final_when_there_is_anonymous_final(): void
     {
         $code = <<< 'EOF'


### PR DESCRIPTION
A nullable return type (?ClassName) parses as a NullableType node wrapping the FullyQualified name, so handleReturnTypeDependency's instanceof check silently dropped the dependency. Unwrap NullableType first, as the property and param type handlers already do.

Fixes #639


Claude-Session: https://claude.ai/code/session_01VUHWv3r1BJyZj4H1WzM3v9