### PR TITLE
Detect dependencies in union, intersection and DNF types

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -249,18 +249,10 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
-        if (null === $node->type) {
-            return;
+        foreach ($this->extractFullyQualifiedTypes($node->type) as $type) {
+            $this->classDescriptionBuilder
+                ->addDependency(new ClassDependency($type->toString(), $node->getLine()));
         }
-
-        $type = $node->type instanceof NullableType ? $node->type->type : $node->type;
-
-        if (!$type instanceof Node\Name\FullyQualified) {
-            return;
-        }
-
-        $this->classDescriptionBuilder
-            ->addDependency(new ClassDependency($type->toString(), $node->getLine()));
     }
 
     private function handleDocComment(Node $node): void
@@ -332,14 +324,10 @@ class FileVisitor extends NodeVisitorAbstract
             return;
         }
 
-        $returnType = $node->returnType instanceof NullableType ? $node->returnType->type : $node->returnType;
-
-        if (!$returnType instanceof Node\Name\FullyQualified) {
-            return;
+        foreach ($this->extractFullyQualifiedTypes($node->returnType) as $returnType) {
+            $this->classDescriptionBuilder
+                ->addDependency(new ClassDependency($returnType->toString(), $returnType->getLine()));
         }
-
-        $this->classDescriptionBuilder
-            ->addDependency(new ClassDependency($returnType->toString(), $returnType->getLine()));
     }
 
     private function handleAttributeNode(Node $node): void
@@ -385,18 +373,38 @@ class FileVisitor extends NodeVisitorAbstract
 
     private function addParamDependency(Node\Param $node): void
     {
-        if (null === $node->type || $node->type instanceof Node\Identifier) {
-            return;
+        foreach ($this->extractFullyQualifiedTypes($node->type) as $type) {
+            $this->classDescriptionBuilder
+                ->addDependency(new ClassDependency($type->toString(), $node->getLine()));
+        }
+    }
+
+    /**
+     * Flattens a type node into the class names it references, unwrapping
+     * nullable, union, intersection and DNF types.
+     *
+     * @return list<Node\Name\FullyQualified>
+     */
+    private function extractFullyQualifiedTypes(?Node $type): array
+    {
+        if ($type instanceof NullableType) {
+            return $this->extractFullyQualifiedTypes($type->type);
         }
 
-        $type = $node->type instanceof NullableType ? $node->type->type : $node->type;
+        if ($type instanceof Node\UnionType || $type instanceof Node\IntersectionType) {
+            $types = [];
+            foreach ($type->types as $innerType) {
+                $types = array_merge($types, $this->extractFullyQualifiedTypes($innerType));
+            }
 
-        if (!$type instanceof Node\Name\FullyQualified) {
-            return;
+            return $types;
         }
 
-        $this->classDescriptionBuilder
-            ->addDependency(new ClassDependency($type->toString(), $node->getLine()));
+        if ($type instanceof Node\Name\FullyQualified) {
+            return [$type];
+        }
+
+        return [];
     }
 
     private function handlePropertyHookNode(Node $node): void

--- a/tests/Unit/Analyzer/FileParser/CanParseClassPropertiesTest.php
+++ b/tests/Unit/Analyzer/FileParser/CanParseClassPropertiesTest.php
@@ -68,6 +68,61 @@ class CanParseClassPropertiesTest extends TestCase
         self::assertEquals('Symfony\Component\Validator\Constraints\NotBlank', $dep[0]->getFQCN()->toString());
     }
 
+    public function test_it_parse_union_typed_property(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+        namespace MyProject\AppBundle\Application;
+
+        use Symfony\Component\Validator\Constraints\Email;
+        use Symfony\Component\Validator\Constraints\NotBlank;
+
+        class ApplicationLevelDto
+        {
+            public NotBlank|Email $foo;
+
+            public NotBlank|string|null $bar;
+        }
+        EOF;
+
+        $fp = FileParserFactory::forPhpVersion(TargetPhpVersion::PHP_8_1);
+        $result = $fp->parse($code, 'relativePathName');
+
+        $cd = $result->classDescriptions();
+        $dep = $cd[0]->getDependencies();
+
+        self::assertCount(3, $dep);
+        self::assertEquals('Symfony\Component\Validator\Constraints\NotBlank', $dep[0]->getFQCN()->toString());
+        self::assertEquals('Symfony\Component\Validator\Constraints\Email', $dep[1]->getFQCN()->toString());
+        self::assertEquals('Symfony\Component\Validator\Constraints\NotBlank', $dep[2]->getFQCN()->toString());
+    }
+
+    public function test_it_parse_intersection_typed_property(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+        namespace MyProject\AppBundle\Application;
+
+        use Symfony\Component\Validator\Constraints\Email;
+        use Symfony\Component\Validator\Constraints\NotBlank;
+
+        class ApplicationLevelDto
+        {
+            public NotBlank&Email $foo;
+        }
+        EOF;
+
+        $fp = FileParserFactory::forPhpVersion(TargetPhpVersion::PHP_8_1);
+        $result = $fp->parse($code, 'relativePathName');
+
+        $cd = $result->classDescriptions();
+        $dep = $cd[0]->getDependencies();
+
+        self::assertCount(2, $dep);
+        self::assertEquals('Symfony\Component\Validator\Constraints\NotBlank', $dep[0]->getFQCN()->toString());
+        self::assertEquals('Symfony\Component\Validator\Constraints\Email', $dep[1]->getFQCN()->toString());
+    }
+
     public function test_it_parse_scalar_typed_property(): void
     {
         $code = <<< 'EOF'

--- a/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
+++ b/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
@@ -567,6 +567,100 @@ class CanParseClassTest extends TestCase
         self::assertCount(1, $violations);
     }
 
+    public function test_it_handles_union_param_and_return_types(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+        namespace Foo\Bar;
+
+        use Symfony\Component\HttpFoundation\Request;
+        use Symfony\Component\HttpFoundation\Response;
+
+        class MyClass
+        {
+            public function handle(Request|Response $message): Request|Response|null
+            {
+                return $message;
+            }
+        }
+        EOF;
+
+        $cd = $this->parseCode($code);
+        $dependencies = array_map(
+            static fn (ClassDependency $dependency): string => $dependency->getFQCN()->toString(),
+            $cd[0]->getDependencies()
+        );
+
+        self::assertEquals([
+            'Symfony\Component\HttpFoundation\Request',
+            'Symfony\Component\HttpFoundation\Response',
+            'Symfony\Component\HttpFoundation\Request',
+            'Symfony\Component\HttpFoundation\Response',
+        ], $dependencies);
+    }
+
+    public function test_it_handles_intersection_param_and_return_types(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+        namespace Foo\Bar;
+
+        use Doctrine\Common\Collections\Collection;
+        use Doctrine\Common\Collections\Selectable;
+
+        class MyClass
+        {
+            public function handle(Collection&Selectable $collection): Collection&Selectable
+            {
+                return $collection;
+            }
+        }
+        EOF;
+
+        $cd = $this->parseCode($code, TargetPhpVersion::PHP_8_1);
+        $dependencies = array_map(
+            static fn (ClassDependency $dependency): string => $dependency->getFQCN()->toString(),
+            $cd[0]->getDependencies()
+        );
+
+        self::assertEquals([
+            'Doctrine\Common\Collections\Collection',
+            'Doctrine\Common\Collections\Selectable',
+            'Doctrine\Common\Collections\Collection',
+            'Doctrine\Common\Collections\Selectable',
+        ], $dependencies);
+    }
+
+    public function test_it_handles_dnf_return_types(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+        namespace Foo\Bar;
+
+        use Doctrine\Common\Collections\Collection;
+        use Doctrine\Common\Collections\Selectable;
+
+        class MyClass
+        {
+            public function handle(): (Collection&Selectable)|null
+            {
+                return null;
+            }
+        }
+        EOF;
+
+        $cd = $this->parseCode($code, TargetPhpVersion::PHP_8_2);
+        $dependencies = array_map(
+            static fn (ClassDependency $dependency): string => $dependency->getFQCN()->toString(),
+            $cd[0]->getDependencies()
+        );
+
+        self::assertEquals([
+            'Doctrine\Common\Collections\Collection',
+            'Doctrine\Common\Collections\Selectable',
+        ], $dependencies);
+    }
+
     public function test_is_final_when_there_is_anonymous_final(): void
     {
         $code = <<< 'EOF'


### PR DESCRIPTION
Union (A|B), intersection (A&B) and DNF ((A&B)|null) types were never traversed by the property, param and return-type handlers, which only checked the raw node against FullyQualified (after a NullableType unwrap), silently dropping every class referenced inside them.

Replace the three ad-hoc unwraps with a shared helper that recursively flattens NullableType/UnionType/IntersectionType into the list of FullyQualified names they reference.

Fixes #641


Claude-Session: https://claude.ai/code/session_01VUHWv3r1BJyZj4H1WzM3v9