### PR TITLE
Detect closure and arrow function return type dependencies

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -65,7 +65,7 @@ class FileVisitor extends NodeVisitorAbstract
         // handles code like public function myMethod(MyClass $myClass) {}
         $this->handleParamDependency($node);
 
-        // handles code like public function myMethod(): MyClass {}
+        // handles return types like public function myMethod(): MyClass {}, function (): MyClass {}, fn (): MyClass => ...
         $this->handleReturnTypeDependency($node);
 
         // handles attribute definition like #[MyAttribute]
@@ -320,11 +320,11 @@ class FileVisitor extends NodeVisitorAbstract
 
     private function handleReturnTypeDependency(Node $node): void
     {
-        if (!$node instanceof Node\Stmt\ClassMethod) {
+        if (!$node instanceof Node\FunctionLike) {
             return;
         }
 
-        foreach ($this->extractFullyQualifiedTypes($node->returnType) as $returnType) {
+        foreach ($this->extractFullyQualifiedTypes($node->getReturnType()) as $returnType) {
             $this->classDescriptionBuilder
                 ->addDependency(new ClassDependency($returnType->toString(), $returnType->getLine()));
         }

--- a/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
+++ b/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
@@ -661,6 +661,65 @@ class CanParseClassTest extends TestCase
         ], $dependencies);
     }
 
+    public function test_it_handles_closure_return_types(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+        namespace Foo\Bar;
+
+        use Symfony\Component\HttpFoundation\Request;
+
+        class MyClass
+        {
+            public function make(): callable
+            {
+                return function (): ?Request {
+                    return null;
+                };
+            }
+        }
+        EOF;
+
+        $cd = $this->parseCode($code);
+        $dependencies = array_map(
+            static fn (ClassDependency $dependency): string => $dependency->getFQCN()->toString(),
+            $cd[0]->getDependencies()
+        );
+
+        self::assertEquals(['Symfony\Component\HttpFoundation\Request'], $dependencies);
+    }
+
+    public function test_it_handles_arrow_function_return_types(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+        namespace Foo\Bar;
+
+        use Symfony\Component\HttpFoundation\Request;
+        use Symfony\Component\HttpFoundation\Response;
+
+        class MyClass
+        {
+            public function make(): callable
+            {
+                return fn (): Request|Response => new Request();
+            }
+        }
+        EOF;
+
+        $cd = $this->parseCode($code);
+        $dependencies = array_map(
+            static fn (ClassDependency $dependency): string => $dependency->getFQCN()->toString(),
+            $cd[0]->getDependencies()
+        );
+
+        self::assertEquals([
+            'Symfony\Component\HttpFoundation\Request',
+            'Symfony\Component\HttpFoundation\Response',
+            'Symfony\Component\HttpFoundation\Request',
+        ], $dependencies);
+    }
+
     public function test_is_final_when_there_is_anonymous_final(): void
     {
         $code = <<< 'EOF'


### PR DESCRIPTION
handleReturnTypeDependency only accepted Node\Stmt\ClassMethod, so return types on closures and arrow functions were silently ignored, while their parameters were already collected. Accept any FunctionLike node and read the type via getReturnType() so all function-like constructs are handled consistently.

Fixes #642


Claude-Session: https://claude.ai/code/session_01VUHWv3r1BJyZj4H1WzM3v9