### PR TITLE
Detect typed class constant dependencies (PHP 8.3)

### DIFF
--- a/src/Analyzer/FileVisitor.php
+++ b/src/Analyzer/FileVisitor.php
@@ -79,6 +79,9 @@ class FileVisitor extends NodeVisitorAbstract
 
         // handles catch types like catch (MyException $e)
         $this->handleCatchDependency($node);
+
+        // handles typed class constants like const MyClass FOO = null;
+        $this->handleClassConstDependency($node);
     }
 
     public function getClassDescriptions(): array
@@ -356,6 +359,18 @@ class FileVisitor extends NodeVisitorAbstract
         foreach ($node->getAttribute(DocblockTypesResolver::THROWS_TYPES_ATTRIBUTE) as $throw) {
             $this->classDescriptionBuilder
                 ->addDependency(new ClassDependency($throw->toString(), $throw->getLine()));
+        }
+    }
+
+    private function handleClassConstDependency(Node $node): void
+    {
+        if (!$node instanceof Node\Stmt\ClassConst) {
+            return;
+        }
+
+        foreach ($this->extractFullyQualifiedTypes($node->type) as $type) {
+            $this->classDescriptionBuilder
+                ->addDependency(new ClassDependency($type->toString(), $node->getLine()));
         }
     }
 

--- a/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
+++ b/tests/Unit/Analyzer/FileParser/CanParseClassTest.php
@@ -720,6 +720,38 @@ class CanParseClassTest extends TestCase
         ], $dependencies);
     }
 
+    public function test_it_handles_typed_class_constants(): void
+    {
+        $code = <<< 'EOF'
+        <?php
+        namespace Foo\Bar;
+
+        use Symfony\Component\HttpFoundation\Request;
+        use Symfony\Component\HttpFoundation\Response;
+
+        class MyClass
+        {
+            public const ?Request EMPTY_REQUEST = null;
+
+            public const Request|Response|null FALLBACK = null;
+
+            public const string NAME = 'name';
+        }
+        EOF;
+
+        $cd = $this->parseCode($code, TargetPhpVersion::PHP_8_3);
+        $dependencies = array_map(
+            static fn (ClassDependency $dependency): string => $dependency->getFQCN()->toString(),
+            $cd[0]->getDependencies()
+        );
+
+        self::assertEquals([
+            'Symfony\Component\HttpFoundation\Request',
+            'Symfony\Component\HttpFoundation\Request',
+            'Symfony\Component\HttpFoundation\Response',
+        ], $dependencies);
+    }
+
     public function test_is_final_when_there_is_anonymous_final(): void
     {
         $code = <<< 'EOF'


### PR DESCRIPTION
FileVisitor had no handler reading the type of a Node\Stmt\ClassConst, so the class referenced by a typed constant (const MyClass FOO = null) was never registered as a dependency. Add a handler that reuses the shared type-flattening helper, covering nullable and union constant types as well.

Fixes #643


Claude-Session: https://claude.ai/code/session_01VUHWv3r1BJyZj4H1WzM3v9