### PR TITLE
ci: switch dependabot versioning-strategy to widen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       time: "09:00"
       timezone: "Europe/Rome"
     open-pull-requests-limit: 5
-    versioning-strategy: increase
+    versioning-strategy: widen
     commit-message:
       prefix: "deps"
       include: "scope"


### PR DESCRIPTION
Arkitect is a library, so composer constraints should be widened, not
narrowed, when new dependency versions come out. The 'increase' strategy
produced PRs like #651, which narrowed phpstan/phpdoc-parser from
'^1.2|^2.0' to '^2.3.3', dropping 1.x support that the code deliberately
keeps (DocblockParserFactory) and breaking installability alongside
PHPStan 1.x in consumer projects.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HGn14CC9FzxoFZVyDutsic