### PR TITLE
Extract CheckHandler application service from Check command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Before committing, `make csfix && make psalm && make test` must all pass (CI gat
 
 `bin/phparkitect` → `PhpArkitectApplication` registers the commands in `src/CLI/Command/` (`Check`, `Init`, `DebugExpression`).
 
-`Check::execute` (`src/CLI/Command/Check.php`):
+`Check::execute` (`src/CLI/Command/Check.php`) parses the CLI options into a `CheckOptions` value object and delegates to `CheckHandler` (`src/CLI/CheckHandler.php`), the application service that runs the actual flow:
 1. `ConfigBuilder` loads the user's `phparkitect.php`, which receives a `Config` and registers `ClassSet`s + `Rule`s.
 2. `Runner` (`src/CLI/Runner.php`) iterates every `SplFileInfo` in each `ClassSet`, parses it via `FileParser`, and gets back `ClassDescription`s.
 3. Each `Rule` is evaluated against each `ClassDescription`, accumulating `Violations`.

--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -7,6 +7,8 @@ use Arkitect\Rules\Violations;
 
 class Baseline
 {
+    public const DEFAULT_FILENAME = 'phparkitect-baseline.json';
+
     private Violations $violations;
 
     private string $filename;

--- a/src/CLI/CheckHandler.php
+++ b/src/CLI/CheckHandler.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\CLI;
+
+use Arkitect\CLI\Printer\PrinterFactory;
+use Arkitect\CLI\Progress\Progress;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Application service behind the `check` command: loads the config,
+ * runs the analysis and renders the result. It only depends on
+ * OutputInterface for writing, so it can be unit tested with a
+ * BufferedOutput — no console, no exit codes, no global state.
+ */
+final class CheckHandler
+{
+    public function __construct(private Runner $runner)
+    {
+    }
+
+    public function check(
+        CheckOptions $options,
+        Progress $progress,
+        OutputInterface $output,
+        OutputInterface $violationsOutput,
+    ): AnalysisResult {
+        [$config, $baseline] = $this->prepare($options, $output);
+
+        $printer = PrinterFactory::create($config->getFormat());
+
+        $result = $this->runner->run($config, $baseline, $progress);
+
+        // we always print this so we do not have to do additional ifs later
+        $violationsOutput->writeln($printer->print($result->getViolations()->groupedByFqcn()));
+
+        if ($result->hasViolations()) {
+            $output->writeln("⚠️ {$result->getViolations()->count()} violations detected!");
+        }
+
+        $this->printStaleBaselineViolations($baseline, $output);
+
+        if ($result->hasParsingErrors()) {
+            $output->writeln('❌ found parsing errors in these files:');
+            foreach ($result->getParsingErrors() as $parsingError) {
+                $output->writeln("$parsingError");
+            }
+        }
+
+        !$result->hasErrors() && $output->writeln('✅ No violations detected');
+
+        return $result;
+    }
+
+    public function generateBaseline(CheckOptions $options, Progress $progress, OutputInterface $output): void
+    {
+        [$config] = $this->prepare($options, $output);
+
+        $result = $this->runner->baseline($config, $progress);
+
+        $baselineFilePath = Baseline::save(
+            $options->getGenerateBaselineFilePath(),
+            Baseline::DEFAULT_FILENAME,
+            $result->getViolations(),
+            $options->isIgnoreBaselineLinenumbers()
+        );
+
+        $output->writeln("ℹ️ Baseline file '$baselineFilePath' created!");
+    }
+
+    /**
+     * @return array{Config, Baseline}
+     */
+    private function prepare(CheckOptions $options, OutputInterface $output): array
+    {
+        $config = ConfigBuilder::loadFromFile($options->getConfigFilePath())
+            ->autoloadFilePath($options->getAutoloadFilePath())
+            ->stopOnFailure($options->isStopOnFailure())
+            ->targetPhpVersion(TargetPhpVersion::create($options->getTargetPhpVersion()))
+            ->baselineFilePath($options->getBaselineFilePath())
+            ->ignoreBaselineLinenumbers($options->isIgnoreBaselineLinenumbers())
+            ->skipBaseline($options->isSkipBaseline())
+            ->format($options->getFormat());
+
+        $baseline = Baseline::create($config->isSkipBaseline(), $config->getBaselineFilePath());
+
+        $baseline->getFilename() && $output->writeln("Baseline file '{$baseline->getFilename()}' found");
+
+        $output->writeln("Config file '{$options->getConfigFilePath()}' found\n");
+
+        return [$config, $baseline];
+    }
+
+    private function printStaleBaselineViolations(Baseline $baseline, OutputInterface $output): void
+    {
+        $staleViolationsCount = $baseline->getStaleViolationsCount();
+
+        if ($staleViolationsCount > 0) {
+            $verb = 1 === $staleViolationsCount ? 'looks' : 'look';
+            $pronoun = 1 === $staleViolationsCount ? 'it' : 'them';
+            $noun = 1 === $staleViolationsCount ? 'violation' : 'violations';
+            $output->writeln("💡 {$staleViolationsCount} {$noun} in the baseline {$verb} fixed — regenerate the baseline to remove {$pronoun}");
+        }
+    }
+}

--- a/src/CLI/CheckOptions.php
+++ b/src/CLI/CheckOptions.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\CLI;
+
+/**
+ * Immutable bag of the options a `check` run needs, already parsed and
+ * resolved: no CLI concerns (option names, tri-state flags) leak past here.
+ */
+final class CheckOptions
+{
+    public function __construct(
+        private string $configFilePath,
+        private ?string $targetPhpVersion,
+        private bool $stopOnFailure,
+        private ?string $baselineFilePath,
+        private bool $skipBaseline,
+        private bool $ignoreBaselineLinenumbers,
+        private bool $generateBaseline,
+        private ?string $generateBaselineFilePath,
+        private string $format,
+        private ?string $autoloadFilePath,
+    ) {
+    }
+
+    public function getConfigFilePath(): string
+    {
+        return $this->configFilePath;
+    }
+
+    public function getTargetPhpVersion(): ?string
+    {
+        return $this->targetPhpVersion;
+    }
+
+    public function isStopOnFailure(): bool
+    {
+        return $this->stopOnFailure;
+    }
+
+    public function getBaselineFilePath(): ?string
+    {
+        return $this->baselineFilePath;
+    }
+
+    public function isSkipBaseline(): bool
+    {
+        return $this->skipBaseline;
+    }
+
+    public function isIgnoreBaselineLinenumbers(): bool
+    {
+        return $this->ignoreBaselineLinenumbers;
+    }
+
+    public function shouldGenerateBaseline(): bool
+    {
+        return $this->generateBaseline;
+    }
+
+    public function getGenerateBaselineFilePath(): ?string
+    {
+        return $this->generateBaselineFilePath;
+    }
+
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    public function getAutoloadFilePath(): ?string
+    {
+        return $this->autoloadFilePath;
+    }
+}

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Arkitect\CLI\Command;
 
 use Arkitect\CLI\Baseline;
-use Arkitect\CLI\ConfigBuilder;
-use Arkitect\CLI\Printer\Printer;
-use Arkitect\CLI\Printer\PrinterFactory;
+use Arkitect\CLI\CheckHandler;
+use Arkitect\CLI\CheckOptions;
 use Arkitect\CLI\Progress\DebugProgress;
 use Arkitect\CLI\Progress\Progress;
 use Arkitect\CLI\Progress\ProgressBarProgress;
 use Arkitect\CLI\Runner;
-use Arkitect\CLI\TargetPhpVersion;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -34,14 +32,16 @@ class Check extends Command
     private const GENERATE_BASELINE_PARAM = 'generate-baseline';
     private const DEFAULT_RULES_FILENAME = 'phparkitect.php';
 
-    private const DEFAULT_BASELINE_FILENAME = 'phparkitect-baseline.json';
-
     private const SUCCESS_CODE = 0;
     private const ERROR_CODE = 1;
 
-    public function __construct()
+    private CheckHandler $handler;
+
+    public function __construct(?CheckHandler $handler = null)
     {
         parent::__construct('check');
+
+        $this->handler = $handler ?? new CheckHandler(new Runner());
     }
 
     protected function configure(): void
@@ -119,83 +119,34 @@ class Check extends Command
         ini_set('xdebug.max_nesting_level', '10000');
         $startTime = microtime(true);
 
+        // we write everything on STDERR apart from the list of violations which goes on STDOUT
+        // this allows to pipe the output of this command to a file while showing output on the terminal
+        $stdOut = $output;
+        $output = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+
         try {
             $verbose = (bool) $input->getOption('verbose');
-            $rulesFilename = $input->getOption(self::CONFIG_FILENAME_PARAM);
-            $stopOnFailure = (bool) $input->getOption(self::STOP_ON_FAILURE_PARAM);
-            $useBaseline = (string) $input->getOption(self::USE_BASELINE_PARAM);
-            $skipBaseline = (bool) $input->getOption(self::SKIP_BASELINE_PARAM);
-            $ignoreBaselineLinenumbers = (bool) $input->getOption(self::IGNORE_BASELINE_LINENUMBERS_PARAM);
-            $generateBaseline = $input->getOption(self::GENERATE_BASELINE_PARAM);
-            $phpVersion = $input->getOption('target-php-version');
-            $format = $input->getOption(self::FORMAT_PARAM);
+            $options = $this->parseOptions($input);
 
-            // we write everything on STDERR apart from the list of violations which goes on STDOUT
-            // this allows to pipe the output of this command to a file while showing output on the terminal
-            $stdOut = $output;
-            $output = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
-
-            if ($this->isRunningAsPhar() && null === $input->getOption(self::AUTOLOAD_PARAM)) {
+            if ($this->isRunningAsPhar() && null === $options->getAutoloadFilePath()) {
                 $output->writeln('❌ The --autoload option is required when running phparkitect as a PHAR');
 
                 return self::ERROR_CODE;
             }
 
             $this->printHeadingLine($output);
+            $this->requireAutoload($output, $options->getAutoloadFilePath());
 
-            $config = ConfigBuilder::loadFromFile($rulesFilename)
-                ->autoloadFilePath($input->getOption(self::AUTOLOAD_PARAM))
-                ->stopOnFailure($stopOnFailure)
-                ->targetPhpVersion(TargetPhpVersion::create($phpVersion))
-                ->baselineFilePath(Baseline::resolveFilePath($useBaseline, self::DEFAULT_BASELINE_FILENAME))
-                ->ignoreBaselineLinenumbers($ignoreBaselineLinenumbers)
-                ->skipBaseline($skipBaseline)
-                ->format($format);
-
-            $this->requireAutoload($output, $config->getAutoloadFilePath());
-            $printer = $this->createPrinter($output, $config->getFormat());
+            $output->writeln("Output format: {$options->getFormat()}");
             $progress = $this->createProgress($output, $verbose);
-            $baseline = $this->createBaseline($output, $config->isSkipBaseline(), $config->getBaselineFilePath());
 
-            $output->writeln("Config file '$rulesFilename' found\n");
-
-            $runner = new Runner();
-
-            if (false !== $generateBaseline) {
-                $result = $runner->baseline($config, $progress);
-
-                $baselineFilePath = Baseline::save($generateBaseline, self::DEFAULT_BASELINE_FILENAME, $result->getViolations(), $ignoreBaselineLinenumbers);
-
-                $output->writeln("ℹ️ Baseline file '$baselineFilePath' created!");
+            if ($options->shouldGenerateBaseline()) {
+                $this->handler->generateBaseline($options, $progress, $output);
 
                 return self::SUCCESS_CODE;
             }
 
-            $result = $runner->run($config, $baseline, $progress);
-
-            // we always print this so we do not have to do additional ifs later
-            $stdOut->writeln($printer->print($result->getViolations()->groupedByFqcn()));
-
-            if ($result->hasViolations()) {
-                $output->writeln("⚠️ {$result->getViolations()->count()} violations detected!");
-            }
-
-            $staleViolationsCount = $baseline->getStaleViolationsCount();
-            if ($staleViolationsCount > 0) {
-                $verb = 1 === $staleViolationsCount ? 'looks' : 'look';
-                $pronoun = 1 === $staleViolationsCount ? 'it' : 'them';
-                $noun = 1 === $staleViolationsCount ? 'violation' : 'violations';
-                $output->writeln("💡 {$staleViolationsCount} {$noun} in the baseline {$verb} fixed — regenerate the baseline to remove {$pronoun}");
-            }
-
-            if ($result->hasParsingErrors()) {
-                $output->writeln('❌ found parsing errors in these files:');
-                foreach ($result->getParsingErrors() as $parsingError) {
-                    $output->writeln("$parsingError");
-                }
-            }
-
-            !$result->hasErrors() && $output->writeln('✅ No violations detected');
+            $result = $this->handler->check($options, $progress, $output, $stdOut);
 
             return $result->hasErrors() ? self::ERROR_CODE : self::SUCCESS_CODE;
         } catch (\Throwable $e) {
@@ -205,6 +156,29 @@ class Check extends Command
         } finally {
             $this->printExecutionTime($output, $startTime);
         }
+    }
+
+    protected function parseOptions(InputInterface $input): CheckOptions
+    {
+        $targetPhpVersion = $input->getOption(self::TARGET_PHP_PARAM);
+        $autoloadFilePath = $input->getOption(self::AUTOLOAD_PARAM);
+        $useBaseline = (string) $input->getOption(self::USE_BASELINE_PARAM);
+
+        // false = option not set, null = option set but without value, string = option with value
+        $generateBaseline = $input->getOption(self::GENERATE_BASELINE_PARAM);
+
+        return new CheckOptions(
+            configFilePath: (string) $input->getOption(self::CONFIG_FILENAME_PARAM),
+            targetPhpVersion: \is_string($targetPhpVersion) ? $targetPhpVersion : null,
+            stopOnFailure: (bool) $input->getOption(self::STOP_ON_FAILURE_PARAM),
+            baselineFilePath: Baseline::resolveFilePath($useBaseline, Baseline::DEFAULT_FILENAME),
+            skipBaseline: (bool) $input->getOption(self::SKIP_BASELINE_PARAM),
+            ignoreBaselineLinenumbers: (bool) $input->getOption(self::IGNORE_BASELINE_LINENUMBERS_PARAM),
+            generateBaseline: false !== $generateBaseline,
+            generateBaselineFilePath: \is_string($generateBaseline) ? $generateBaseline : null,
+            format: (string) $input->getOption(self::FORMAT_PARAM),
+            autoloadFilePath: \is_string($autoloadFilePath) ? $autoloadFilePath : null,
+        );
     }
 
     /**
@@ -223,27 +197,11 @@ class Check extends Command
         $output->writeln("Autoload file '$filePath' added");
     }
 
-    protected function createPrinter(OutputInterface $output, string $format): Printer
-    {
-        $output->writeln("Output format: $format");
-
-        return PrinterFactory::create($format);
-    }
-
     protected function createProgress(OutputInterface $output, bool $verbose): Progress
     {
         $output->writeln('Progress: '.($verbose ? 'debug' : 'bar'));
 
         return $verbose ? new DebugProgress($output) : new ProgressBarProgress($output);
-    }
-
-    protected function createBaseline(OutputInterface $output, bool $skipBaseline, ?string $baselineFilePath): Baseline
-    {
-        $baseline = Baseline::create($skipBaseline, $baselineFilePath);
-
-        $baseline->getFilename() && $output->writeln("Baseline file '{$baseline->getFilename()}' found");
-
-        return $baseline;
     }
 
     protected function printHeadingLine(OutputInterface $output): void

--- a/tests/Unit/CLI/CheckHandlerTest.php
+++ b/tests/Unit/CLI/CheckHandlerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\CLI;
+
+use Arkitect\CLI\CheckHandler;
+use Arkitect\CLI\CheckOptions;
+use Arkitect\CLI\Progress\VoidProgress;
+use Arkitect\CLI\Runner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CheckHandlerTest extends TestCase
+{
+    private string $generatedBaselineFilePath = __DIR__.'/_fixtures/checkhandler/generated-baseline.json';
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->generatedBaselineFilePath)) {
+            unlink($this->generatedBaselineFilePath);
+        }
+    }
+
+    public function test_check_reports_violations(): void
+    {
+        $handler = new CheckHandler(new Runner());
+        $output = new BufferedOutput();
+        $violationsOutput = new BufferedOutput();
+
+        $result = $handler->check(
+            $this->createOptions(configFilePath: __DIR__.'/_fixtures/checkhandler/configWithViolations.php'),
+            new VoidProgress(),
+            $output,
+            $violationsOutput
+        );
+
+        self::assertTrue($result->hasViolations());
+        self::assertStringContainsString('App\Foo has 1 violations', $violationsOutput->fetch());
+        self::assertStringContainsString('⚠️ 1 violations detected!', $output->fetch());
+    }
+
+    public function test_check_reports_success_when_there_are_no_violations(): void
+    {
+        $handler = new CheckHandler(new Runner());
+        $output = new BufferedOutput();
+        $violationsOutput = new BufferedOutput();
+
+        $result = $handler->check(
+            $this->createOptions(configFilePath: __DIR__.'/_fixtures/checkhandler/configWithoutViolations.php'),
+            new VoidProgress(),
+            $output,
+            $violationsOutput
+        );
+
+        self::assertFalse($result->hasErrors());
+        self::assertStringContainsString('✅ No violations detected', $output->fetch());
+    }
+
+    public function test_check_applies_the_baseline(): void
+    {
+        $handler = new CheckHandler(new Runner());
+        $output = new BufferedOutput();
+
+        $handler->generateBaseline(
+            $this->createOptions(
+                configFilePath: __DIR__.'/_fixtures/checkhandler/configWithViolations.php',
+                generateBaseline: true,
+                generateBaselineFilePath: $this->generatedBaselineFilePath
+            ),
+            new VoidProgress(),
+            $output
+        );
+
+        $result = $handler->check(
+            $this->createOptions(
+                configFilePath: __DIR__.'/_fixtures/checkhandler/configWithViolations.php',
+                baselineFilePath: $this->generatedBaselineFilePath
+            ),
+            new VoidProgress(),
+            $output,
+            new BufferedOutput()
+        );
+
+        self::assertFalse($result->hasErrors());
+        self::assertStringContainsString("Baseline file '{$this->generatedBaselineFilePath}' found", $output->fetch());
+    }
+
+    public function test_generate_baseline_writes_the_violations_to_a_file(): void
+    {
+        $handler = new CheckHandler(new Runner());
+        $output = new BufferedOutput();
+
+        $handler->generateBaseline(
+            $this->createOptions(
+                configFilePath: __DIR__.'/_fixtures/checkhandler/configWithViolations.php',
+                generateBaseline: true,
+                generateBaselineFilePath: $this->generatedBaselineFilePath
+            ),
+            new VoidProgress(),
+            $output
+        );
+
+        self::assertFileExists($this->generatedBaselineFilePath);
+        self::assertStringContainsString("ℹ️ Baseline file '{$this->generatedBaselineFilePath}' created!", $output->fetch());
+
+        $baseline = json_decode((string) file_get_contents($this->generatedBaselineFilePath), true);
+
+        self::assertCount(1, $baseline['violations']);
+        self::assertSame('App\Foo', $baseline['violations'][0]['fqcn']);
+    }
+
+    private function createOptions(
+        string $configFilePath,
+        ?string $baselineFilePath = null,
+        bool $generateBaseline = false,
+        ?string $generateBaselineFilePath = null,
+    ): CheckOptions {
+        return new CheckOptions(
+            configFilePath: $configFilePath,
+            targetPhpVersion: null,
+            stopOnFailure: false,
+            baselineFilePath: $baselineFilePath,
+            skipBaseline: false,
+            ignoreBaselineLinenumbers: false,
+            generateBaseline: $generateBaseline,
+            generateBaselineFilePath: $generateBaselineFilePath,
+            format: 'text',
+            autoloadFilePath: null,
+        );
+    }
+}

--- a/tests/Unit/CLI/_fixtures/checkhandler/configWithViolations.php
+++ b/tests/Unit/CLI/_fixtures/checkhandler/configWithViolations.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Arkitect\ClassSet;
+use Arkitect\CLI\Config;
+use Arkitect\Expression\ForClasses\HaveNameMatching;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+
+return static function (Config $config): void {
+    $classSet = ClassSet::fromDir(__DIR__.'/src');
+
+    $rule = Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('App'))
+        ->should(new HaveNameMatching('*Controller'))
+        ->because('we want uniform naming');
+
+    $config->add($classSet, $rule);
+};

--- a/tests/Unit/CLI/_fixtures/checkhandler/configWithoutViolations.php
+++ b/tests/Unit/CLI/_fixtures/checkhandler/configWithoutViolations.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Arkitect\ClassSet;
+use Arkitect\CLI\Config;
+use Arkitect\Expression\ForClasses\HaveNameMatching;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+
+return static function (Config $config): void {
+    $classSet = ClassSet::fromDir(__DIR__.'/src');
+
+    $rule = Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('App'))
+        ->should(new HaveNameMatching('Foo'))
+        ->because('we want uniform naming');
+
+    $config->add($classSet, $rule);
+};

--- a/tests/Unit/CLI/_fixtures/checkhandler/src/Foo.php
+++ b/tests/Unit/CLI/_fixtures/checkhandler/src/Foo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+class Foo
+{
+}


### PR DESCRIPTION
Check::execute mixed CLI concerns (option parsing, stdout/stderr split,
exit codes) with the actual check flow (config loading, baseline handling,
running the analysis, rendering the result), which made the flow testable
only end-to-end.

- New CheckOptions: immutable value object with the parsed CLI options,
  so no Symfony Input concerns leak past the command.
- New CheckHandler: application service that loads the config, runs the
  analysis (check or baseline generation, now two separate methods) and
  renders the result to the given outputs. Runner is injected, so the
  flow is unit-testable with a BufferedOutput.
- Check keeps only CLI concerns: option definitions/parsing, the
  stdout/stderr split, ini_set, the phar autoload guard, requireAutoload
  (global side effect stays in the command), progress creation and exit
  codes. The handler can be injected for testing.
- Baseline::DEFAULT_FILENAME replaces the private constant in Check since
  both the command and the handler need it.
- Unit tests for CheckHandler covering violations, success, baseline
  generation and baseline application, with dedicated fixtures.

Behavior is preserved, with one benign difference: the autoload file is
now required before the config file is loaded (it was loaded after), so
user config files can now reference autoloaded classes at load time.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015K1TKiwtwkW7twBCTz758P