### PR TITLE
Extract CommonOptions, composed by analysis-running commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Before committing, `make csfix && make psalm && make test` must all pass (CI gat
 
 ## Pipeline (how a `check` run flows)
 
-`bin/phparkitect` → `PhpArkitectApplication` registers the commands in `src/CLI/Command/` (`Check`, `Init`, `DebugExpression`).
+`bin/phparkitect` → `PhpArkitectApplication` registers the commands in `src/CLI/Command/` (`Check`, `Init`, `DebugExpression`). Options shared between analysis-running commands (`--config`, `--target-php-version`, `--autoload`, `--ignore-baseline-linenumbers`) are defined once in `CommonOptions`, composed by each command.
 
 `Check::execute` (`src/CLI/Command/Check.php`) parses the CLI options into a `CheckOptions` value object and delegates to `CheckHandler` (`src/CLI/CheckHandler.php`), the application service that runs the actual flow:
 1. `ConfigBuilder` loads the user's `phparkitect.php`, which receives a `Config` and registers `ClassSet`s + `Rule`s.

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -16,29 +16,29 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Webmozart\Assert\Assert;
 
 class Check extends Command
 {
-    private const CONFIG_FILENAME_PARAM = 'config';
-    private const TARGET_PHP_PARAM = 'target-php-version';
     private const STOP_ON_FAILURE_PARAM = 'stop-on-failure';
     private const USE_BASELINE_PARAM = 'use-baseline';
     private const SKIP_BASELINE_PARAM = 'skip-baseline';
-    private const IGNORE_BASELINE_LINENUMBERS_PARAM = 'ignore-baseline-linenumbers';
     private const FORMAT_PARAM = 'format';
-    private const AUTOLOAD_PARAM = 'autoload';
 
     private const GENERATE_BASELINE_PARAM = 'generate-baseline';
-    private const DEFAULT_RULES_FILENAME = 'phparkitect.php';
 
     private const SUCCESS_CODE = 0;
     private const ERROR_CODE = 1;
 
     private CheckHandler $handler;
 
+    private CommonOptions $commonOptions;
+
     public function __construct(?CheckHandler $handler = null)
     {
+        // assigned before the parent constructor because Symfony's
+        // Command::__construct() invokes configure(), which uses it
+        $this->commonOptions = new CommonOptions();
+
         parent::__construct('check');
 
         $this->handler = $handler ?? new CheckHandler(new Runner());
@@ -49,19 +49,6 @@ class Check extends Command
         $this
             ->setDescription('Check that architectural rules are matched.')
             ->setHelp('This command allows you check that architectural rules defined in your config file are matched.')
-            ->addOption(
-                self::CONFIG_FILENAME_PARAM,
-                'c',
-                InputOption::VALUE_OPTIONAL,
-                'File containing configs, such as rules to be matched',
-                self::DEFAULT_RULES_FILENAME
-            )
-            ->addOption(
-                self::TARGET_PHP_PARAM,
-                't',
-                InputOption::VALUE_OPTIONAL,
-                'Target php version to use for parsing'
-            )
             ->addOption(
                 self::STOP_ON_FAILURE_PARAM,
                 's',
@@ -88,24 +75,14 @@ class Check extends Command
                 'Don\'t use the default baseline'
             )
             ->addOption(
-                self::IGNORE_BASELINE_LINENUMBERS_PARAM,
-                'i',
-                InputOption::VALUE_NONE,
-                'Ignore line numbers when checking the baseline'
-            )
-            ->addOption(
                 self::FORMAT_PARAM,
                 'f',
                 InputOption::VALUE_OPTIONAL,
                 'Output format: text (default), json, gitlab',
                 'text'
-            )
-            ->addOption(
-                self::AUTOLOAD_PARAM,
-                'a',
-                InputOption::VALUE_REQUIRED,
-                'Specify an autoload file to use',
             );
+
+        $this->commonOptions->addTo($this);
     }
 
     protected function isRunningAsPhar(): bool
@@ -135,7 +112,7 @@ class Check extends Command
             }
 
             $this->printHeadingLine($output);
-            $this->requireAutoload($output, $options->getAutoloadFilePath());
+            $this->commonOptions->requireAutoload($input, $output);
 
             $output->writeln("Output format: {$options->getFormat()}");
             $progress = $this->createProgress($output, $verbose);
@@ -160,41 +137,23 @@ class Check extends Command
 
     protected function parseOptions(InputInterface $input): CheckOptions
     {
-        $targetPhpVersion = $input->getOption(self::TARGET_PHP_PARAM);
-        $autoloadFilePath = $input->getOption(self::AUTOLOAD_PARAM);
         $useBaseline = (string) $input->getOption(self::USE_BASELINE_PARAM);
 
         // false = option not set, null = option set but without value, string = option with value
         $generateBaseline = $input->getOption(self::GENERATE_BASELINE_PARAM);
 
         return new CheckOptions(
-            configFilePath: (string) $input->getOption(self::CONFIG_FILENAME_PARAM),
-            targetPhpVersion: \is_string($targetPhpVersion) ? $targetPhpVersion : null,
+            configFilePath: $this->commonOptions->configFilePath($input),
+            targetPhpVersion: $this->commonOptions->targetPhpVersion($input),
             stopOnFailure: (bool) $input->getOption(self::STOP_ON_FAILURE_PARAM),
             baselineFilePath: Baseline::resolveFilePath($useBaseline, Baseline::DEFAULT_FILENAME),
             skipBaseline: (bool) $input->getOption(self::SKIP_BASELINE_PARAM),
-            ignoreBaselineLinenumbers: (bool) $input->getOption(self::IGNORE_BASELINE_LINENUMBERS_PARAM),
+            ignoreBaselineLinenumbers: $this->commonOptions->isIgnoreBaselineLinenumbers($input),
             generateBaseline: false !== $generateBaseline,
             generateBaselineFilePath: \is_string($generateBaseline) ? $generateBaseline : null,
             format: (string) $input->getOption(self::FORMAT_PARAM),
-            autoloadFilePath: \is_string($autoloadFilePath) ? $autoloadFilePath : null,
+            autoloadFilePath: $this->commonOptions->autoloadFilePath($input),
         );
-    }
-
-    /**
-     * @psalm-suppress UnresolvableInclude
-     */
-    protected function requireAutoload(OutputInterface $output, ?string $filePath): void
-    {
-        if (null === $filePath) {
-            return;
-        }
-
-        Assert::file($filePath, "Cannot find '$filePath'");
-
-        require_once $filePath;
-
-        $output->writeln("Autoload file '$filePath' added");
     }
 
     protected function createProgress(OutputInterface $output, bool $verbose): Progress

--- a/src/CLI/Command/CommonOptions.php
+++ b/src/CLI/Command/CommonOptions.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\CLI\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * The CLI options shared by every command that runs an analysis.
+ * Commands compose this object so the option names, shortcuts, defaults
+ * and parsing stay in sync across the whole CLI.
+ */
+final class CommonOptions
+{
+    public const CONFIG_PARAM = 'config';
+    public const TARGET_PHP_PARAM = 'target-php-version';
+    public const AUTOLOAD_PARAM = 'autoload';
+    public const IGNORE_BASELINE_LINENUMBERS_PARAM = 'ignore-baseline-linenumbers';
+
+    private const DEFAULT_RULES_FILENAME = 'phparkitect.php';
+
+    public function addTo(Command $command): void
+    {
+        $command
+            ->addOption(
+                self::CONFIG_PARAM,
+                'c',
+                InputOption::VALUE_OPTIONAL,
+                'File containing configs, such as rules to be matched',
+                self::DEFAULT_RULES_FILENAME
+            )
+            ->addOption(
+                self::TARGET_PHP_PARAM,
+                't',
+                InputOption::VALUE_OPTIONAL,
+                'Target php version to use for parsing'
+            )
+            ->addOption(
+                self::AUTOLOAD_PARAM,
+                'a',
+                InputOption::VALUE_REQUIRED,
+                'Specify an autoload file to use',
+            )
+            ->addOption(
+                self::IGNORE_BASELINE_LINENUMBERS_PARAM,
+                'i',
+                InputOption::VALUE_NONE,
+                'Ignore line numbers when checking the baseline'
+            );
+    }
+
+    public function configFilePath(InputInterface $input): string
+    {
+        return (string) $input->getOption(self::CONFIG_PARAM);
+    }
+
+    public function targetPhpVersion(InputInterface $input): ?string
+    {
+        $targetPhpVersion = $input->getOption(self::TARGET_PHP_PARAM);
+
+        return \is_string($targetPhpVersion) ? $targetPhpVersion : null;
+    }
+
+    public function autoloadFilePath(InputInterface $input): ?string
+    {
+        $autoloadFilePath = $input->getOption(self::AUTOLOAD_PARAM);
+
+        return \is_string($autoloadFilePath) ? $autoloadFilePath : null;
+    }
+
+    public function isIgnoreBaselineLinenumbers(InputInterface $input): bool
+    {
+        return (bool) $input->getOption(self::IGNORE_BASELINE_LINENUMBERS_PARAM);
+    }
+
+    /**
+     * Loading the autoload file is a process-wide side effect, so it belongs
+     * to the command layer: it is kept here, next to the option it consumes,
+     * and out of the unit-testable handlers.
+     *
+     * @psalm-suppress UnresolvableInclude
+     */
+    public function requireAutoload(InputInterface $input, OutputInterface $output): void
+    {
+        $filePath = $this->autoloadFilePath($input);
+
+        if (null === $filePath) {
+            return;
+        }
+
+        Assert::file($filePath, "Cannot find '$filePath'");
+
+        require_once $filePath;
+
+        $output->writeln("Autoload file '$filePath' added");
+    }
+}


### PR DESCRIPTION
### Improvement

|    Q        |   A
|------------ | ------
| New Feature | no
| BC Break    | no
| Issue       | Prepares #648 and #649

#### Summary

First step of a three-PR series toward the `*-baseline` command family (#648, #649): a pure refactoring of `check`, with no behavior change.

The upcoming `generate-baseline` and `prune-baseline` commands need the same `--config`, `--target-php-version`, `--autoload` and `--ignore-baseline-linenumbers` options as `check`. Defining them per command would let names, shortcuts, defaults and parsing drift apart, so they move to **`CommonOptions`**, a collaborator each command composes: `addTo()` defines the options in `configure()`, and typed readers (`configFilePath()`, `targetPhpVersion()`, …) parse them from the `InputInterface`.

`CommonOptions` also owns `requireAutoload()`, the behavior attached to its autoload option — the `require_once` side effect stays in the command layer, out of the unit-testable handlers.

Composition is deliberate (no base command class, no trait): commands keep their flat structure and the shared surface is an explicit object.

`check`'s `--help` output is identical apart from option ordering; the whole test suite passes unchanged.

**Series**: this PR → add `generate-baseline` as a new command while keeping the old flag working (#648, additive) → turn `check --generate-baseline` into a fail-fast pointer to the new command (#648, the only BC-breaking step, isolated for discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015K1TKiwtwkW7twBCTz758P