### PR TITLE
Promote --generate-baseline to a first-class generate-baseline command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Before committing, `make csfix && make psalm && make test` must all pass (CI gat
 
 ## Pipeline (how a `check` run flows)
 
-`bin/phparkitect` → `PhpArkitectApplication` registers the commands in `src/CLI/Command/` (`Check`, `GenerateBaseline`, `Init`, `DebugExpression`). Options shared between analysis-running commands (`--config`, `--target-php-version`, `--autoload`, `--ignore-baseline-linenumbers`) are defined once in `CommonOptions`, composed by each command.
+`bin/phparkitect` → `PhpArkitectApplication` registers the commands in `src/CLI/Command/` (`Check`, `GenerateBaseline`, `Init`, `DebugExpression`). Options shared between analysis-running commands (`--config`, `--target-php-version`, `--autoload`, `--ignore-baseline-linenumbers`) are defined once in `CommonOptions`, and the shared console plumbing (process limits, progress, heading, timing) in `CommandRuntime` — both composed by each command.
 
 `Check::execute` (`src/CLI/Command/Check.php`) parses the CLI options into a `CheckOptions` value object and delegates to `CheckHandler` (`src/CLI/CheckHandler.php`), the application service that runs the actual flow:
 1. `ConfigBuilder` loads the user's `phparkitect.php`, which receives a `Config` and registers `ClassSet`s + `Rule`s.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Before committing, `make csfix && make psalm && make test` must all pass (CI gat
 
 ## Pipeline (how a `check` run flows)
 
-`bin/phparkitect` → `PhpArkitectApplication` registers the commands in `src/CLI/Command/` (`Check`, `Init`, `DebugExpression`). Options shared between analysis-running commands (`--config`, `--target-php-version`, `--autoload`, `--ignore-baseline-linenumbers`) are defined once in `CommonOptions`, composed by each command.
+`bin/phparkitect` → `PhpArkitectApplication` registers the commands in `src/CLI/Command/` (`Check`, `GenerateBaseline`, `Init`, `DebugExpression`). Options shared between analysis-running commands (`--config`, `--target-php-version`, `--autoload`, `--ignore-baseline-linenumbers`) are defined once in `CommonOptions`, composed by each command.
 
 `Check::execute` (`src/CLI/Command/Check.php`) parses the CLI options into a `CheckOptions` value object and delegates to `CheckHandler` (`src/CLI/CheckHandler.php`), the application service that runs the actual flow:
 1. `ConfigBuilder` loads the user's `phparkitect.php`, which receives a `Config` and registers `ClassSet`s + `Rule`s.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ Every setting can be passed as a CLI option or set via the corresponding `Config
 | `--skip-baseline` | `-k` | `skipBaseline()` | Skips the default baseline even if present. |
 | `--ignore-baseline-linenumbers` | `-i` | `ignoreBaselineLinenumbers()` | Matches baseline violations without checking line numbers. |
 | `--config` | `-c` | — | Configuration file to load (default: `phparkitect.php`). |
-| `--generate-baseline` | `-g` | — | Writes current violations to a baseline file instead of failing. |
 | `--verbose` | `-v` | — | Prints every parsed file instead of the progress bar. |
 | — | — | `skipParsingCustomAnnotations()` | Disables custom DocBlock annotation parsing (enabled by default). |
 
@@ -155,10 +154,14 @@ Every setting can be passed as a CLI option or set via the corresponding `Config
 If your codebase already has violations you can't fix right now, generate a baseline to ignore them:
 
 ```
-phparkitect check --generate-baseline
+phparkitect generate-baseline
 ```
 
-This creates `phparkitect-baseline.json`. Subsequent runs pick it up automatically. Use a custom file name with `--generate-baseline=my-baseline.json`, point to it with `--use-baseline=my-baseline.json`, or skip it entirely with `--skip-baseline`.
+This creates `phparkitect-baseline.json`. Subsequent `check` runs pick it up automatically. Use a custom file name with `phparkitect generate-baseline my-baseline.json`, point `check` to it with `--use-baseline=my-baseline.json`, or skip it entirely with `--skip-baseline`.
+
+The `generate-baseline` command accepts the same `--config`, `--target-php-version`, `--autoload` and `--ignore-baseline-linenumbers` options as `check`.
+
+> **Note**: baseline generation was previously a `check` option (`check --generate-baseline`); it is now a dedicated command, and the old option fails with a pointer to the new one.
 
 By default the baseline also checks line numbers — a change before the offending line shifts the number and the check fails. Use `--ignore-baseline-linenumbers` to match violations regardless of line number.
 

--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -81,18 +81,12 @@ class Baseline
         );
     }
 
-    public static function save(?string $filename, string $defaultFilePath, Violations $violations, bool $ignoreLineNumbers = false): string
+    public static function save(string $filename, Violations $violations, bool $ignoreLineNumbers = false): void
     {
-        if (null === $filename) {
-            $filename = $defaultFilePath;
-        }
-
         if ($ignoreLineNumbers) {
             $violations = $violations->withoutLineNumbers();
         }
 
         file_put_contents($filename, json_encode($violations, \JSON_PRETTY_PRINT));
-
-        return $filename;
     }
 }

--- a/src/CLI/CheckHandler.php
+++ b/src/CLI/CheckHandler.php
@@ -26,7 +26,20 @@ final class CheckHandler
         OutputInterface $output,
         OutputInterface $violationsOutput,
     ): AnalysisResult {
-        [$config, $baseline] = $this->prepare($options, $output);
+        $config = ConfigBuilder::loadFromFile($options->getConfigFilePath())
+            ->autoloadFilePath($options->getAutoloadFilePath())
+            ->stopOnFailure($options->isStopOnFailure())
+            ->targetPhpVersion(TargetPhpVersion::create($options->getTargetPhpVersion()))
+            ->baselineFilePath($options->getBaselineFilePath())
+            ->ignoreBaselineLinenumbers($options->isIgnoreBaselineLinenumbers())
+            ->skipBaseline($options->isSkipBaseline())
+            ->format($options->getFormat());
+
+        $baseline = Baseline::create($config->isSkipBaseline(), $config->getBaselineFilePath());
+
+        $baseline->getFilename() && $output->writeln("Baseline file '{$baseline->getFilename()}' found");
+
+        $output->writeln("Config file '{$options->getConfigFilePath()}' found\n");
 
         $printer = PrinterFactory::create($config->getFormat());
 
@@ -51,45 +64,6 @@ final class CheckHandler
         !$result->hasErrors() && $output->writeln('✅ No violations detected');
 
         return $result;
-    }
-
-    public function generateBaseline(CheckOptions $options, Progress $progress, OutputInterface $output): void
-    {
-        [$config] = $this->prepare($options, $output);
-
-        $result = $this->runner->baseline($config, $progress);
-
-        $baselineFilePath = Baseline::save(
-            $options->getGenerateBaselineFilePath(),
-            Baseline::DEFAULT_FILENAME,
-            $result->getViolations(),
-            $options->isIgnoreBaselineLinenumbers()
-        );
-
-        $output->writeln("ℹ️ Baseline file '$baselineFilePath' created!");
-    }
-
-    /**
-     * @return array{Config, Baseline}
-     */
-    private function prepare(CheckOptions $options, OutputInterface $output): array
-    {
-        $config = ConfigBuilder::loadFromFile($options->getConfigFilePath())
-            ->autoloadFilePath($options->getAutoloadFilePath())
-            ->stopOnFailure($options->isStopOnFailure())
-            ->targetPhpVersion(TargetPhpVersion::create($options->getTargetPhpVersion()))
-            ->baselineFilePath($options->getBaselineFilePath())
-            ->ignoreBaselineLinenumbers($options->isIgnoreBaselineLinenumbers())
-            ->skipBaseline($options->isSkipBaseline())
-            ->format($options->getFormat());
-
-        $baseline = Baseline::create($config->isSkipBaseline(), $config->getBaselineFilePath());
-
-        $baseline->getFilename() && $output->writeln("Baseline file '{$baseline->getFilename()}' found");
-
-        $output->writeln("Config file '{$options->getConfigFilePath()}' found\n");
-
-        return [$config, $baseline];
     }
 
     private function printStaleBaselineViolations(Baseline $baseline, OutputInterface $output): void

--- a/src/CLI/CheckOptions.php
+++ b/src/CLI/CheckOptions.php
@@ -17,8 +17,6 @@ final class CheckOptions
         private ?string $baselineFilePath,
         private bool $skipBaseline,
         private bool $ignoreBaselineLinenumbers,
-        private bool $generateBaseline,
-        private ?string $generateBaselineFilePath,
         private string $format,
         private ?string $autoloadFilePath,
     ) {
@@ -52,16 +50,6 @@ final class CheckOptions
     public function isIgnoreBaselineLinenumbers(): bool
     {
         return $this->ignoreBaselineLinenumbers;
-    }
-
-    public function shouldGenerateBaseline(): bool
-    {
-        return $this->generateBaseline;
-    }
-
-    public function getGenerateBaselineFilePath(): ?string
-    {
-        return $this->generateBaselineFilePath;
     }
 
     public function getFormat(): string

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -7,9 +7,6 @@ namespace Arkitect\CLI\Command;
 use Arkitect\CLI\Baseline;
 use Arkitect\CLI\CheckHandler;
 use Arkitect\CLI\CheckOptions;
-use Arkitect\CLI\Progress\DebugProgress;
-use Arkitect\CLI\Progress\Progress;
-use Arkitect\CLI\Progress\ProgressBarProgress;
 use Arkitect\CLI\Runner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,12 +23,11 @@ class Check extends Command
 
     private const GENERATE_BASELINE_PARAM = 'generate-baseline';
 
-    private const SUCCESS_CODE = 0;
-    private const ERROR_CODE = 1;
-
     private CheckHandler $handler;
 
     private CommonOptions $commonOptions;
+
+    private CommandRuntime $runtime;
 
     public function __construct(?CheckHandler $handler = null)
     {
@@ -42,6 +38,7 @@ class Check extends Command
         parent::__construct('check');
 
         $this->handler = $handler ?? new CheckHandler(new Runner());
+        $this->runtime = new CommandRuntime();
     }
 
     protected function configure(): void
@@ -92,8 +89,7 @@ class Check extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        ini_set('memory_limit', '-1');
-        ini_set('xdebug.max_nesting_level', '10000');
+        $this->runtime->raiseLimits();
         $startTime = microtime(true);
 
         // we write everything on STDERR apart from the list of violations which goes on STDOUT
@@ -110,7 +106,7 @@ class Check extends Command
                 $output->writeln('❌ The --generate-baseline option has been moved to its own command.');
                 $output->writeln("   Run: phparkitect generate-baseline$filename");
 
-                return self::ERROR_CODE;
+                return self::FAILURE;
             }
 
             $verbose = (bool) $input->getOption('verbose');
@@ -119,24 +115,24 @@ class Check extends Command
             if ($this->isRunningAsPhar() && null === $options->getAutoloadFilePath()) {
                 $output->writeln('❌ The --autoload option is required when running phparkitect as a PHAR');
 
-                return self::ERROR_CODE;
+                return self::FAILURE;
             }
 
-            $this->printHeadingLine($output);
+            $this->runtime->printHeadingLine($this, $output);
             $this->commonOptions->requireAutoload($input, $output);
 
             $output->writeln("Output format: {$options->getFormat()}");
-            $progress = $this->createProgress($output, $verbose);
+            $progress = $this->runtime->createProgress($output, $verbose);
 
             $result = $this->handler->check($options, $progress, $output, $stdOut);
 
-            return $result->hasErrors() ? self::ERROR_CODE : self::SUCCESS_CODE;
+            return $result->hasErrors() ? self::FAILURE : self::SUCCESS;
         } catch (\Throwable $e) {
             $output->writeln("❌ {$e->getMessage()}");
 
-            return self::ERROR_CODE;
+            return self::FAILURE;
         } finally {
-            $this->printExecutionTime($output, $startTime);
+            $this->runtime->printExecutionTime($output, $startTime);
         }
     }
 
@@ -154,29 +150,5 @@ class Check extends Command
             format: (string) $input->getOption(self::FORMAT_PARAM),
             autoloadFilePath: $this->commonOptions->autoloadFilePath($input),
         );
-    }
-
-    protected function createProgress(OutputInterface $output, bool $verbose): Progress
-    {
-        $output->writeln('Progress: '.($verbose ? 'debug' : 'bar'));
-
-        return $verbose ? new DebugProgress($output) : new ProgressBarProgress($output);
-    }
-
-    protected function printHeadingLine(OutputInterface $output): void
-    {
-        $app = $this->getApplication();
-
-        $version = $app ? $app->getVersion() : 'unknown';
-
-        $output->writeln("<info>PHPArkitect $version</info>\n");
-    }
-
-    protected function printExecutionTime(OutputInterface $output, float $startTime): void
-    {
-        $endTime = microtime(true);
-        $executionTime = number_format($endTime - $startTime, 2);
-
-        $output->writeln("⏱️ Execution time: $executionTime\n");
     }
 }

--- a/src/CLI/Command/Check.php
+++ b/src/CLI/Command/Check.php
@@ -59,7 +59,7 @@ class Check extends Command
                 self::GENERATE_BASELINE_PARAM,
                 'g',
                 InputOption::VALUE_OPTIONAL,
-                'Generate a file containing the current errors',
+                '[MOVED] Use the generate-baseline command instead',
                 false
             )
             ->addOption(
@@ -102,6 +102,17 @@ class Check extends Command
         $output = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
 
         try {
+            // the option is kept (instead of being removed) so users get this
+            // explanation rather than a generic "option does not exist" error
+            $generateBaseline = $input->getOption(self::GENERATE_BASELINE_PARAM);
+            if (false !== $generateBaseline) {
+                $filename = \is_string($generateBaseline) ? " $generateBaseline" : '';
+                $output->writeln('❌ The --generate-baseline option has been moved to its own command.');
+                $output->writeln("   Run: phparkitect generate-baseline$filename");
+
+                return self::ERROR_CODE;
+            }
+
             $verbose = (bool) $input->getOption('verbose');
             $options = $this->parseOptions($input);
 
@@ -116,12 +127,6 @@ class Check extends Command
 
             $output->writeln("Output format: {$options->getFormat()}");
             $progress = $this->createProgress($output, $verbose);
-
-            if ($options->shouldGenerateBaseline()) {
-                $this->handler->generateBaseline($options, $progress, $output);
-
-                return self::SUCCESS_CODE;
-            }
 
             $result = $this->handler->check($options, $progress, $output, $stdOut);
 
@@ -139,9 +144,6 @@ class Check extends Command
     {
         $useBaseline = (string) $input->getOption(self::USE_BASELINE_PARAM);
 
-        // false = option not set, null = option set but without value, string = option with value
-        $generateBaseline = $input->getOption(self::GENERATE_BASELINE_PARAM);
-
         return new CheckOptions(
             configFilePath: $this->commonOptions->configFilePath($input),
             targetPhpVersion: $this->commonOptions->targetPhpVersion($input),
@@ -149,8 +151,6 @@ class Check extends Command
             baselineFilePath: Baseline::resolveFilePath($useBaseline, Baseline::DEFAULT_FILENAME),
             skipBaseline: (bool) $input->getOption(self::SKIP_BASELINE_PARAM),
             ignoreBaselineLinenumbers: $this->commonOptions->isIgnoreBaselineLinenumbers($input),
-            generateBaseline: false !== $generateBaseline,
-            generateBaselineFilePath: \is_string($generateBaseline) ? $generateBaseline : null,
             format: (string) $input->getOption(self::FORMAT_PARAM),
             autoloadFilePath: $this->commonOptions->autoloadFilePath($input),
         );

--- a/src/CLI/Command/CommandRuntime.php
+++ b/src/CLI/Command/CommandRuntime.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\CLI\Command;
+
+use Arkitect\CLI\Progress\DebugProgress;
+use Arkitect\CLI\Progress\Progress;
+use Arkitect\CLI\Progress\ProgressBarProgress;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The console plumbing shared by every command that runs an analysis:
+ * process limits, progress creation, the version heading and the
+ * execution-time footer. Commands compose this object (like CommonOptions)
+ * so the run lifecycle cannot drift between them.
+ */
+final class CommandRuntime
+{
+    public function raiseLimits(): void
+    {
+        ini_set('memory_limit', '-1');
+        ini_set('xdebug.max_nesting_level', '10000');
+    }
+
+    public function createProgress(OutputInterface $output, bool $verbose): Progress
+    {
+        $output->writeln('Progress: '.($verbose ? 'debug' : 'bar'));
+
+        return $verbose ? new DebugProgress($output) : new ProgressBarProgress($output);
+    }
+
+    public function printHeadingLine(Command $command, OutputInterface $output): void
+    {
+        $app = $command->getApplication();
+
+        $version = $app ? $app->getVersion() : 'unknown';
+
+        $output->writeln("<info>PHPArkitect $version</info>\n");
+    }
+
+    public function printExecutionTime(OutputInterface $output, float $startTime): void
+    {
+        $endTime = microtime(true);
+        $executionTime = number_format($endTime - $startTime, 2);
+
+        $output->writeln("⏱️ Execution time: $executionTime\n");
+    }
+}

--- a/src/CLI/Command/CommonOptions.php
+++ b/src/CLI/Command/CommonOptions.php
@@ -11,9 +11,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Webmozart\Assert\Assert;
 
 /**
- * The CLI options shared by every command that runs an analysis.
- * Commands compose this object so the option names, shortcuts, defaults
- * and parsing stay in sync across the whole CLI.
+ * The CLI options shared by every command that runs an analysis
+ * (`check`, `generate-baseline`). Commands compose this object so the
+ * option names, shortcuts, defaults and parsing stay in sync across
+ * the whole CLI.
  */
 final class CommonOptions
 {
@@ -50,7 +51,7 @@ final class CommonOptions
                 self::IGNORE_BASELINE_LINENUMBERS_PARAM,
                 'i',
                 InputOption::VALUE_NONE,
-                'Ignore line numbers when checking the baseline'
+                'Ignore line numbers when checking or generating the baseline'
             );
     }
 

--- a/src/CLI/Command/GenerateBaseline.php
+++ b/src/CLI/Command/GenerateBaseline.php
@@ -7,9 +7,6 @@ namespace Arkitect\CLI\Command;
 use Arkitect\CLI\Baseline;
 use Arkitect\CLI\GenerateBaselineHandler;
 use Arkitect\CLI\GenerateBaselineOptions;
-use Arkitect\CLI\Progress\DebugProgress;
-use Arkitect\CLI\Progress\Progress;
-use Arkitect\CLI\Progress\ProgressBarProgress;
 use Arkitect\CLI\Runner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -21,12 +18,11 @@ class GenerateBaseline extends Command
 {
     private const FILENAME_ARG = 'filename';
 
-    private const SUCCESS_CODE = 0;
-    private const ERROR_CODE = 1;
-
     private GenerateBaselineHandler $handler;
 
     private CommonOptions $commonOptions;
+
+    private CommandRuntime $runtime;
 
     public function __construct(?GenerateBaselineHandler $handler = null)
     {
@@ -37,6 +33,7 @@ class GenerateBaseline extends Command
         parent::__construct('generate-baseline');
 
         $this->handler = $handler ?? new GenerateBaselineHandler(new Runner());
+        $this->runtime = new CommandRuntime();
     }
 
     protected function configure(): void
@@ -61,8 +58,7 @@ class GenerateBaseline extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        ini_set('memory_limit', '-1');
-        ini_set('xdebug.max_nesting_level', '10000');
+        $this->runtime->raiseLimits();
         $startTime = microtime(true);
 
         // we write everything on STDERR to be consistent with the check command
@@ -75,23 +71,23 @@ class GenerateBaseline extends Command
             if ($this->isRunningAsPhar() && null === $options->getAutoloadFilePath()) {
                 $output->writeln('❌ The --autoload option is required when running phparkitect as a PHAR');
 
-                return self::ERROR_CODE;
+                return self::FAILURE;
             }
 
-            $this->printHeadingLine($output);
+            $this->runtime->printHeadingLine($this, $output);
             $this->commonOptions->requireAutoload($input, $output);
 
-            $progress = $this->createProgress($output, $verbose);
+            $progress = $this->runtime->createProgress($output, $verbose);
 
             $this->handler->generateBaseline($options, $progress, $output);
 
-            return self::SUCCESS_CODE;
+            return self::SUCCESS;
         } catch (\Throwable $e) {
             $output->writeln("❌ {$e->getMessage()}");
 
-            return self::ERROR_CODE;
+            return self::FAILURE;
         } finally {
-            $this->printExecutionTime($output, $startTime);
+            $this->runtime->printExecutionTime($output, $startTime);
         }
     }
 
@@ -104,29 +100,5 @@ class GenerateBaseline extends Command
             ignoreBaselineLinenumbers: $this->commonOptions->isIgnoreBaselineLinenumbers($input),
             baselineFilePath: (string) $input->getArgument(self::FILENAME_ARG),
         );
-    }
-
-    protected function createProgress(OutputInterface $output, bool $verbose): Progress
-    {
-        $output->writeln('Progress: '.($verbose ? 'debug' : 'bar'));
-
-        return $verbose ? new DebugProgress($output) : new ProgressBarProgress($output);
-    }
-
-    protected function printHeadingLine(OutputInterface $output): void
-    {
-        $app = $this->getApplication();
-
-        $version = $app ? $app->getVersion() : 'unknown';
-
-        $output->writeln("<info>PHPArkitect $version</info>\n");
-    }
-
-    protected function printExecutionTime(OutputInterface $output, float $startTime): void
-    {
-        $endTime = microtime(true);
-        $executionTime = number_format($endTime - $startTime, 2);
-
-        $output->writeln("⏱️ Execution time: $executionTime\n");
     }
 }

--- a/src/CLI/Command/GenerateBaseline.php
+++ b/src/CLI/Command/GenerateBaseline.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\CLI\Command;
+
+use Arkitect\CLI\Baseline;
+use Arkitect\CLI\GenerateBaselineHandler;
+use Arkitect\CLI\GenerateBaselineOptions;
+use Arkitect\CLI\Progress\DebugProgress;
+use Arkitect\CLI\Progress\Progress;
+use Arkitect\CLI\Progress\ProgressBarProgress;
+use Arkitect\CLI\Runner;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GenerateBaseline extends Command
+{
+    private const FILENAME_ARG = 'filename';
+
+    private const SUCCESS_CODE = 0;
+    private const ERROR_CODE = 1;
+
+    private GenerateBaselineHandler $handler;
+
+    private CommonOptions $commonOptions;
+
+    public function __construct(?GenerateBaselineHandler $handler = null)
+    {
+        // assigned before the parent constructor because Symfony's
+        // Command::__construct() invokes configure(), which uses it
+        $this->commonOptions = new CommonOptions();
+
+        parent::__construct('generate-baseline');
+
+        $this->handler = $handler ?? new GenerateBaselineHandler(new Runner());
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Generate a file containing the current violations, to be ignored by the check command.')
+            ->setHelp('This command runs the analysis and saves the current violations to a baseline file, so that the check command can ignore them.')
+            ->addArgument(
+                self::FILENAME_ARG,
+                InputArgument::OPTIONAL,
+                'The baseline file to create',
+                Baseline::DEFAULT_FILENAME
+            );
+
+        $this->commonOptions->addTo($this);
+    }
+
+    protected function isRunningAsPhar(): bool
+    {
+        return '' !== \Phar::running();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        ini_set('memory_limit', '-1');
+        ini_set('xdebug.max_nesting_level', '10000');
+        $startTime = microtime(true);
+
+        // we write everything on STDERR to be consistent with the check command
+        $output = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+
+        try {
+            $verbose = (bool) $input->getOption('verbose');
+            $options = $this->parseOptions($input);
+
+            if ($this->isRunningAsPhar() && null === $options->getAutoloadFilePath()) {
+                $output->writeln('❌ The --autoload option is required when running phparkitect as a PHAR');
+
+                return self::ERROR_CODE;
+            }
+
+            $this->printHeadingLine($output);
+            $this->commonOptions->requireAutoload($input, $output);
+
+            $progress = $this->createProgress($output, $verbose);
+
+            $this->handler->generateBaseline($options, $progress, $output);
+
+            return self::SUCCESS_CODE;
+        } catch (\Throwable $e) {
+            $output->writeln("❌ {$e->getMessage()}");
+
+            return self::ERROR_CODE;
+        } finally {
+            $this->printExecutionTime($output, $startTime);
+        }
+    }
+
+    protected function parseOptions(InputInterface $input): GenerateBaselineOptions
+    {
+        return new GenerateBaselineOptions(
+            configFilePath: $this->commonOptions->configFilePath($input),
+            targetPhpVersion: $this->commonOptions->targetPhpVersion($input),
+            autoloadFilePath: $this->commonOptions->autoloadFilePath($input),
+            ignoreBaselineLinenumbers: $this->commonOptions->isIgnoreBaselineLinenumbers($input),
+            baselineFilePath: (string) $input->getArgument(self::FILENAME_ARG),
+        );
+    }
+
+    protected function createProgress(OutputInterface $output, bool $verbose): Progress
+    {
+        $output->writeln('Progress: '.($verbose ? 'debug' : 'bar'));
+
+        return $verbose ? new DebugProgress($output) : new ProgressBarProgress($output);
+    }
+
+    protected function printHeadingLine(OutputInterface $output): void
+    {
+        $app = $this->getApplication();
+
+        $version = $app ? $app->getVersion() : 'unknown';
+
+        $output->writeln("<info>PHPArkitect $version</info>\n");
+    }
+
+    protected function printExecutionTime(OutputInterface $output, float $startTime): void
+    {
+        $endTime = microtime(true);
+        $executionTime = number_format($endTime - $startTime, 2);
+
+        $output->writeln("⏱️ Execution time: $executionTime\n");
+    }
+}

--- a/src/CLI/GenerateBaselineHandler.php
+++ b/src/CLI/GenerateBaselineHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\CLI;
+
+use Arkitect\CLI\Progress\Progress;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Application service behind the `generate-baseline` command: loads the
+ * config, runs the analysis and snapshots the current violations to a
+ * baseline file. It only depends on OutputInterface for writing, so it
+ * can be unit tested with a BufferedOutput.
+ */
+final class GenerateBaselineHandler
+{
+    public function __construct(private Runner $runner)
+    {
+    }
+
+    public function generateBaseline(GenerateBaselineOptions $options, Progress $progress, OutputInterface $output): void
+    {
+        $config = ConfigBuilder::loadFromFile($options->getConfigFilePath())
+            ->autoloadFilePath($options->getAutoloadFilePath())
+            ->targetPhpVersion(TargetPhpVersion::create($options->getTargetPhpVersion()));
+
+        $output->writeln("Config file '{$options->getConfigFilePath()}' found\n");
+
+        $result = $this->runner->baseline($config, $progress);
+
+        $baselineFilePath = Baseline::save(
+            $options->getBaselineFilePath(),
+            Baseline::DEFAULT_FILENAME,
+            $result->getViolations(),
+            $options->isIgnoreBaselineLinenumbers()
+        );
+
+        $output->writeln("ℹ️ Baseline file '$baselineFilePath' created!");
+    }
+}

--- a/src/CLI/GenerateBaselineHandler.php
+++ b/src/CLI/GenerateBaselineHandler.php
@@ -29,13 +29,12 @@ final class GenerateBaselineHandler
 
         $result = $this->runner->baseline($config, $progress);
 
-        $baselineFilePath = Baseline::save(
+        Baseline::save(
             $options->getBaselineFilePath(),
-            Baseline::DEFAULT_FILENAME,
             $result->getViolations(),
             $options->isIgnoreBaselineLinenumbers()
         );
 
-        $output->writeln("ℹ️ Baseline file '$baselineFilePath' created!");
+        $output->writeln("ℹ️ Baseline file '{$options->getBaselineFilePath()}' created!");
     }
 }

--- a/src/CLI/GenerateBaselineOptions.php
+++ b/src/CLI/GenerateBaselineOptions.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\CLI;
+
+/**
+ * Immutable bag of the options a `generate-baseline` run needs,
+ * already parsed and resolved: no CLI concerns leak past here.
+ */
+final class GenerateBaselineOptions
+{
+    public function __construct(
+        private string $configFilePath,
+        private ?string $targetPhpVersion,
+        private ?string $autoloadFilePath,
+        private bool $ignoreBaselineLinenumbers,
+        private string $baselineFilePath,
+    ) {
+    }
+
+    public function getConfigFilePath(): string
+    {
+        return $this->configFilePath;
+    }
+
+    public function getTargetPhpVersion(): ?string
+    {
+        return $this->targetPhpVersion;
+    }
+
+    public function getAutoloadFilePath(): ?string
+    {
+        return $this->autoloadFilePath;
+    }
+
+    public function isIgnoreBaselineLinenumbers(): bool
+    {
+        return $this->ignoreBaselineLinenumbers;
+    }
+
+    public function getBaselineFilePath(): string
+    {
+        return $this->baselineFilePath;
+    }
+}

--- a/src/CLI/PhpArkitectApplication.php
+++ b/src/CLI/PhpArkitectApplication.php
@@ -6,6 +6,7 @@ namespace Arkitect\CLI;
 
 use Arkitect\CLI\Command\Check;
 use Arkitect\CLI\Command\DebugExpression;
+use Arkitect\CLI\Command\GenerateBaseline;
 use Arkitect\CLI\Command\Init;
 
 class PhpArkitectApplication extends \Symfony\Component\Console\Application
@@ -27,6 +28,7 @@ class PhpArkitectApplication extends \Symfony\Component\Console\Application
         $addMethod = method_exists($this, 'addCommand') ? 'addCommand' : 'add';
 
         $this->$addMethod(new Check());
+        $this->$addMethod(new GenerateBaseline());
         $this->$addMethod(new Init());
         $this->$addMethod(new DebugExpression());
     }

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -111,13 +111,25 @@ class CheckCommandTest extends TestCase
         self::assertStringContainsString($expectedErrors, $cmdTester->getDisplay());
     }
 
+    public function test_generate_baseline_option_has_moved_to_its_own_command(): void
+    {
+        $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
+
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, 'text', null, $this->customBaselineFilename);
+
+        self::assertCommandExitedWithError($cmdTester);
+        self::assertStringContainsString('The --generate-baseline option has been moved to its own command', $cmdTester->getErrorOutput());
+        self::assertStringContainsString("Run: phparkitect generate-baseline {$this->customBaselineFilename}", $cmdTester->getErrorOutput());
+        self::assertFileDoesNotExist($this->customBaselineFilename);
+    }
+
     public function test_baseline(): void
     {
         $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
 
         // Produce the baseline
 
-        $this->runCheck($configFilePath, null, null, $this->customBaselineFilename);
+        $this->runGenerateBaseline($configFilePath, $this->customBaselineFilename);
 
         // Check it detects error if baseline is not used
 
@@ -138,7 +150,7 @@ class CheckCommandTest extends TestCase
 
         // Produce the baseline
 
-        $this->runCheck($configFilePath, null, null, null);
+        $this->runGenerateBaseline($configFilePath);
 
         // Check it ignores error if baseline is used
 
@@ -152,10 +164,10 @@ class CheckCommandTest extends TestCase
         $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
 
         // Produce the baseline
-        $this->runCheck($configFilePath, null, null, null);
+        $this->runGenerateBaseline($configFilePath);
 
         // Check it ignores the default baseline
-        $cmdTester = $this->runCheck($configFilePath, null, null, false, true);
+        $cmdTester = $this->runCheck($configFilePath, null, null, true);
 
         self::assertCommandExitedWithError($cmdTester);
     }
@@ -172,7 +184,7 @@ class CheckCommandTest extends TestCase
         $configFilePath = __DIR__.'/../_fixtures/configIgnoreBaselineLineNumbers.php';
 
         // No errors when ignoring baseline line numbers
-        $cmdTester = $this->runCheck($configFilePath, null, __DIR__.'/../_fixtures/line_numbers/baseline.json', false, false, true);
+        $cmdTester = $this->runCheck($configFilePath, null, __DIR__.'/../_fixtures/line_numbers/baseline.json', false, true);
         self::assertCommandWasSuccessful($cmdTester);
 
         // Errors when not ignoring baseline line numbers
@@ -185,7 +197,7 @@ class CheckCommandTest extends TestCase
         $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
 
         // Produce the baseline matching the current violation
-        $this->runCheck($configFilePath, null, null, $this->customBaselineFilename);
+        $this->runGenerateBaseline($configFilePath, $this->customBaselineFilename);
 
         // Add a fake, already-fixed entry to the baseline
         $baseline = json_decode((string) file_get_contents($this->customBaselineFilename), true);
@@ -207,7 +219,7 @@ class CheckCommandTest extends TestCase
     {
         $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
 
-        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, false, 'json');
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, 'json');
 
         $expectedJson = <<<'ERRORS'
         {
@@ -230,7 +242,7 @@ class CheckCommandTest extends TestCase
     {
         $configFilePath = __DIR__.'/../_fixtures/configMvcWithoutErrors.php';
 
-        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, false, 'json');
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, 'json');
 
         $expectedJson = '{"totalViolations":0,"details":[]}';
 
@@ -242,7 +254,7 @@ class CheckCommandTest extends TestCase
     {
         $configFilePath = __DIR__.'/../_fixtures/configMvcForYieldBug.php';
 
-        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, false, 'gitlab');
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, 'gitlab');
 
         $expectedJson = <<<'ERRORS'
         [
@@ -269,7 +281,7 @@ class CheckCommandTest extends TestCase
     {
         $configFilePath = __DIR__.'/../_fixtures/configMvcWithoutErrors.php';
 
-        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, false, 'gitlab');
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, 'gitlab');
 
         $expectedJson = '[]';
 
@@ -305,7 +317,7 @@ class CheckCommandTest extends TestCase
     {
         $configFilePath = __DIR__.'/../_fixtures/autoload/phparkitect.php';
 
-        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, false, 'text', __DIR__.'/../_fixtures/autoload/autoload.php');
+        $cmdTester = $this->runCheck($configFilePath, null, null, false, false, 'text', __DIR__.'/../_fixtures/autoload/autoload.php');
 
         self::assertCommandWasSuccessful($cmdTester);
     }
@@ -314,11 +326,11 @@ class CheckCommandTest extends TestCase
         $configFilePath = null,
         ?bool $stopOnFailure = null,
         ?string $useBaseline = null,
-        $generateBaseline = false,
         bool $skipBaseline = false,
         bool $ignoreBaselineNumbers = false,
         string $format = 'text',
         ?string $autoloadFilePath = null,
+        $generateBaseline = false,
     ): ApplicationTester {
         $input = ['check'];
 
@@ -348,6 +360,23 @@ class CheckCommandTest extends TestCase
 
         if ($autoloadFilePath) {
             $input['--autoload'] = $autoloadFilePath;
+        }
+
+        $app = new PhpArkitectApplication();
+        $app->setAutoExit(false);
+
+        $appTester = new ApplicationTester($app);
+        $appTester->run($input, ['capture_stderr_separately' => true]);
+
+        return $appTester;
+    }
+
+    protected function runGenerateBaseline(string $configFilePath, ?string $filename = null): ApplicationTester
+    {
+        $input = ['generate-baseline', '--config' => $configFilePath];
+
+        if (null !== $filename) {
+            $input['filename'] = $filename;
         }
 
         $app = new PhpArkitectApplication();

--- a/tests/E2E/Cli/GenerateBaselineCommandTest.php
+++ b/tests/E2E/Cli/GenerateBaselineCommandTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\E2E\Cli;
+
+use Arkitect\CLI\PhpArkitectApplication;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+class GenerateBaselineCommandTest extends TestCase
+{
+    const SUCCESS_CODE = 0;
+
+    const ERROR_CODE = 1;
+
+    private string $customBaselineFilename = __DIR__.'/my-generated-baseline.json';
+
+    private string $defaultBaselineFilename = 'phparkitect-baseline.json';
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->customBaselineFilename)) {
+            unlink($this->customBaselineFilename);
+        }
+        if (file_exists($this->defaultBaselineFilename)) {
+            unlink($this->defaultBaselineFilename);
+        }
+    }
+
+    public function test_creates_the_baseline_with_the_default_filename(): void
+    {
+        $cmdTester = $this->runGenerateBaseline(__DIR__.'/../_fixtures/configMvcForYieldBug.php');
+
+        self::assertEquals(self::SUCCESS_CODE, $cmdTester->getStatusCode());
+        self::assertStringContainsString("ℹ️ Baseline file '{$this->defaultBaselineFilename}' created!", $cmdTester->getErrorOutput());
+        self::assertFileExists($this->defaultBaselineFilename);
+
+        $baseline = json_decode((string) file_get_contents($this->defaultBaselineFilename), true);
+
+        self::assertCount(1, $baseline['violations']);
+        self::assertSame('App\Controller\Foo', $baseline['violations'][0]['fqcn']);
+    }
+
+    public function test_creates_the_baseline_with_a_custom_filename(): void
+    {
+        $cmdTester = $this->runGenerateBaseline(
+            __DIR__.'/../_fixtures/configMvcForYieldBug.php',
+            $this->customBaselineFilename
+        );
+
+        self::assertEquals(self::SUCCESS_CODE, $cmdTester->getStatusCode());
+        self::assertStringContainsString("ℹ️ Baseline file '{$this->customBaselineFilename}' created!", $cmdTester->getErrorOutput());
+        self::assertFileExists($this->customBaselineFilename);
+        self::assertFileDoesNotExist($this->defaultBaselineFilename);
+    }
+
+    public function test_can_ignore_line_numbers(): void
+    {
+        $cmdTester = $this->runGenerateBaseline(
+            __DIR__.'/../_fixtures/configMvcForYieldBug.php',
+            $this->customBaselineFilename,
+            true
+        );
+
+        self::assertEquals(self::SUCCESS_CODE, $cmdTester->getStatusCode());
+
+        $baseline = json_decode((string) file_get_contents($this->customBaselineFilename), true);
+
+        self::assertCount(1, $baseline['violations']);
+        self::assertNull($baseline['violations'][0]['line']);
+    }
+
+    public function test_fails_gracefully_when_the_config_file_does_not_exist(): void
+    {
+        $cmdTester = $this->runGenerateBaseline('not-a-real-config.php');
+
+        self::assertEquals(self::ERROR_CODE, $cmdTester->getStatusCode());
+        self::assertStringContainsString('not found', $cmdTester->getErrorOutput());
+        self::assertFileDoesNotExist($this->defaultBaselineFilename);
+    }
+
+    protected function runGenerateBaseline(
+        string $configFilePath,
+        ?string $filename = null,
+        bool $ignoreBaselineNumbers = false,
+    ): ApplicationTester {
+        $input = ['generate-baseline', '--config' => $configFilePath];
+
+        if (null !== $filename) {
+            $input['filename'] = $filename;
+        }
+
+        if ($ignoreBaselineNumbers) {
+            $input['--ignore-baseline-linenumbers'] = true;
+        }
+
+        $app = new PhpArkitectApplication();
+        $app->setAutoExit(false);
+
+        $appTester = new ApplicationTester($app);
+        $appTester->run($input, ['capture_stderr_separately' => true]);
+
+        return $appTester;
+    }
+}

--- a/tests/Unit/CLI/CheckHandlerTest.php
+++ b/tests/Unit/CLI/CheckHandlerTest.php
@@ -6,6 +6,8 @@ namespace Arkitect\Tests\Unit\CLI;
 
 use Arkitect\CLI\CheckHandler;
 use Arkitect\CLI\CheckOptions;
+use Arkitect\CLI\GenerateBaselineHandler;
+use Arkitect\CLI\GenerateBaselineOptions;
 use Arkitect\CLI\Progress\VoidProgress;
 use Arkitect\CLI\Runner;
 use PHPUnit\Framework\TestCase;
@@ -59,18 +61,22 @@ class CheckHandlerTest extends TestCase
 
     public function test_check_applies_the_baseline(): void
     {
-        $handler = new CheckHandler(new Runner());
+        $generateBaselineHandler = new GenerateBaselineHandler(new Runner());
         $output = new BufferedOutput();
 
-        $handler->generateBaseline(
-            $this->createOptions(
+        $generateBaselineHandler->generateBaseline(
+            new GenerateBaselineOptions(
                 configFilePath: __DIR__.'/_fixtures/checkhandler/configWithViolations.php',
-                generateBaseline: true,
-                generateBaselineFilePath: $this->generatedBaselineFilePath
+                targetPhpVersion: null,
+                autoloadFilePath: null,
+                ignoreBaselineLinenumbers: false,
+                baselineFilePath: $this->generatedBaselineFilePath,
             ),
             new VoidProgress(),
             $output
         );
+
+        $handler = new CheckHandler(new Runner());
 
         $result = $handler->check(
             $this->createOptions(
@@ -86,35 +92,9 @@ class CheckHandlerTest extends TestCase
         self::assertStringContainsString("Baseline file '{$this->generatedBaselineFilePath}' found", $output->fetch());
     }
 
-    public function test_generate_baseline_writes_the_violations_to_a_file(): void
-    {
-        $handler = new CheckHandler(new Runner());
-        $output = new BufferedOutput();
-
-        $handler->generateBaseline(
-            $this->createOptions(
-                configFilePath: __DIR__.'/_fixtures/checkhandler/configWithViolations.php',
-                generateBaseline: true,
-                generateBaselineFilePath: $this->generatedBaselineFilePath
-            ),
-            new VoidProgress(),
-            $output
-        );
-
-        self::assertFileExists($this->generatedBaselineFilePath);
-        self::assertStringContainsString("ℹ️ Baseline file '{$this->generatedBaselineFilePath}' created!", $output->fetch());
-
-        $baseline = json_decode((string) file_get_contents($this->generatedBaselineFilePath), true);
-
-        self::assertCount(1, $baseline['violations']);
-        self::assertSame('App\Foo', $baseline['violations'][0]['fqcn']);
-    }
-
     private function createOptions(
         string $configFilePath,
         ?string $baselineFilePath = null,
-        bool $generateBaseline = false,
-        ?string $generateBaselineFilePath = null,
     ): CheckOptions {
         return new CheckOptions(
             configFilePath: $configFilePath,
@@ -123,8 +103,6 @@ class CheckHandlerTest extends TestCase
             baselineFilePath: $baselineFilePath,
             skipBaseline: false,
             ignoreBaselineLinenumbers: false,
-            generateBaseline: $generateBaseline,
-            generateBaselineFilePath: $generateBaselineFilePath,
             format: 'text',
             autoloadFilePath: null,
         );

--- a/tests/Unit/CLI/GenerateBaselineHandlerTest.php
+++ b/tests/Unit/CLI/GenerateBaselineHandlerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\CLI;
+
+use Arkitect\CLI\GenerateBaselineHandler;
+use Arkitect\CLI\GenerateBaselineOptions;
+use Arkitect\CLI\Progress\VoidProgress;
+use Arkitect\CLI\Runner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class GenerateBaselineHandlerTest extends TestCase
+{
+    private string $generatedBaselineFilePath = __DIR__.'/_fixtures/checkhandler/generated-baseline.json';
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->generatedBaselineFilePath)) {
+            unlink($this->generatedBaselineFilePath);
+        }
+    }
+
+    public function test_generate_baseline_writes_the_violations_to_a_file(): void
+    {
+        $handler = new GenerateBaselineHandler(new Runner());
+        $output = new BufferedOutput();
+
+        $handler->generateBaseline(
+            $this->createOptions(configFilePath: __DIR__.'/_fixtures/checkhandler/configWithViolations.php'),
+            new VoidProgress(),
+            $output
+        );
+
+        self::assertFileExists($this->generatedBaselineFilePath);
+        self::assertStringContainsString("ℹ️ Baseline file '{$this->generatedBaselineFilePath}' created!", $output->fetch());
+
+        $baseline = json_decode((string) file_get_contents($this->generatedBaselineFilePath), true);
+
+        self::assertCount(1, $baseline['violations']);
+        self::assertSame('App\Foo', $baseline['violations'][0]['fqcn']);
+    }
+
+    public function test_generate_baseline_can_omit_line_numbers(): void
+    {
+        $handler = new GenerateBaselineHandler(new Runner());
+        $output = new BufferedOutput();
+
+        $handler->generateBaseline(
+            $this->createOptions(
+                configFilePath: __DIR__.'/_fixtures/checkhandler/configWithViolations.php',
+                ignoreBaselineLinenumbers: true
+            ),
+            new VoidProgress(),
+            $output
+        );
+
+        $baseline = json_decode((string) file_get_contents($this->generatedBaselineFilePath), true);
+
+        self::assertCount(1, $baseline['violations']);
+        self::assertNull($baseline['violations'][0]['line']);
+    }
+
+    public function test_generate_baseline_writes_an_empty_baseline_when_there_are_no_violations(): void
+    {
+        $handler = new GenerateBaselineHandler(new Runner());
+        $output = new BufferedOutput();
+
+        $handler->generateBaseline(
+            $this->createOptions(configFilePath: __DIR__.'/_fixtures/checkhandler/configWithoutViolations.php'),
+            new VoidProgress(),
+            $output
+        );
+
+        self::assertFileExists($this->generatedBaselineFilePath);
+
+        $baseline = json_decode((string) file_get_contents($this->generatedBaselineFilePath), true);
+
+        self::assertSame([], $baseline['violations']);
+    }
+
+    private function createOptions(
+        string $configFilePath,
+        bool $ignoreBaselineLinenumbers = false,
+    ): GenerateBaselineOptions {
+        return new GenerateBaselineOptions(
+            configFilePath: $configFilePath,
+            targetPhpVersion: null,
+            autoloadFilePath: null,
+            ignoreBaselineLinenumbers: $ignoreBaselineLinenumbers,
+            baselineFilePath: $this->generatedBaselineFilePath,
+        );
+    }
+}


### PR DESCRIPTION
### New Feature

|    Q        |   A
|------------ | ------
| New Feature | yes
| RFC         | no
| BC Break    | yes (intentional, see below)
| Issue       | Close #648

#### Summary

Second and final step of the series started with #655 (the `CommonOptions` extraction): `check --generate-baseline` was an action disguised as an option — it ran a completely different flow, printed no violations and always returned success. It becomes a dedicated command:

```
phparkitect generate-baseline [filename]
```

- **New `GenerateBaseline` command** with an optional `filename` argument (defaults to `phparkitect-baseline.json`, same as before), backed by a `GenerateBaselineHandler` / `GenerateBaselineOptions` pair mirroring the `check` command's structure. It composes the `CommonOptions` collaborator merged in #655, so the shared options (`--config`, `--target-php-version`, `--autoload`, `--ignore-baseline-linenumbers`) cannot drift between commands. `CheckHandler` loses `generateBaseline()` and is now only about checking.
- **Fail-fast migration** as specified in the issue: `check --generate-baseline` now exits with code 1 and points to the new command, echoing back the filename if one was passed:
  ```
  ❌ The --generate-baseline option has been moved to its own command.
     Run: phparkitect generate-baseline my-baseline.json
  ```
  The option is deliberately kept as a failing stub — removing it would surface Symfony's generic "option does not exist" error instead of a migration hint.

Two deliberate choices worth reviewing:
- `--target-php-version` is included in the new command even though #648 didn't list it: the baseline should be generated with the same parser settings as the `check` runs that will consume it.
- Unlike the old flag flow, `generate-baseline` does not load an existing baseline before running (that was an artifact of the shared code path), so generation can no longer fail on a stale `--use-baseline` path. It also intentionally omits check-only options that had no effect on generation (`--stop-on-failure`, `--format`, `--use-baseline`, `--skip-baseline`).

Covered by new unit tests (`GenerateBaselineHandlerTest`) and E2E tests (`GenerateBaselineCommandTest`, plus the migration-error case in `CheckCommandTest`); the existing baseline E2E fixtures now generate through the new command. README and CLAUDE.md updated.

Next up, in a separate PR: `prune-baseline` (#649).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015K1TKiwtwkW7twBCTz758P

---
_Generated by [Claude Code](https://claude.ai/code/session_015K1TKiwtwkW7twBCTz758P)_