### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/architectural-rules.yml
+++ b/.github/workflows/architectural-rules.yml
@@ -17,7 +17,7 @@ jobs:
               uses: actions/checkout@v7
 
             - name: Install PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
                   php-version: '8.2'
                   tools: composer:v2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Install PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: pcov
@@ -59,7 +59,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: ${{ matrix.php-versions  == '8.0' }}
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.2
           tools: composer:v2.2
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-versions }}
         env:
@@ -147,7 +147,7 @@ jobs:
           name: phar-artifact
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_KEY_47CD54B6398FE21B3709D0A4D9C905CED1932CA2 }}
           passphrase: ${{ secrets.GPG_KEY_47CD54B6398FE21B3709D0A4D9C905CED1932CA2_PASSPHRASE }}
@@ -166,7 +166,7 @@ jobs:
           ./phparkitect.phar
 
       - name: Add phar to the release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |

--- a/.github/workflows/cs-fixer.yml
+++ b/.github/workflows/cs-fixer.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.0'
           tools: composer:v2.2

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -11,13 +11,13 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: minicli/action-contributors@v3
+      - uses: minicli/action-contributors@adc68c92715e07f0f39e7cdfe6397ea37e25b7ae # v3
         name: "Update a projects CONTRIBUTORS file"
         env:
           CONTRIB_REPOSITORY: 'phparkitect/arkitect'
           CONTRIB_OUTPUT_FILE: 'CONTRIBUTORS.md'
       - name: Commit changes
-        uses: test-room-7/action-update-file@v2
+        uses: test-room-7/action-update-file@6b8249d09d5926fbae288c0bb640757f09ec7ce0 # v2.1.0
         with:
           file-path: 'CONTRIBUTORS.md'
           commit-msg: Update Contributors


### PR DESCRIPTION
Pins all third-party (non-`actions/*`) GitHub Actions to full commit SHAs instead of mutable version tags, keeping the version as a comment next to each pin.

Tags like `@v2` can be repointed at any time: if one of these actions' repos were compromised, the workflows would silently execute attacker-controlled code. This matters most for `publish_phar` (which handles the GPG release-signing key and passphrase via `crazy-max/ghaction-import-gpg` and `softprops/action-gh-release`) and `update-contributors.yml` (which runs on a schedule with `contents: write`).

Pinned: `shivammathur/setup-php` (2.37.2), `codecov/codecov-action` (v7.0.0), `crazy-max/ghaction-import-gpg` (v7.0.0), `softprops/action-gh-release` (v3.0.2), `minicli/action-contributors` (v3), `test-room-7/action-update-file` (v2.1.0).

Dependabot already watches the `github-actions` ecosystem, so the SHA pins (and their version comments) will keep being updated by its weekly PRs. First-party `actions/*` remain tag-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)