### PR TITLE
Document breaking change: `check --generate-baseline` → `generate-baseline` command

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -65,8 +65,8 @@ consumed as a substring match.
 
 ### User-defined classes in the global namespace are now evaluated
 
-PHP core classes are now auto-excluded from dependency checks via reflection
-(`isInternal()`), so you no longer need to list `\Exception`, `\DateTime`,
+**PHP core classes are now auto-excluded** from dependency checks via reflection
+(`isInternal()`) — you **no longer need to list** `\Exception`, `\DateTime`,
 `MongoDB\Driver\Manager`, etc. in your rules.
 
 As a consequence, the previous "skip everything in the root namespace" shortcut

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,33 @@ PHPArkitect, ordered from the most recent version to the oldest.
 > If a release is **not** listed here, it contains no breaking changes and you
 > can upgrade to it without modifying your configuration.
 
+## 1.3.0
+
+### `check --generate-baseline` is now the `generate-baseline` command
+
+Generating a baseline was an action disguised as a `check` option: it ran a
+different flow, printed no violations and always exited successfully. It is now
+a dedicated command:
+
+```diff
+- phparkitect check --generate-baseline
++ phparkitect generate-baseline
+
+- phparkitect check --generate-baseline my-baseline.json
++ phparkitect generate-baseline my-baseline.json
+```
+
+The optional filename is now an argument (still defaulting to
+`phparkitect-baseline.json`), and the command accepts the same `--config`,
+`--target-php-version`, `--autoload` and `--ignore-baseline-linenumbers`
+options as before. The check-only options that never affected generation
+(`--stop-on-failure`, `--format`, `--use-baseline`, `--skip-baseline`) are no
+longer accepted.
+
+`check --generate-baseline` is kept as a failing stub that points to the new
+command, so an old CI invocation fails loudly with a migration hint instead of
+silently doing nothing.
+
 ## 1.0.0
 
 ### PHP 7 support dropped


### PR DESCRIPTION
## Summary

This PR updates `UPGRADE.md` to document the breaking change in version 1.3.0 where baseline generation was refactored from a `check` option into a dedicated `generate-baseline` command.

## Changes

- **Added v1.3.0 upgrade section** documenting the migration from `phparkitect check --generate-baseline` to `phparkitect generate-baseline`
- **Clarified the new command signature**: the optional filename is now a positional argument (defaulting to `phparkitect-baseline.json`)
- **Listed preserved options**: `--config`, `--target-php-version`, `--autoload`, `--ignore-baseline-linenumbers`
- **Listed removed options**: `--stop-on-failure`, `--format`, `--use-baseline`, `--skip-baseline` (check-only options that never affected generation)
- **Noted the migration path**: the old `check --generate-baseline` is kept as a failing stub with a helpful error message
- **Minor formatting improvements** to the v1.0.0 section for consistency (bold emphasis on key changes)

## Notes

This is a documentation-only change reflecting the command refactoring already implemented in the codebase. It provides users with a clear migration guide when upgrading to 1.3.0.

https://claude.ai/code/session_01UJkKYwpak6n96nXv56zeVo