### PR TITLE
Remove final from all classes and enforce it with an architectural rule

### DIFF
--- a/phparkitect.php
+++ b/phparkitect.php
@@ -6,6 +6,7 @@ use Arkitect\ClassSet;
 use Arkitect\CLI\Config;
 use Arkitect\Expression\ForClasses\Extend;
 use Arkitect\Expression\ForClasses\Implement;
+use Arkitect\Expression\ForClasses\IsNotFinal;
 use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
 use Arkitect\Rules\Rule;
 
@@ -18,6 +19,11 @@ return static function (Config $config): void {
         ->that(new ResideInOneOfTheseNamespaces('Arkitect\Expression\ForClasses'))
         ->should(new Implement('Arkitect\Expression\Expression'))
         ->because('we want that all rules for classes implement Expression class.');
+
+    $rules[] = Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('Arkitect'))
+        ->should(new IsNotFinal())
+        ->because('users extend our classes to adapt the tool to their needs, and final would take that away from them.');
 
     $rules[] = Rule::allClasses()
         ->that(new Extend('Symfony\Component\Console\Command\Command'))

--- a/src/CLI/BaselineFileRepository.php
+++ b/src/CLI/BaselineFileRepository.php
@@ -11,7 +11,7 @@ use Arkitect\Rules\Violations;
  * Loads and saves Baselines as JSON files. All the filesystem concerns of
  * the baseline live here, so Baseline itself stays a pure domain object.
  */
-final class BaselineFileRepository
+class BaselineFileRepository
 {
     public const DEFAULT_FILENAME = 'phparkitect-baseline.json';
 

--- a/src/CLI/CheckHandler.php
+++ b/src/CLI/CheckHandler.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * OutputInterface for writing, so it can be unit tested with a
  * BufferedOutput — no console, no exit codes, no global state.
  */
-final class CheckHandler
+class CheckHandler
 {
     public function __construct(
         private Runner $runner,

--- a/src/CLI/CheckOptions.php
+++ b/src/CLI/CheckOptions.php
@@ -8,7 +8,7 @@ namespace Arkitect\CLI;
  * Immutable bag of the options a `check` run needs, already parsed and
  * resolved: no CLI concerns (option names, tri-state flags) leak past here.
  */
-final class CheckOptions
+class CheckOptions
 {
     public function __construct(
         private string $configFilePath,

--- a/src/CLI/Command/CommandRuntime.php
+++ b/src/CLI/Command/CommandRuntime.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * execution-time footer. Commands compose this object (like CommonOptions)
  * so the run lifecycle cannot drift between them.
  */
-final class CommandRuntime
+class CommandRuntime
 {
     public function raiseLimits(): void
     {

--- a/src/CLI/Command/CommonOptions.php
+++ b/src/CLI/Command/CommonOptions.php
@@ -16,7 +16,7 @@ use Webmozart\Assert\Assert;
  * option names, shortcuts, defaults and parsing stay in sync across
  * the whole CLI.
  */
-final class CommonOptions
+class CommonOptions
 {
     public const CONFIG_PARAM = 'config';
     public const TARGET_PHP_PARAM = 'target-php-version';

--- a/src/CLI/GenerateBaselineHandler.php
+++ b/src/CLI/GenerateBaselineHandler.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * baseline file. It only depends on OutputInterface for writing, so it
  * can be unit tested with a BufferedOutput.
  */
-final class GenerateBaselineHandler
+class GenerateBaselineHandler
 {
     public function __construct(
         private Runner $runner,

--- a/src/CLI/GenerateBaselineOptions.php
+++ b/src/CLI/GenerateBaselineOptions.php
@@ -8,7 +8,7 @@ namespace Arkitect\CLI;
  * Immutable bag of the options a `generate-baseline` run needs,
  * already parsed and resolved: no CLI concerns leak past here.
  */
-final class GenerateBaselineOptions
+class GenerateBaselineOptions
 {
     public function __construct(
         private string $configFilePath,

--- a/src/CLI/Printer/PrinterFactory.php
+++ b/src/CLI/Printer/PrinterFactory.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Arkitect\CLI\Printer;
 
-final class PrinterFactory
+class PrinterFactory
 {
     public static function default(): string
     {

--- a/src/CLI/PruneBaselineHandler.php
+++ b/src/CLI/PruneBaselineHandler.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * anything, so unlike regenerating it cannot legitimize new violations
  * and is safe to automate.
  */
-final class PruneBaselineHandler
+class PruneBaselineHandler
 {
     public function __construct(
         private Runner $runner,

--- a/src/CLI/PruneBaselineOptions.php
+++ b/src/CLI/PruneBaselineOptions.php
@@ -8,7 +8,7 @@ namespace Arkitect\CLI;
  * Immutable bag of the options a `prune-baseline` run needs,
  * already parsed and resolved: no CLI concerns leak past here.
  */
-final class PruneBaselineOptions
+class PruneBaselineOptions
 {
     public function __construct(
         private string $configFilePath,

--- a/src/Expression/ForClasses/HaveAttribute.php
+++ b/src/Expression/ForClasses/HaveAttribute.php
@@ -10,7 +10,7 @@ use Arkitect\Rules\Violation;
 use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
-final class HaveAttribute implements Expression
+class HaveAttribute implements Expression
 {
     private string $attribute;
 

--- a/src/Expression/ForClasses/HaveTrait.php
+++ b/src/Expression/ForClasses/HaveTrait.php
@@ -10,7 +10,7 @@ use Arkitect\Rules\Violation;
 use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
-final class HaveTrait implements Expression
+class HaveTrait implements Expression
 {
     private string $trait;
 

--- a/src/Expression/ForClasses/IsA.php
+++ b/src/Expression/ForClasses/IsA.php
@@ -11,7 +11,7 @@ use Arkitect\Rules\Violation;
 use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
-final class IsA implements Expression
+class IsA implements Expression
 {
     /** @var class-string */
     private string $allowedFqcn;

--- a/src/Expression/ForClasses/IsNotA.php
+++ b/src/Expression/ForClasses/IsNotA.php
@@ -11,7 +11,7 @@ use Arkitect\Rules\Violation;
 use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
-final class IsNotA implements Expression
+class IsNotA implements Expression
 {
     /** @var class-string */
     private string $disallowedFqcn;

--- a/src/Expression/ForClasses/NotHaveAttribute.php
+++ b/src/Expression/ForClasses/NotHaveAttribute.php
@@ -11,7 +11,7 @@ use Arkitect\Rules\Violation;
 use Arkitect\Rules\ViolationMessage;
 use Arkitect\Rules\Violations;
 
-final class NotHaveAttribute implements Expression
+class NotHaveAttribute implements Expression
 {
     private string $attribute;
 

--- a/tests/Integration/AndThatFilterTest.php
+++ b/tests/Integration/AndThatFilterTest.php
@@ -14,7 +14,7 @@ use Arkitect\Tests\Utils\TestRunner;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
-final class AndThatFilterTest extends TestCase
+class AndThatFilterTest extends TestCase
 {
     public function test_only_classes_matching_both_namespace_and_naming_are_checked(): void
     {

--- a/tests/Integration/CheckClassHaveAttributeTest.php
+++ b/tests/Integration/CheckClassHaveAttributeTest.php
@@ -12,7 +12,7 @@ use Arkitect\Tests\Utils\TestRunner;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
-final class CheckClassHaveAttributeTest extends TestCase
+class CheckClassHaveAttributeTest extends TestCase
 {
     public function test_models_should_reside_in_app_model(): void
     {

--- a/tests/Integration/CheckClassHaveTraitTest.php
+++ b/tests/Integration/CheckClassHaveTraitTest.php
@@ -12,7 +12,7 @@ use Arkitect\Tests\Utils\TestRunner;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
-final class CheckClassHaveTraitTest extends TestCase
+class CheckClassHaveTraitTest extends TestCase
 {
     public function test_feature_tests_should_use_database_transactions_trait(): void
     {

--- a/tests/Integration/CheckClassNotHaveAttributeTest.php
+++ b/tests/Integration/CheckClassNotHaveAttributeTest.php
@@ -12,7 +12,7 @@ use Arkitect\Tests\Utils\TestRunner;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
-final class CheckClassNotHaveAttributeTest extends TestCase
+class CheckClassNotHaveAttributeTest extends TestCase
 {
     public function test_controllers_should_not_have_deprecated_attribute(): void
     {

--- a/tests/Unit/Expressions/ForClasses/IsATest.php
+++ b/tests/Unit/Expressions/ForClasses/IsATest.php
@@ -14,7 +14,7 @@ use Arkitect\Tests\Unit\Expressions\ForClasses\IsATest\Fruit\DwarfCavendishBanan
 use Arkitect\Tests\Unit\Expressions\ForClasses\IsATest\Fruit\FruitInterface;
 use PHPUnit\Framework\TestCase;
 
-final class IsATest extends TestCase
+class IsATest extends TestCase
 {
     public function test_it_should_have_no_violation_when_it_implements(): void
     {

--- a/tests/Unit/Expressions/ForClasses/IsNotATest.php
+++ b/tests/Unit/Expressions/ForClasses/IsNotATest.php
@@ -14,7 +14,7 @@ use Arkitect\Tests\Unit\Expressions\ForClasses\IsNotA\Fruit\DwarfCavendishBanana
 use Arkitect\Tests\Unit\Expressions\ForClasses\IsNotA\Fruit\FruitInterface;
 use PHPUnit\Framework\TestCase;
 
-final class IsNotATest extends TestCase
+class IsNotATest extends TestCase
 {
     public function test_it_should_have_no_violation_when_it_doesnt_extend(): void
     {


### PR DESCRIPTION
### Improvement

|    Q        |   A
|------------ | ------
| New Feature | no
| BC Break    | no
| Issue       | —

#### Summary

Removes `final` from every class in `src/` (15) and from the test cases that carried it (6), and adds a rule to `phparkitect.php` so it does not drift back.

`final` was never a convention here: the occurrences arrived one at a time from six different contributors over four years, each bringing the habit of their own codebase. `HaveTrait` and `NotHaveTrait` show it best — sibling classes added in the same commit, one `final` and one not.

It also works against the tool. Expressions are the one real seam users have: they instantiate them in their `phparkitect.php` and pass them to `that()` and `should()`, so a subclass of a built-in rule is genuinely used — and five of those were sealed, which meant "I want `HaveAttribute` with a small tweak" had no answer. Everywhere else `final` protected nothing, because nothing reaches those classes through a seam a user controls: `Baseline` has a private constructor, the handlers are built by the commands. Sealing them only forbade experiments we gain nothing from forbidding.

Removing it is not a BC break — it only widens what users are allowed to do — while adding it back later would be one, which is the asymmetry that makes the permissive default the right one for a library.

The new rule states the reason where the next contributor will read it, and runs in CI like the existing ones:

```php
Rule::allClasses()
    ->that(new ResideInOneOfTheseNamespaces('Arkitect'))
    ->should(new IsNotFinal())
    ->because('users extend our classes to adapt the tool to their needs, and final would take that away from them.');
```

The classes the tests *analyse* keep their `final` (`Dog`, `DwarfCavendishBanana`, the `line_numbers` fixture): there it is a property of the specimen rather than a design choice, and none of them is asserted on for finality today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
