### PR TITLE
refactor: pair violations with baseline entries in one place

### DIFF
--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -56,7 +56,7 @@ class Baseline
      */
     public function prune(Violations $currentViolations): self
     {
-        $prunedViolations = $currentViolations->intersection($this->violations);
+        $prunedViolations = $currentViolations->matchAgainst($this->violations, true)->known();
 
         // a baseline stored without line numbers keeps its format
         if (!$this->hasLineNumbers()) {

--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -43,12 +43,9 @@ class Baseline
      */
     public function applyTo(Violations $violations, bool $ignoreBaselineLinenumbers): BaselineResult
     {
-        $staleEntriesCount = $this->violations->countUnmatchedIn($violations, $ignoreBaselineLinenumbers);
+        $match = $violations->matchAgainst($this->violations, $ignoreBaselineLinenumbers);
 
-        $remainingViolations = clone $violations;
-        $remainingViolations->remove($this->violations, $ignoreBaselineLinenumbers);
-
-        return new BaselineResult($remainingViolations, $staleEntriesCount);
+        return new BaselineResult($match->new(), $match->stale()->count());
     }
 
     /**

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -78,35 +78,50 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
     }
 
     /**
+     * Pairs the violations of this set (the current run) with the entries of
+     * $baseline, one to one: what matched, what is new and what the baseline
+     * still claims but nothing matches anymore.
+     *
+     * A violation is identified by its class and by the problem it reports;
+     * $ignoreLineNumbers decides whether where it sits in the file is part of
+     * that identity too.
+     */
+    public function matchAgainst(self $baseline, bool $ignoreLineNumbers): ViolationsMatch
+    {
+        $key = $ignoreLineNumbers ? [__CLASS__, 'violationKey'] : [__CLASS__, 'positionKey'];
+
+        $currentViolations = $this->violations;
+        $baselineViolations = $baseline->violations;
+        $baselineByKey = self::indexBy($baselineViolations, $key);
+
+        foreach ($currentViolations as $idx => $violation) {
+            $violationKey = $key($violation);
+            $unpaired = $baselineByKey[$violationKey] ?? [];
+
+            if ([] === $unpaired) {
+                continue;
+            }
+
+            $baselineIdx = array_shift($unpaired);
+            $baselineByKey[$violationKey] = $unpaired;
+
+            unset($currentViolations[$idx], $baselineViolations[$baselineIdx]);
+        }
+
+        return new ViolationsMatch(
+            self::fromArray(array_diff_key($this->violations, $currentViolations)),
+            self::fromArray($currentViolations),
+            self::fromArray($baselineViolations)
+        );
+    }
+
+    /**
      * @param Violations $violations                Known violations from the baseline
      * @param bool       $ignoreBaselineLinenumbers If set to true, violations from the baseline are ignored for the same file even if the line number is different
      */
     public function remove(self $violations, bool $ignoreBaselineLinenumbers = false): void
     {
-        if (!$ignoreBaselineLinenumbers) {
-            $this->violations = array_values(array_udiff(
-                $this->violations,
-                $violations->violations,
-                [__CLASS__, 'compareViolations']
-            ));
-
-            return;
-        }
-
-        $baselineViolations = $violations->violations;
-        foreach ($this->violations as $idx => $violation) {
-            foreach ($baselineViolations as $baseIdx => $baselineViolation) {
-                if (
-                    $baselineViolation->getFqcn() === $violation->getFqcn()
-                    && self::extractViolationKey($baselineViolation->getError()) === self::extractViolationKey($violation->getError())
-                ) {
-                    unset($this->violations[$idx], $baselineViolations[$baseIdx]);
-                    continue 2;
-                }
-            }
-        }
-
-        $this->violations = array_values($this->violations);
+        $this->violations = $this->matchAgainst($violations, $ignoreBaselineLinenumbers)->new()->violations;
     }
 
     /**
@@ -116,31 +131,7 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
      */
     public function countUnmatchedIn(self $current, bool $ignoreLineNumbers): int
     {
-        if (!$ignoreLineNumbers) {
-            return \count(array_udiff(
-                $this->violations,
-                $current->violations,
-                [__CLASS__, 'compareViolations']
-            ));
-        }
-
-        $currentViolations = $current->violations;
-        $unmatched = 0;
-        foreach ($this->violations as $violation) {
-            foreach ($currentViolations as $idx => $currentViolation) {
-                if (
-                    $currentViolation->getFqcn() === $violation->getFqcn()
-                    && self::extractViolationKey($currentViolation->getError()) === self::extractViolationKey($violation->getError())
-                ) {
-                    unset($currentViolations[$idx]);
-                    continue 2;
-                }
-            }
-
-            ++$unmatched;
-        }
-
-        return $unmatched;
+        return $current->matchAgainst($this, $ignoreLineNumbers)->stale()->count();
     }
 
     /**
@@ -153,23 +144,7 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
      */
     public function intersection(self $other): self
     {
-        $result = new self();
-
-        $otherViolations = $other->violations;
-        foreach ($this->violations as $violation) {
-            foreach ($otherViolations as $idx => $otherViolation) {
-                if (
-                    $otherViolation->getFqcn() === $violation->getFqcn()
-                    && self::extractViolationKey($otherViolation->getError()) === self::extractViolationKey($violation->getError())
-                ) {
-                    $result->add($violation);
-                    unset($otherViolations[$idx]);
-                    continue 2;
-                }
-            }
-        }
-
-        return $result;
+        return $this->matchAgainst($other, true)->known();
     }
 
     public function withoutLineNumbers(): self
@@ -193,25 +168,51 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
     }
 
     /**
-     * Comparison method that respects all fields in the violation.
+     * Groups the given violations by the key the callback derives from each
+     * of them, so that only the ones that can possibly match are compared.
      *
-     * Uses the stable violation key (the part before ', but ') for comparison,
-     * so that changes to rule configuration (e.g. allowed namespaces) do not
-     * invalidate existing baseline entries.
+     * @param array<Violation>           $violations
+     * @param callable(Violation):string $key
+     *
+     * @return array<string, array<int>> the indexes of $violations, by key
      */
-    public static function compareViolations(Violation $a, Violation $b): int
+    private static function indexBy(array $violations, callable $key): array
     {
-        return [
-            $a->getFqcn(),
-            $a->getLine(),
-            $a->getFilePath(),
-            self::extractViolationKey($a->getError()),
-        ] <=> [
-            $b->getFqcn(),
-            $b->getLine(),
-            $b->getFilePath(),
-            self::extractViolationKey($b->getError()),
-        ];
+        $indexes = [];
+
+        foreach ($violations as $idx => $violation) {
+            $indexes[$key($violation)][] = $idx;
+        }
+
+        return $indexes;
+    }
+
+    /**
+     * Identifies the problem a violation reports, no matter where in the file
+     * it sits: same class, same violation.
+     */
+    private static function violationKey(Violation $violation): string
+    {
+        return $violation->getFqcn()."\0".self::extractViolationKey($violation->getError());
+    }
+
+    /**
+     * Identifies a violation down to the exact spot it was reported at.
+     */
+    private static function positionKey(Violation $violation): string
+    {
+        return self::violationKey($violation)."\0".$violation->getFilePath()."\0".(string) $violation->getLine();
+    }
+
+    /**
+     * @param array<Violation> $violations
+     */
+    private static function fromArray(array $violations): self
+    {
+        $instance = new self();
+        $instance->violations = array_values($violations);
+
+        return $instance;
     }
 
     /**

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -115,38 +115,6 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
         return new ViolationsMatch(self::fromArray($known), self::fromArray($new), self::fromArray($stale));
     }
 
-    /**
-     * @param Violations $violations                Known violations from the baseline
-     * @param bool       $ignoreBaselineLinenumbers If set to true, violations from the baseline are ignored for the same file even if the line number is different
-     */
-    public function remove(self $violations, bool $ignoreBaselineLinenumbers = false): void
-    {
-        $this->violations = $this->matchAgainst($violations, $ignoreBaselineLinenumbers)->new()->violations;
-    }
-
-    /**
-     * Counts how many violations in this set (typically the baseline) have no
-     * corresponding entry in $current (typically the current run's violations) —
-     * i.e. how many are stale and could be removed from the baseline.
-     */
-    public function countUnmatchedIn(self $current, bool $ignoreLineNumbers): int
-    {
-        return $current->matchAgainst($this, $ignoreLineNumbers)->stale()->count();
-    }
-
-    /**
-     * Returns a new set with the violations from this set (typically the
-     * current run) that have a matching entry in $other (typically the
-     * baseline). Matching uses the stable violation key and ignores line
-     * numbers, so the returned violations carry this set's line numbers.
-     * Each entry in $other matches at most one violation, so duplicated
-     * violations are kept only as many times as they appear in $other.
-     */
-    public function intersection(self $other): self
-    {
-        return $this->matchAgainst($other, true)->known();
-    }
-
     public function withoutLineNumbers(): self
     {
         $copy = new self();

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -89,30 +89,30 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
     public function matchAgainst(self $baseline, bool $ignoreLineNumbers): ViolationsMatch
     {
         $key = $ignoreLineNumbers ? [__CLASS__, 'violationKey'] : [__CLASS__, 'positionKey'];
+        $unpairedByKey = self::indexBy($baseline->violations, $key);
 
-        $currentViolations = $this->violations;
-        $baselineViolations = $baseline->violations;
-        $baselineByKey = self::indexBy($baselineViolations, $key);
+        $known = [];
+        $new = [];
+        $paired = [];
 
-        foreach ($currentViolations as $idx => $violation) {
+        foreach ($this->violations as $violation) {
             $violationKey = $key($violation);
-            $unpaired = $baselineByKey[$violationKey] ?? [];
 
-            if ([] === $unpaired) {
+            if ([] === ($unpairedByKey[$violationKey] ?? [])) {
+                $new[] = $violation;
+
                 continue;
             }
 
-            $baselineIdx = array_shift($unpaired);
-            $baselineByKey[$violationKey] = $unpaired;
-
-            unset($currentViolations[$idx], $baselineViolations[$baselineIdx]);
+            // the bucket was just checked to be non-empty, so array_pop() returns an index
+            /** @psalm-suppress PossiblyNullArrayOffset */
+            $paired[array_pop($unpairedByKey[$violationKey])] = true;
+            $known[] = $violation;
         }
 
-        return new ViolationsMatch(
-            self::fromArray(array_diff_key($this->violations, $currentViolations)),
-            self::fromArray($currentViolations),
-            self::fromArray($baselineViolations)
-        );
+        $stale = array_diff_key($baseline->violations, $paired);
+
+        return new ViolationsMatch(self::fromArray($known), self::fromArray($new), self::fromArray($stale));
     }
 
     /**

--- a/src/Rules/ViolationsMatch.php
+++ b/src/Rules/ViolationsMatch.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Rules;
+
+/**
+ * The outcome of pairing the violations of a run with the entries of a
+ * baseline: what is already known, what is new, and what the baseline
+ * still claims but nothing matches anymore.
+ */
+class ViolationsMatch
+{
+    private Violations $known;
+
+    private Violations $new;
+
+    private Violations $stale;
+
+    public function __construct(Violations $known, Violations $new, Violations $stale)
+    {
+        $this->known = $known;
+        $this->new = $new;
+        $this->stale = $stale;
+    }
+
+    /**
+     * The current violations that matched a baseline entry, with the line
+     * numbers of the current run.
+     */
+    public function known(): Violations
+    {
+        return $this->known;
+    }
+
+    /**
+     * The current violations no baseline entry matched.
+     */
+    public function new(): Violations
+    {
+        return $this->new;
+    }
+
+    /**
+     * The baseline entries no current violation matched.
+     */
+    public function stale(): Violations
+    {
+        return $this->stale;
+    }
+}

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -197,6 +197,22 @@ class ViolationsTest extends TestCase
         self::assertCount(0, $violations);
     }
 
+    public function test_remove_reports_a_duplicate_the_baseline_only_knows_once(): void
+    {
+        $error = 'depends on App\Bar, but should depend only on classes in one of these namespaces: App\Domain';
+
+        $baseline = new Violations();
+        $baseline->add(new Violation('App\Foo', $error, 10, 'src/Foo.php'));
+
+        $violations = new Violations();
+        $violations->add(new Violation('App\Foo', $error, 10, 'src/Foo.php'));
+        $violations->add(new Violation('App\Foo', $error, 10, 'src/Foo.php'));
+
+        $violations->remove($baseline);
+
+        self::assertCount(1, $violations, 'each baseline entry covers one violation, not every identical one');
+    }
+
     public function test_remove_violations_does_not_match_different_dependency(): void
     {
         $violations = new Violations();

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -82,7 +82,7 @@ class ViolationsTest extends TestCase
         ], $this->violationStore->toArray());
     }
 
-    public function test_remove_violations_from_violations(): void
+    public function test_match_reports_the_violations_the_baseline_does_not_know(): void
     {
         $violation1 = new Violation(
             'App\Controller\Shop',
@@ -101,13 +101,13 @@ class ViolationsTest extends TestCase
         $violationsBaseline = new Violations();
         $violationsBaseline->add($this->violation);
 
-        $this->violationStore->remove($violationsBaseline);
+        $new = $this->violationStore->matchAgainst($violationsBaseline, false)->new();
 
-        self::assertCount(2, $this->violationStore->toArray());
+        self::assertCount(2, $new);
         self::assertEquals([
             $violation1,
             $violation2,
-        ], $this->violationStore->toArray());
+        ], $new->toArray());
     }
 
     public function test_sort(): void
@@ -155,7 +155,7 @@ class ViolationsTest extends TestCase
         ], $violationStore->toArray());
     }
 
-    public function test_remove_violations_matches_when_rule_description_changes(): void
+    public function test_match_pairs_when_rule_description_changes(): void
     {
         $violations = new Violations();
         $violations->add(new Violation(
@@ -171,12 +171,10 @@ class ViolationsTest extends TestCase
             10
         ));
 
-        $violations->remove($baseline);
-
-        self::assertCount(0, $violations);
+        self::assertCount(0, $violations->matchAgainst($baseline, false)->new());
     }
 
-    public function test_remove_violations_matches_when_rule_description_changes_ignore_linenumber(): void
+    public function test_match_pairs_when_rule_description_changes_ignore_linenumber(): void
     {
         $violations = new Violations();
         $violations->add(new Violation(
@@ -192,12 +190,10 @@ class ViolationsTest extends TestCase
             10
         ));
 
-        $violations->remove($baseline, true);
-
-        self::assertCount(0, $violations);
+        self::assertCount(0, $violations->matchAgainst($baseline, true)->new());
     }
 
-    public function test_remove_reports_a_duplicate_the_baseline_only_knows_once(): void
+    public function test_match_reports_a_duplicate_the_baseline_only_knows_once(): void
     {
         $error = 'depends on App\Bar, but should depend only on classes in one of these namespaces: App\Domain';
 
@@ -208,12 +204,10 @@ class ViolationsTest extends TestCase
         $violations->add(new Violation('App\Foo', $error, 10, 'src/Foo.php'));
         $violations->add(new Violation('App\Foo', $error, 10, 'src/Foo.php'));
 
-        $violations->remove($baseline);
-
-        self::assertCount(1, $violations, 'each baseline entry covers one violation, not every identical one');
+        self::assertCount(1, $violations->matchAgainst($baseline, false)->new(), 'each baseline entry covers one violation, not every identical one');
     }
 
-    public function test_remove_violations_does_not_match_different_dependency(): void
+    public function test_match_does_not_pair_different_dependency(): void
     {
         $violations = new Violations();
         $violations->add(new Violation(
@@ -229,12 +223,10 @@ class ViolationsTest extends TestCase
             10
         ));
 
-        $violations->remove($baseline);
-
-        self::assertCount(1, $violations);
+        self::assertCount(1, $violations->matchAgainst($baseline, false)->new());
     }
 
-    public function test_remove_violations_still_works_for_self_explanatory_messages(): void
+    public function test_match_pairs_self_explanatory_messages(): void
     {
         $violations = new Violations();
         $violations->add(new Violation(
@@ -248,12 +240,10 @@ class ViolationsTest extends TestCase
             'should be final because we want immutability'
         ));
 
-        $violations->remove($baseline);
-
-        self::assertCount(0, $violations);
+        self::assertCount(0, $violations->matchAgainst($baseline, false)->new());
     }
 
-    public function test_remove_violations_matches_self_explanatory_messages_when_because_is_reworded(): void
+    public function test_match_pairs_self_explanatory_messages_when_because_is_reworded(): void
     {
         $violations = new Violations();
         $violations->add(new Violation(
@@ -267,9 +257,7 @@ class ViolationsTest extends TestCase
             'should be final because we want immutability'
         ));
 
-        $violations->remove($baseline);
-
-        self::assertCount(0, $violations);
+        self::assertCount(0, $violations->matchAgainst($baseline, false)->new());
     }
 
     public function test_violation_without_line_number_returns_copy_with_null_line(): void
@@ -340,17 +328,17 @@ class ViolationsTest extends TestCase
             21
         ));
 
-        $this->violationStore->remove($violationsBaseline, true);
+        $new = $this->violationStore->matchAgainst($violationsBaseline, true)->new();
 
-        self::assertCount(3, $this->violationStore->toArray());
+        self::assertCount(3, $new);
         self::assertEquals([
             $this->violation,
             $violation2,
             $violation3,
-        ], $this->violationStore->toArray());
+        ], $new->toArray());
     }
 
-    public function test_count_unmatched_in_returns_zero_when_everything_still_occurs(): void
+    public function test_match_stale_returns_zero_when_everything_still_occurs(): void
     {
         $baseline = new Violations();
         $baseline->add($this->violation);
@@ -358,10 +346,10 @@ class ViolationsTest extends TestCase
         $current = new Violations();
         $current->add($this->violation);
 
-        self::assertSame(0, $baseline->countUnmatchedIn($current, false));
+        self::assertCount(0, $current->matchAgainst($baseline, false)->stale());
     }
 
-    public function test_count_unmatched_in_counts_fixed_baseline_entries(): void
+    public function test_match_stale_counts_fixed_baseline_entries(): void
     {
         $stillPresent = new Violation('App\Controller\Shop', 'should have name end with Controller', 10);
         $fixed = new Violation('App\Controller\Shop', 'should implement AbstractController', 20);
@@ -373,10 +361,10 @@ class ViolationsTest extends TestCase
         $current = new Violations();
         $current->add($stillPresent);
 
-        self::assertSame(1, $baseline->countUnmatchedIn($current, false));
+        self::assertCount(1, $current->matchAgainst($baseline, false)->stale());
     }
 
-    public function test_count_unmatched_in_counts_fixed_baseline_entries_ignoring_line_numbers(): void
+    public function test_match_stale_counts_fixed_baseline_entries_ignoring_line_numbers(): void
     {
         $stillPresent = new Violation('App\Controller\Shop', 'should have name end with Controller', 10);
         $fixed = new Violation('App\Controller\Shop', 'should implement AbstractController', 20);
@@ -389,11 +377,11 @@ class ViolationsTest extends TestCase
         $current = new Violations();
         $current->add($stillPresentMovedLine);
 
-        self::assertSame(1, $baseline->countUnmatchedIn($current, true));
-        self::assertSame(2, $baseline->countUnmatchedIn($current, false));
+        self::assertCount(1, $current->matchAgainst($baseline, true)->stale());
+        self::assertCount(2, $current->matchAgainst($baseline, false)->stale());
     }
 
-    public function test_count_unmatched_in_does_not_mutate_either_set(): void
+    public function test_match_stale_does_not_mutate_either_set(): void
     {
         $stillPresent = new Violation('App\Controller\Shop', 'should have name end with Controller', 10);
 
@@ -403,13 +391,13 @@ class ViolationsTest extends TestCase
         $current = new Violations();
         $current->add($stillPresent);
 
-        $baseline->countUnmatchedIn($current, true);
+        $current->matchAgainst($baseline, true);
 
         self::assertCount(1, $baseline);
         self::assertCount(1, $current);
     }
 
-    public function test_intersection_keeps_only_matching_violations_with_this_sets_line_numbers(): void
+    public function test_match_known_keeps_only_matching_violations_with_this_sets_line_numbers(): void
     {
         $current = new Violations();
         $current->add(new Violation('App\Controller\Shop', 'should have name end with Controller', 25));
@@ -419,14 +407,14 @@ class ViolationsTest extends TestCase
         $baseline->add(new Violation('App\Controller\Shop', 'should have name end with Controller', 10));
         $baseline->add(new Violation('App\Controller\Fixed', 'should have name end with Controller', 3));
 
-        $intersection = $current->intersection($baseline);
+        $intersection = $current->matchAgainst($baseline, true)->known();
 
         self::assertCount(1, $intersection);
         self::assertEquals('App\Controller\Shop', $intersection->get(0)->getFqcn());
         self::assertEquals(25, $intersection->get(0)->getLine());
     }
 
-    public function test_intersection_matches_each_entry_at_most_once(): void
+    public function test_match_known_matches_each_entry_at_most_once(): void
     {
         $duplicated = new Violation('App\Controller\Shop', 'should have name end with Controller', 10);
 
@@ -437,10 +425,10 @@ class ViolationsTest extends TestCase
         $baseline = new Violations();
         $baseline->add($duplicated);
 
-        self::assertCount(1, $current->intersection($baseline));
+        self::assertCount(1, $current->matchAgainst($baseline, true)->known());
     }
 
-    public function test_intersection_does_not_mutate_either_set(): void
+    public function test_match_known_does_not_mutate_either_set(): void
     {
         $violation = new Violation('App\Controller\Shop', 'should have name end with Controller', 10);
 
@@ -450,7 +438,7 @@ class ViolationsTest extends TestCase
         $baseline = new Violations();
         $baseline->add($violation);
 
-        $current->intersection($baseline);
+        $current->matchAgainst($baseline, true);
 
         self::assertCount(1, $current);
         self::assertCount(1, $baseline);


### PR DESCRIPTION
Matching current violations against baseline entries was implemented three times: `Violations::remove()`, `Violations::countUnmatchedIn()` and `Violations::intersection()` each had their own loop, two of them in both a line-number and a line-number-less variant. On top of that `Baseline::applyTo()` walked the two sets twice — once for the remaining violations, once for the stale entry count.

`Violations::matchAgainst()` now pairs the two sets once and returns what matched, what is new and what is stale (`ViolationsMatch`). `Baseline::applyTo()` and `Baseline::prune()` ask it for the part they need, so the choice of matching by position or not is visible where it is made instead of being buried in a method name. The three wrappers are gone — nothing in `src/` called them anymore — and the unit tests now cover `matchAgainst()` itself.

Matching itself is unchanged: a violation is identified by its class plus the problem it reports, and `$ignoreLineNumbers` still decides whether its position in the file belongs to that identity. The existing test suite passes with no assertion changed.

**One behaviour does change**: `array_udiff()` dropped *every* violation identical to a baseline entry, so a second identical violation (same class, same line, same file, same message) was hidden by a baseline that only knew one. Pairing is one to one, so that one is now reported. It's the same family of problem as #636 — a genuinely new violation silently absorbed — and it's covered by a test.

Pairing also went from a nested scan to a single hash-indexed pass: on a synthetic 20k-entry baseline where every violation moved, matching drops from tens of seconds to 0.02s.

Beyond removing the duplication, this gives us a single place to change when we pick the baseline matching strategy discussed in #662 and #636 (line-content hash, enclosing member, count-based grouping, …): each alternative becomes a change to one method rather than to three code paths that must be kept consistent.

Refs #662, #636
