### PR TITLE
feat: match baseline violations without asking the user how

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Every setting can be passed as a CLI option or set via the corresponding `Config
 | `--autoload` | `-a` | `autoloadFilePath()` | Autoload file to load before running. Required for all Phar runs. |
 | `--use-baseline` | `-b` | `baselineFilePath()` | Baseline file path for ignoring known violations. |
 | `--skip-baseline` | `-k` | `skipBaseline()` | Skips the default baseline even if present. |
-| `--ignore-baseline-linenumbers` | `-i` | `ignoreBaselineLinenumbers()` | Matches baseline violations without checking line numbers. |
+| `--ignore-baseline-linenumbers` | `-i` | `ignoreBaselineLinenumbers()` | **Deprecated**: has no effect, baseline matching already tolerates moved violations. |
 | `--config` | `-c` | — | Configuration file to load (default: `phparkitect.php`). |
 | `--verbose` | `-v` | — | Prints every parsed file instead of the progress bar. |
 | — | — | `skipParsingCustomAnnotations()` | Disables custom DocBlock annotation parsing (enabled by default). |
@@ -165,15 +165,17 @@ When violations get fixed over time, prune the baseline instead of regenerating 
 phparkitect prune-baseline
 ```
 
-Pruning only removes entries that no longer match a current violation — it never adds anything. Regenerating snapshots the entire current state, so it would silently legitimize any new violation introduced since the baseline was created; pruning cannot, which makes it safe to run routinely (even automated). Since matching ignores line numbers and the kept entries are saved with their current ones, pruning also refreshes a baseline whose line numbers went stale after refactorings. `check` prints a hint when it detects baseline entries that look fixed.
+Pruning only removes entries that no longer match a current violation — it never adds anything. Regenerating snapshots the entire current state, so it would silently legitimize any new violation introduced since the baseline was created; pruning cannot, which makes it safe to run routinely (even automated). Pruning also refreshes a baseline whose line numbers went stale after refactorings, since the kept entries are saved with their current ones. `check` prints a hint when it detects baseline entries that look fixed.
 
-Both `generate-baseline` and `prune-baseline` accept an optional custom file name as argument and the same `--config`, `--target-php-version` and `--autoload` options as `check`; `generate-baseline` also accepts `--ignore-baseline-linenumbers` to write the baseline without line numbers. `prune-baseline` needs no such flag: matching already ignores line numbers, and a baseline stored without line numbers keeps its format when pruned.
+Both `generate-baseline` and `prune-baseline` accept an optional custom file name as argument and the same `--config`, `--target-php-version` and `--autoload` options as `check`.
 
 > **Note**: baseline generation was previously a `check` option (`check --generate-baseline`); it is now a dedicated command, and the old option fails with a pointer to the new one.
 
-By default the baseline also checks line numbers — a change before the offending line shifts the number and the check fails. Use `--ignore-baseline-linenumbers` to match violations regardless of line number.
+#### How baseline entries are matched
 
-> **Warning**: when ignoring line numbers, PHPArkitect cannot detect if the same rule is violated additional times in the same file.
+You don't have to choose: a violation is identified by its class and by what it reports, never by where it sits in the file. Entries are matched first by exact position, and whatever is left over is matched within the same class and rule, in file order. A change above the offending line therefore doesn't reopen a known violation, while two violations of the same rule in the same class stay distinct — and when a new one appears among them, it's the new one that gets reported.
+
+`--ignore-baseline-linenumbers` / `ignoreBaselineLinenumbers()` used to select this behaviour and is now **deprecated**: it has no effect and will be removed in the next major version. Existing baselines keep working and need no regeneration, whether or not they store line numbers.
 
 ### Output format
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,30 @@ PHPArkitect, ordered from the most recent version to the oldest.
 
 ## 1.3.0
 
+### `--ignore-baseline-linenumbers` is deprecated
+
+Baseline matching no longer depends on line numbers: a violation is identified
+by its class and by what it reports, so an edit above the offending line does
+not reopen a known violation, and two violations of the same rule in the same
+class stay distinct. The option that used to select this behaviour has no
+effect and prints a deprecation notice, both from the CLI and from
+`phparkitect.php`:
+
+```diff
+- phparkitect check --ignore-baseline-linenumbers
++ phparkitect check
+
+- $config->ignoreBaselineLinenumbers(true);
++ $config;
+```
+
+It will be removed in the next major version.
+
+`generate-baseline` now always writes line numbers — the option no longer
+strips them. **Existing baselines keep working and need no regeneration**,
+whether or not they store line numbers, and `prune-baseline` still preserves
+the format it finds.
+
 ### `check --generate-baseline` is now the `generate-baseline` command
 
 Generating a baseline was an action disguised as a `check` option: it ran a
@@ -24,8 +48,7 @@ a dedicated command:
 
 The optional filename is now an argument (still defaulting to
 `phparkitect-baseline.json`), and the command accepts the same `--config`,
-`--target-php-version`, `--autoload` and `--ignore-baseline-linenumbers`
-options as before. The check-only options that never affected generation
+`--target-php-version` and `--autoload` options as before. The check-only options that never affected generation
 (`--stop-on-failure`, `--format`, `--use-baseline`, `--skip-baseline`) are no
 longer accepted.
 

--- a/src/CLI/Baseline.php
+++ b/src/CLI/Baseline.php
@@ -41,22 +41,22 @@ class Baseline
      * given set untouched: what is left to report is in the returned result,
      * together with the number of baseline entries nothing matched.
      */
-    public function applyTo(Violations $violations, bool $ignoreBaselineLinenumbers): BaselineResult
+    public function applyTo(Violations $violations): BaselineResult
     {
-        $match = $violations->matchAgainst($this->violations, $ignoreBaselineLinenumbers);
+        $match = $violations->matchAgainst($this->violations);
 
         return new BaselineResult($match->new(), $match->stale()->count());
     }
 
     /**
      * Shrink-only update: returns a baseline containing only the entries that
-     * still match a current violation — nothing is ever added. Matching
-     * ignores line numbers and the current violations are the ones kept, so
-     * pruning also refreshes line numbers gone stale after refactorings.
+     * still match a current violation — nothing is ever added. The current
+     * violations are the ones kept, so pruning also refreshes line numbers
+     * gone stale after refactorings.
      */
     public function prune(Violations $currentViolations): self
     {
-        $prunedViolations = $currentViolations->matchAgainst($this->violations, true)->known();
+        $prunedViolations = $currentViolations->matchAgainst($this->violations)->known();
 
         // a baseline stored without line numbers keeps its format
         if (!$this->hasLineNumbers()) {

--- a/src/CLI/CheckHandler.php
+++ b/src/CLI/CheckHandler.php
@@ -32,8 +32,11 @@ class CheckHandler
             ->autoloadFilePath($options->getAutoloadFilePath())
             ->stopOnFailure($options->isStopOnFailure())
             ->targetPhpVersion(TargetPhpVersion::create($options->getTargetPhpVersion()))
-            ->ignoreBaselineLinenumbers($options->isIgnoreBaselineLinenumbers())
             ->format($options->getFormat());
+
+        if ($options->isIgnoreBaselineLinenumbers() || $config->isIgnoreBaselineLinenumbers()) {
+            $output->writeln(DeprecationNotice::IGNORE_BASELINE_LINENUMBERS);
+        }
 
         $baselineFilePath = $options->getBaselineFilePath();
 

--- a/src/CLI/Command/CommonOptions.php
+++ b/src/CLI/Command/CommonOptions.php
@@ -50,9 +50,10 @@ class CommonOptions
     }
 
     /**
-     * Not part of addTo() because not every analysis command takes it:
-     * prune-baseline always matches ignoring line numbers and preserves
-     * the baseline's stored format instead.
+     * Not part of addTo() because prune-baseline never took it.
+     *
+     * The option is deprecated and has no effect: it is still registered so
+     * that the commands accept it and can warn who is passing it.
      */
     public function addIgnoreBaselineLinenumbers(Command $command): void
     {
@@ -60,7 +61,7 @@ class CommonOptions
             self::IGNORE_BASELINE_LINENUMBERS_PARAM,
             'i',
             InputOption::VALUE_NONE,
-            'Ignore line numbers when checking or generating the baseline'
+            'Deprecated: has no effect, baseline matching already tolerates moved violations'
         );
     }
 

--- a/src/CLI/Config.php
+++ b/src/CLI/Config.php
@@ -120,6 +120,11 @@ class Config
         return $this->baselineFilePath;
     }
 
+    /**
+     * @deprecated baseline matching no longer depends on line numbers; this
+     *             option has no effect and will be removed in the next major
+     *             version. The value is kept only to warn the user about it.
+     */
     public function ignoreBaselineLinenumbers(bool $ignoreBaselineLinenumbers): self
     {
         $this->ignoreBaselineLinenumbers = $ignoreBaselineLinenumbers;

--- a/src/CLI/DeprecationNotice.php
+++ b/src/CLI/DeprecationNotice.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\CLI;
+
+/**
+ * The messages printed when a deprecated option is used.
+ */
+class DeprecationNotice
+{
+    public const IGNORE_BASELINE_LINENUMBERS = '⚠️  `--ignore-baseline-linenumbers` / `ignoreBaselineLinenumbers()` is deprecated and has no effect: baseline matching now tolerates violations moved by edits elsewhere in the file. It will be removed in the next major version.';
+}

--- a/src/CLI/GenerateBaselineHandler.php
+++ b/src/CLI/GenerateBaselineHandler.php
@@ -34,7 +34,7 @@ class GenerateBaselineHandler
         $baseline = Baseline::fromViolations($result->getViolations());
 
         if ($options->isIgnoreBaselineLinenumbers()) {
-            $baseline = $baseline->withoutLineNumbers();
+            $output->writeln(DeprecationNotice::IGNORE_BASELINE_LINENUMBERS);
         }
 
         $this->baselineRepository->save($baseline, $options->getBaselineFilePath());

--- a/src/CLI/Runner.php
+++ b/src/CLI/Runner.php
@@ -20,7 +20,7 @@ class Runner
     {
         [$violations, $parsingErrors] = $this->doRun($config, $progress);
 
-        $baselineResult = $baseline->applyTo($violations, $config->isIgnoreBaselineLinenumbers());
+        $baselineResult = $baseline->applyTo($violations);
 
         return new AnalysisResult(
             $baselineResult->getRemainingViolations(),

--- a/src/Rules/Violations.php
+++ b/src/Rules/Violations.php
@@ -82,37 +82,29 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
      * $baseline, one to one: what matched, what is new and what the baseline
      * still claims but nothing matches anymore.
      *
-     * A violation is identified by its class and by the problem it reports;
-     * $ignoreLineNumbers decides whether where it sits in the file is part of
-     * that identity too.
+     * Pairing happens in two passes: first the violations still sitting where
+     * the baseline recorded them, then, among what is left, the ones matching
+     * by class and reported problem alone — an edit above a violation moves it
+     * without making it a new one. The line number is therefore never part of
+     * the identity of a violation, only a hint on which entry of a group to
+     * pair with, so there is nothing for the user to choose here.
+     *
+     * When a group of identical violations both moved and grew, which of them
+     * is reported as new is a guess; how many are is not.
      */
-    public function matchAgainst(self $baseline, bool $ignoreLineNumbers): ViolationsMatch
+    public function matchAgainst(self $baseline): ViolationsMatch
     {
-        $key = $ignoreLineNumbers ? [__CLASS__, 'violationKey'] : [__CLASS__, 'positionKey'];
-        $unpairedByKey = self::indexBy($baseline->violations, $key);
+        [$stillThere, $moved, $paired] = self::pairWith($this->violations, $baseline->violations, [__CLASS__, 'positionKey']);
 
-        $known = [];
-        $new = [];
-        $paired = [];
+        $unpairedEntries = array_diff_key($baseline->violations, $paired);
 
-        foreach ($this->violations as $violation) {
-            $violationKey = $key($violation);
+        [$movedAndKnown, $new, $pairedMoved] = self::pairWith($moved, $unpairedEntries, [__CLASS__, 'violationKey']);
 
-            if ([] === ($unpairedByKey[$violationKey] ?? [])) {
-                $new[] = $violation;
-
-                continue;
-            }
-
-            // the bucket was just checked to be non-empty, so array_pop() returns an index
-            /** @psalm-suppress PossiblyNullArrayOffset */
-            $paired[array_pop($unpairedByKey[$violationKey])] = true;
-            $known[] = $violation;
-        }
-
-        $stale = array_diff_key($baseline->violations, $paired);
-
-        return new ViolationsMatch(self::fromArray($known), self::fromArray($new), self::fromArray($stale));
+        return new ViolationsMatch(
+            self::fromArray(array_intersect_key($this->violations, $stillThere + $movedAndKnown)),
+            self::fromArray($new),
+            self::fromArray(array_diff_key($unpairedEntries, $pairedMoved))
+        );
     }
 
     public function withoutLineNumbers(): self
@@ -133,6 +125,43 @@ class Violations implements \IteratorAggregate, \Countable, \JsonSerializable
     public function jsonSerialize(): array
     {
         return get_object_vars($this);
+    }
+
+    /**
+     * Pairs each violation with an entry carrying the same key, in the order
+     * both appear in their file, and reports what paired with what.
+     *
+     * @param array<int, Violation>      $violations
+     * @param array<int, Violation>      $entries
+     * @param callable(Violation):string $key
+     *
+     * @return array{array<int, true>, array<int, Violation>, array<int, true>} the paired violations, the unpaired ones, the paired entries
+     */
+    private static function pairWith(array $violations, array $entries, callable $key): array
+    {
+        $entriesByKey = self::indexBy($entries, $key);
+
+        $matched = [];
+        $unpaired = [];
+        $paired = [];
+        $pairedPerKey = [];
+
+        foreach ($violations as $idx => $violation) {
+            $violationKey = $key($violation);
+            $alreadyPaired = $pairedPerKey[$violationKey] ?? 0;
+
+            if (!isset($entriesByKey[$violationKey][$alreadyPaired])) {
+                $unpaired[$idx] = $violation;
+
+                continue;
+            }
+
+            $pairedPerKey[$violationKey] = $alreadyPaired + 1;
+            $paired[$entriesByKey[$violationKey][$alreadyPaired]] = true;
+            $matched[$idx] = true;
+        }
+
+        return [$matched, $unpaired, $paired];
     }
 
     /**

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -179,17 +179,23 @@ class CheckCommandTest extends TestCase
         self::assertCommandWasSuccessful($cmdTester);
     }
 
-    public function test_baseline_line_numbers_can_be_ignored(): void
+    public function test_baseline_matches_violations_whose_line_number_moved(): void
     {
         $configFilePath = __DIR__.'/../_fixtures/configIgnoreBaselineLineNumbers.php';
 
-        // No errors when ignoring baseline line numbers
-        $cmdTester = $this->runCheck($configFilePath, null, __DIR__.'/../_fixtures/line_numbers/baseline.json', false, true);
-        self::assertCommandWasSuccessful($cmdTester);
-
-        // Errors when not ignoring baseline line numbers
         $cmdTester = $this->runCheck($configFilePath, null, __DIR__.'/../_fixtures/line_numbers/baseline.json');
-        self::assertCommandExitedWithError($cmdTester);
+
+        self::assertCommandWasSuccessful($cmdTester);
+    }
+
+    public function test_deprecated_ignore_baseline_linenumbers_warns_and_changes_nothing(): void
+    {
+        $configFilePath = __DIR__.'/../_fixtures/configIgnoreBaselineLineNumbers.php';
+
+        $cmdTester = $this->runCheck($configFilePath, null, __DIR__.'/../_fixtures/line_numbers/baseline.json', false, true);
+
+        self::assertCommandWasSuccessful($cmdTester);
+        self::assertStringContainsString('is deprecated and has no effect', $cmdTester->getErrorOutput());
     }
 
     public function test_baseline_reports_stale_violations(): void

--- a/tests/E2E/Cli/GenerateBaselineCommandTest.php
+++ b/tests/E2E/Cli/GenerateBaselineCommandTest.php
@@ -55,20 +55,20 @@ class GenerateBaselineCommandTest extends TestCase
         self::assertFileDoesNotExist($this->defaultBaselineFilename);
     }
 
-    public function test_can_ignore_line_numbers(): void
+    public function test_deprecated_ignore_line_numbers_warns_and_still_writes_them(): void
     {
         $cmdTester = $this->runGenerateBaseline(
-            __DIR__.'/../_fixtures/configMvcForYieldBug.php',
+            __DIR__.'/../_fixtures/configIgnoreBaselineLineNumbers.php',
             $this->customBaselineFilename,
             true
         );
 
         self::assertEquals(self::SUCCESS_CODE, $cmdTester->getStatusCode());
+        self::assertStringContainsString('is deprecated and has no effect', $cmdTester->getDisplay());
 
         $baseline = json_decode((string) file_get_contents($this->customBaselineFilename), true);
 
-        self::assertCount(1, $baseline['violations']);
-        self::assertNull($baseline['violations'][0]['line']);
+        self::assertNotNull($baseline['violations'][0]['line']);
     }
 
     public function test_fails_gracefully_when_the_config_file_does_not_exist(): void

--- a/tests/E2E/Cli/PruneBaselineCommandTest.php
+++ b/tests/E2E/Cli/PruneBaselineCommandTest.php
@@ -70,22 +70,20 @@ class PruneBaselineCommandTest extends TestCase
     }
 
     /**
-     * Pruning has no --ignore-baseline-linenumbers flag: it always matches
-     * ignoring line numbers and infers the format to save from the baseline
-     * itself, so a line-numberless workflow has nothing to remember.
+     * Baselines written by older versions with --ignore-baseline-linenumbers
+     * store no line number: pruning keeps that format instead of silently
+     * upgrading the file.
      */
-    public function test_pruning_preserves_a_baseline_generated_without_line_numbers(): void
+    public function test_pruning_preserves_a_baseline_stored_without_line_numbers(): void
     {
-        // this fixture violates a dependency rule, so its violations carry a
-        // line number: without -i the baseline would store one
         $configFilePath = __DIR__.'/../_fixtures/configIgnoreBaselineLineNumbers.php';
 
         $this->runCommand([
             'generate-baseline',
             '--config' => $configFilePath,
             'filename' => $this->customBaselineFilename,
-            '--ignore-baseline-linenumbers' => true,
         ]);
+        $this->stripLineNumbersFrom($this->customBaselineFilename);
 
         $cmdTester = $this->runCommand(['prune-baseline', '--config' => $configFilePath, 'filename' => $this->customBaselineFilename]);
 
@@ -104,7 +102,6 @@ class PruneBaselineCommandTest extends TestCase
             'check',
             '--config' => $configFilePath,
             '--use-baseline' => $this->customBaselineFilename,
-            '--ignore-baseline-linenumbers' => true,
         ]);
 
         self::assertEquals(self::SUCCESS_CODE, $cmdTester->getStatusCode());
@@ -130,5 +127,16 @@ class PruneBaselineCommandTest extends TestCase
         $appTester->run($input, ['capture_stderr_separately' => true]);
 
         return $appTester;
+    }
+
+    private function stripLineNumbersFrom(string $baselineFilename): void
+    {
+        $baseline = json_decode((string) file_get_contents($baselineFilename), true);
+
+        foreach ($baseline['violations'] as $idx => $violation) {
+            $baseline['violations'][$idx]['line'] = null;
+        }
+
+        file_put_contents($baselineFilename, json_encode($baseline));
     }
 }

--- a/tests/Unit/CLI/BaselineTest.php
+++ b/tests/Unit/CLI/BaselineTest.php
@@ -25,7 +25,7 @@ class BaselineTest extends TestCase
         $current = new Violations();
         $current->add($stillPresent);
 
-        $result = $baseline->applyTo($current, false);
+        $result = $baseline->applyTo($current);
 
         self::assertCount(0, $result->getRemainingViolations());
         self::assertSame(1, $result->getStaleBaselineEntriesCount());
@@ -41,7 +41,7 @@ class BaselineTest extends TestCase
         $current = new Violations();
         $current->add($violation);
 
-        Baseline::fromViolations($baselineViolations)->applyTo($current, false);
+        Baseline::fromViolations($baselineViolations)->applyTo($current);
 
         self::assertCount(1, $current);
     }
@@ -104,14 +104,17 @@ class BaselineTest extends TestCase
         self::assertNull($pruned->getViolations()->get(0)->getLine());
     }
 
-    public function test_without_line_numbers_returns_a_copy_with_stripped_line_numbers(): void
+    public function test_apply_to_keeps_a_violation_moved_by_an_edit_above_it(): void
     {
         $baselineViolations = new Violations();
         $baselineViolations->add(new Violation('App\Controller\Shop', 'should have name end with Controller', 10));
 
-        $stripped = Baseline::fromViolations($baselineViolations)->withoutLineNumbers();
+        $current = new Violations();
+        $current->add(new Violation('App\Controller\Shop', 'should have name end with Controller', 42));
 
-        self::assertNull($stripped->getViolations()->get(0)->getLine());
-        self::assertEquals(10, $baselineViolations->get(0)->getLine());
+        $result = Baseline::fromViolations($baselineViolations)->applyTo($current);
+
+        self::assertCount(0, $result->getRemainingViolations());
+        self::assertSame(0, $result->getStaleBaselineEntriesCount());
     }
 }

--- a/tests/Unit/Rules/ViolationsTest.php
+++ b/tests/Unit/Rules/ViolationsTest.php
@@ -101,7 +101,7 @@ class ViolationsTest extends TestCase
         $violationsBaseline = new Violations();
         $violationsBaseline->add($this->violation);
 
-        $new = $this->violationStore->matchAgainst($violationsBaseline, false)->new();
+        $new = $this->violationStore->matchAgainst($violationsBaseline)->new();
 
         self::assertCount(2, $new);
         self::assertEquals([
@@ -171,10 +171,10 @@ class ViolationsTest extends TestCase
             10
         ));
 
-        self::assertCount(0, $violations->matchAgainst($baseline, false)->new());
+        self::assertCount(0, $violations->matchAgainst($baseline)->new());
     }
 
-    public function test_match_pairs_when_rule_description_changes_ignore_linenumber(): void
+    public function test_match_pairs_when_rule_description_changes_and_the_violation_moved(): void
     {
         $violations = new Violations();
         $violations->add(new Violation(
@@ -190,7 +190,7 @@ class ViolationsTest extends TestCase
             10
         ));
 
-        self::assertCount(0, $violations->matchAgainst($baseline, true)->new());
+        self::assertCount(0, $violations->matchAgainst($baseline)->new());
     }
 
     public function test_match_reports_a_duplicate_the_baseline_only_knows_once(): void
@@ -204,7 +204,28 @@ class ViolationsTest extends TestCase
         $violations->add(new Violation('App\Foo', $error, 10, 'src/Foo.php'));
         $violations->add(new Violation('App\Foo', $error, 10, 'src/Foo.php'));
 
-        self::assertCount(1, $violations->matchAgainst($baseline, false)->new(), 'each baseline entry covers one violation, not every identical one');
+        self::assertCount(1, $violations->matchAgainst($baseline)->new(), 'each baseline entry covers one violation, not every identical one');
+    }
+
+    public function test_match_reports_the_violation_that_was_really_added(): void
+    {
+        $error = 'depends on App\Bar, but should depend only on classes in one of these namespaces: App\Domain';
+
+        $baseline = new Violations();
+        $baseline->add(new Violation('App\Foo', $error, 10));
+        $baseline->add(new Violation('App\Foo', $error, 20));
+        $baseline->add(new Violation('App\Foo', $error, 30));
+
+        $violations = new Violations();
+        $violations->add(new Violation('App\Foo', $error, 10));
+        $violations->add(new Violation('App\Foo', $error, 15));
+        $violations->add(new Violation('App\Foo', $error, 20));
+        $violations->add(new Violation('App\Foo', $error, 30));
+
+        $new = $violations->matchAgainst($baseline)->new();
+
+        self::assertCount(1, $new);
+        self::assertSame(15, $new->get(0)->getLine(), 'the untouched violations pair by position, so what is left is the added one');
     }
 
     public function test_match_does_not_pair_different_dependency(): void
@@ -223,7 +244,7 @@ class ViolationsTest extends TestCase
             10
         ));
 
-        self::assertCount(1, $violations->matchAgainst($baseline, false)->new());
+        self::assertCount(1, $violations->matchAgainst($baseline)->new());
     }
 
     public function test_match_pairs_self_explanatory_messages(): void
@@ -240,7 +261,7 @@ class ViolationsTest extends TestCase
             'should be final because we want immutability'
         ));
 
-        self::assertCount(0, $violations->matchAgainst($baseline, false)->new());
+        self::assertCount(0, $violations->matchAgainst($baseline)->new());
     }
 
     public function test_match_pairs_self_explanatory_messages_when_because_is_reworded(): void
@@ -257,7 +278,7 @@ class ViolationsTest extends TestCase
             'should be final because we want immutability'
         ));
 
-        self::assertCount(0, $violations->matchAgainst($baseline, false)->new());
+        self::assertCount(0, $violations->matchAgainst($baseline)->new());
     }
 
     public function test_violation_without_line_number_returns_copy_with_null_line(): void
@@ -328,7 +349,7 @@ class ViolationsTest extends TestCase
             21
         ));
 
-        $new = $this->violationStore->matchAgainst($violationsBaseline, true)->new();
+        $new = $this->violationStore->matchAgainst($violationsBaseline)->new();
 
         self::assertCount(3, $new);
         self::assertEquals([
@@ -346,7 +367,7 @@ class ViolationsTest extends TestCase
         $current = new Violations();
         $current->add($this->violation);
 
-        self::assertCount(0, $current->matchAgainst($baseline, false)->stale());
+        self::assertCount(0, $current->matchAgainst($baseline)->stale());
     }
 
     public function test_match_stale_counts_fixed_baseline_entries(): void
@@ -361,10 +382,10 @@ class ViolationsTest extends TestCase
         $current = new Violations();
         $current->add($stillPresent);
 
-        self::assertCount(1, $current->matchAgainst($baseline, false)->stale());
+        self::assertCount(1, $current->matchAgainst($baseline)->stale());
     }
 
-    public function test_match_stale_counts_fixed_baseline_entries_ignoring_line_numbers(): void
+    public function test_match_does_not_call_stale_a_violation_that_only_moved(): void
     {
         $stillPresent = new Violation('App\Controller\Shop', 'should have name end with Controller', 10);
         $fixed = new Violation('App\Controller\Shop', 'should implement AbstractController', 20);
@@ -377,8 +398,7 @@ class ViolationsTest extends TestCase
         $current = new Violations();
         $current->add($stillPresentMovedLine);
 
-        self::assertCount(1, $current->matchAgainst($baseline, true)->stale());
-        self::assertCount(2, $current->matchAgainst($baseline, false)->stale());
+        self::assertCount(1, $current->matchAgainst($baseline)->stale());
     }
 
     public function test_match_stale_does_not_mutate_either_set(): void
@@ -391,7 +411,7 @@ class ViolationsTest extends TestCase
         $current = new Violations();
         $current->add($stillPresent);
 
-        $current->matchAgainst($baseline, true);
+        $current->matchAgainst($baseline);
 
         self::assertCount(1, $baseline);
         self::assertCount(1, $current);
@@ -407,7 +427,7 @@ class ViolationsTest extends TestCase
         $baseline->add(new Violation('App\Controller\Shop', 'should have name end with Controller', 10));
         $baseline->add(new Violation('App\Controller\Fixed', 'should have name end with Controller', 3));
 
-        $intersection = $current->matchAgainst($baseline, true)->known();
+        $intersection = $current->matchAgainst($baseline)->known();
 
         self::assertCount(1, $intersection);
         self::assertEquals('App\Controller\Shop', $intersection->get(0)->getFqcn());
@@ -425,7 +445,7 @@ class ViolationsTest extends TestCase
         $baseline = new Violations();
         $baseline->add($duplicated);
 
-        self::assertCount(1, $current->matchAgainst($baseline, true)->known());
+        self::assertCount(1, $current->matchAgainst($baseline)->known());
     }
 
     public function test_match_known_does_not_mutate_either_set(): void
@@ -438,7 +458,7 @@ class ViolationsTest extends TestCase
         $baseline = new Violations();
         $baseline->add($violation);
 
-        $current->matchAgainst($baseline, true);
+        $current->matchAgainst($baseline);
 
         self::assertCount(1, $current);
         self::assertCount(1, $baseline);


### PR DESCRIPTION
Choosing between matching the baseline with or without line numbers is a decision about *how* the baseline is compared, not about *what* to enforce — and both answers were wrong somewhere. The default reopened a known violation after any edit above it; `--ignore-baseline-linenumbers` could not tell two violations of the same rule in the same class apart, and could report the wrong one as new (#636).

Matching is now a single strategy with no knob, in two passes:

1. violations still sitting where the baseline recorded them pair first;
2. among what is left, class and reported problem alone decide.

So an edit above a violation moves it without making it new, identical violations in one class stay distinct, and when a violation is added among moved ones it is the added one that gets reported. The `#636` scenario (three baselined violations at 10/20/30, a fourth added at 15) is covered by a test.

When a group of identical violations both moved and grew in the same run, which of them is reported as new is a guess — the count is not. That ambiguity is inherent, and it is documented in the README rather than papered over.

**Deprecation**: `--ignore-baseline-linenumbers` / `ignoreBaselineLinenumbers()` have no effect and print a notice, whether they come from the CLI or from `phparkitect.php`. They will be removed in the next major. `generate-baseline` always writes line numbers now; baselines stored without them keep working and need no regeneration, and `prune-baseline` still preserves that format.

Pairing stays linear: a synthetic 20k-entry baseline where every violation moved matches in 0.04s, and 2000 violations of the same rule in a single class in under 0.01s.

Built on #665, which put all matching in `Violations::matchAgainst()` — this PR is mostly the removal of the boolean from it.

Closes #662
Refs #636
