### PR TITLE
Cache parse results so a repeated class set is parsed only once

### DIFF
--- a/src/Analyzer/FileParserFactory.php
+++ b/src/Analyzer/FileParserFactory.php
@@ -21,6 +21,11 @@ class FileParserFactory
         );
     }
 
+    public static function createMemoizingFileParser(TargetPhpVersion $targetPhpVersion, bool $parseCustomAnnotations = true): MemoizingParser
+    {
+        return new MemoizingParser(self::createFileParser($targetPhpVersion, $parseCustomAnnotations));
+    }
+
     public static function forPhpVersion(string $targetPhpVersion): FileParser
     {
         return self::createFileParser(TargetPhpVersion::create($targetPhpVersion), true);

--- a/src/Analyzer/MemoizingParser.php
+++ b/src/Analyzer/MemoizingParser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Analyzer;
+
+/**
+ * Caches parse results for the lifetime of the instance. On a hit it returns the
+ * same ParserResult instance, so callers must treat it as read-only.
+ */
+class MemoizingParser implements Parser
+{
+    private Parser $parser;
+
+    /** @var array<string, ParserResult> */
+    private array $cache = [];
+
+    public function __construct(Parser $parser)
+    {
+        $this->parser = $parser;
+    }
+
+    public function parse(string $fileContent, string $filename): ParserResult
+    {
+        // both halves are needed: the pathname Runner passes is relative to the class
+        // set root, so it is not unique, and it ends up in ClassDescription::filePath
+        $key = $filename."\0".md5($fileContent);
+
+        return $this->cache[$key] ??= $this->parser->parse($fileContent, $filename);
+    }
+}

--- a/src/CLI/Runner.php
+++ b/src/CLI/Runner.php
@@ -81,7 +81,7 @@ class Runner
         $violations = new Violations();
         $parsingErrors = new ParsingErrors();
 
-        $fileParser = FileParserFactory::createFileParser(
+        $fileParser = FileParserFactory::createMemoizingFileParser(
             $config->getTargetPhpVersion(),
             $config->isParseCustomAnnotationsEnabled()
         );

--- a/tests/E2E/Cli/CheckCommandTest.php
+++ b/tests/E2E/Cli/CheckCommandTest.php
@@ -57,6 +57,29 @@ class CheckCommandTest extends TestCase
         self::assertStringContainsString($expectedErrors, $cmdTester->getDisplay());
     }
 
+    public function test_repeating_the_same_class_set_does_not_change_the_violations(): void
+    {
+        $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvcRepeatedClassSet.php');
+
+        $expectedErrors = <<<'ERRORS'
+        App\Controller\Foo has 2 violations
+          should have a name that matches *Controller because we want uniform naming
+          should implement ContainerAwareInterface because all controllers should be container aware
+
+        App\Controller\ProductsController has 1 violations
+          should implement ContainerAwareInterface because all controllers should be container aware
+
+        App\Controller\UserController has 1 violations
+          should implement ContainerAwareInterface because all controllers should be container aware
+
+        App\Controller\YieldController has 1 violations
+          should implement ContainerAwareInterface because all controllers should be container aware
+        ERRORS;
+
+        self::assertCommandExitedWithError($cmdTester);
+        self::assertStringContainsString($expectedErrors, $cmdTester->getDisplay());
+    }
+
     public function test_app_returns_single_error_because_there_is_stop_on_failure_param(): void
     {
         $cmdTester = $this->runCheck(__DIR__.'/../_fixtures/configMvc.php', true);

--- a/tests/E2E/_fixtures/configMvcRepeatedClassSet.php
+++ b/tests/E2E/_fixtures/configMvcRepeatedClassSet.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use Arkitect\ClassSet;
+use Arkitect\CLI\Config;
+use Arkitect\Expression\ForClasses\HaveNameMatching;
+use Arkitect\Expression\ForClasses\Implement;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\Rule;
+
+return static function (Config $config): void {
+    $rule_1 = Rule::allClasses()
+        ->except('App\Controller\BaseController')
+        ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+        ->should(new Implement('ContainerAwareInterface'))
+        ->because('all controllers should be container aware');
+
+    $rule_2 = Rule::allClasses()
+        ->that(new ResideInOneOfTheseNamespaces('App\Controller'))
+        ->should(new HaveNameMatching('*Controller'))
+        ->because('we want uniform naming');
+
+    $config
+        ->add(ClassSet::fromDir(__DIR__.'/mvc'), $rule_1)
+        ->add(ClassSet::fromDir(__DIR__.'/mvc'), $rule_2);
+};

--- a/tests/Unit/Analyzer/MemoizingParserTest.php
+++ b/tests/Unit/Analyzer/MemoizingParserTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arkitect\Tests\Unit\Analyzer;
+
+use Arkitect\Analyzer\ClassDescriptions;
+use Arkitect\Analyzer\FileParserFactory;
+use Arkitect\Analyzer\MemoizingParser;
+use Arkitect\Analyzer\Parser;
+use Arkitect\Analyzer\ParserResult;
+use Arkitect\Analyzer\ParsingErrors;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class MemoizingParserTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function test_it_parses_the_same_file_only_once(): void
+    {
+        $result = ParserResult::withClassDescriptions(new ClassDescriptions());
+
+        $inner = $this->prophesize(Parser::class);
+        $inner->parse('<?php class Foo {}', 'Foo.php')
+            ->willReturn($result)
+            ->shouldBeCalledOnce();
+
+        $parser = new MemoizingParser($inner->reveal());
+
+        self::assertSame($result, $parser->parse('<?php class Foo {}', 'Foo.php'));
+        self::assertSame($result, $parser->parse('<?php class Foo {}', 'Foo.php'));
+    }
+
+    public function test_it_does_not_confuse_different_contents_under_the_same_filename(): void
+    {
+        $parser = new MemoizingParser(FileParserFactory::forPhpVersion('8.1'));
+
+        $first = $parser->parse('<?php namespace A; class Foo {}', 'Foo.php');
+        $second = $parser->parse('<?php namespace B; class Foo {}', 'Foo.php');
+
+        self::assertSame('A\Foo', $first->classDescriptions()[0]->getFQCN());
+        self::assertSame('B\Foo', $second->classDescriptions()[0]->getFQCN());
+    }
+
+    public function test_it_does_not_confuse_the_same_contents_under_different_filenames(): void
+    {
+        $parser = new MemoizingParser(FileParserFactory::forPhpVersion('8.1'));
+
+        $first = $parser->parse('<?php class Foo {}', 'first/Foo.php');
+        $second = $parser->parse('<?php class Foo {}', 'second/Foo.php');
+
+        self::assertSame('first/Foo.php', $first->classDescriptions()[0]->getFilePath());
+        self::assertSame('second/Foo.php', $second->classDescriptions()[0]->getFilePath());
+    }
+
+    public function test_it_returns_what_the_wrapped_parser_returns(): void
+    {
+        $code = <<<'CODE'
+        <?php
+        namespace App;
+
+        use App\Domain\Thing;
+
+        final class Service extends Base implements Contract
+        {
+            public function doIt(Thing $thing): void {}
+        }
+        CODE;
+
+        $memoizing = new MemoizingParser(FileParserFactory::forPhpVersion('8.1'));
+
+        self::assertEquals(
+            FileParserFactory::forPhpVersion('8.1')->parse($code, 'Service.php'),
+            $memoizing->parse($code, 'Service.php')
+        );
+    }
+
+    public function test_it_caches_parsing_errors_too(): void
+    {
+        $inner = $this->prophesize(Parser::class);
+        $inner->parse('<?php class {', 'Broken.php')
+            ->willReturn(ParserResult::withParsingErrors(new ParsingErrors()))
+            ->shouldBeCalledOnce();
+
+        $parser = new MemoizingParser($inner->reveal());
+
+        $parser->parse('<?php class {', 'Broken.php');
+        $parser->parse('<?php class {', 'Broken.php');
+    }
+}


### PR DESCRIPTION
## Problem

`Parser` implementations re-parse a file every time they are asked to. Within a single `check()` call each file is parsed once, but `Runner::doRun()` calls `check()` once per `ClassSetRules`, so a file belonging to more than one class set is parsed once per class set.

The practical effect is a performance cliff users had to learn to avoid: splitting rules across several `->add()` calls on the same directory — the natural way to keep unrelated rules apart — costs a full extra pass over that directory each time.

## Change

`MemoizingParser` decorates any `Parser` and caches results for the lifetime of the instance. `Runner::doRun()` now builds one, so the cost of repeating a class set is paid once instead of once per repetition.

Measured on this repository's `src/` (120 files), same class set repeated, warmed up:

| repetitions | before | after |
|------------:|-------:|------:|
| 1 | 0.082 s | 0.080 s |
| 2 | 0.151 s | 0.058 s |
| 4 | 0.191 s | 0.050 s |
| 8 | 0.367 s | 0.056 s |

Linear before, flat after. Output is unchanged: the benchmark compares the full printed violation report, not just counts.

## Notes

The cache key is `filename + md5(content)` and both halves are load-bearing. `Runner::check()` passes `$file->getRelativePathname()`, which is relative to each class set root and therefore not unique across class sets; and that name becomes `ClassDescription::filePath`, which is printed in violations, serialized into the baseline, and used by `Violations::positionKey()` for baseline matching.

A consequence is that class sets nested under *different* roots (`src/` plus `src/Analyzer/`) still re-parse shared files, since the same file arrives under two names. That is deliberate here — sharing an entry would give the second class set the first one's path — and a follow-up issue describes what covering it would take.

Memory grows with the number of unique files, roughly 9 KB each (+0.8 MB for 120 files, +22 MB for 2512), and does not grow with repetitions.

Sharing a `ParserResult` between rule checks is safe: `ClassDescription` has no setters, and expressions only read it.

Related to #586, which proposes an on-disk cache surviving across runs. This one is in-memory and scoped to a single run.
